### PR TITLE
Generate taxid locator

### DIFF
--- a/examples/postprocess_dag.json
+++ b/examples/postprocess_dag.json
@@ -20,7 +20,8 @@
       "taxid_annot_sorted_family_nt.fasta",
       "taxid_locations_family_nt.json",
       "taxid_annot_sorted_family_nr.fasta",
-      "taxid_locations_family_nr.json"
+      "taxid_locations_family_nr.json",
+      "taxid_locations_combined.json"
     ]
   },
   "steps": [

--- a/examples/postprocess_dag.json
+++ b/examples/postprocess_dag.json
@@ -7,7 +7,21 @@
       "summary.multihit.gsnapl.unmapped.bowtie2.lzw.cdhitdup.priceseqfilter.unmapped.star.tab",
       "summary.multihit.rapsearch2.filter.deuterostomes.taxids.gsnapl.unmapped.bowtie2.lzw.cdhitdup.priceseqfilter.unmapped.star.tab"
     ],
-    "taxid_fasta_out": ["taxid_annot.fasta"]
+    "taxid_fasta_out": ["taxid_annot.fasta"],
+    "taxid_locator_out": [
+      "taxid_annot_sorted_nt.fasta",
+      "taxid_locations_nt.json",
+      "taxid_annot_sorted_nr.fasta",
+      "taxid_locations_nr.json",
+      "taxid_annot_sorted_genus_nt.fasta",
+      "taxid_locations_genus_nt.json",
+      "taxid_annot_sorted_genus_nr.fasta",
+      "taxid_locations_genus_nr.json",
+      "taxid_annot_sorted_family_nt.fasta",
+      "taxid_locations_family_nt.json",
+      "taxid_annot_sorted_family_nr.fasta",
+      "taxid_locations_family_nr.json"
+    ]
   },
   "steps": [
     {
@@ -19,6 +33,14 @@
         "lineage_db":
           "s3://idseq-database/taxonomy/2018-02-15-utc-1518652800-unixtime__2018-02-15-utc-1518652800-unixtime/taxid-lineages.db"
       },
+      "additional_attributes": {}
+    },
+    {
+      "in": ["taxid_fasta_out"],
+      "out": "taxid_locator_out",
+      "class": "PipelineStepGenerateTaxidLocator",
+      "module": "idseq_dag.steps.generate_taxid_locator",
+      "additional_files": {},
       "additional_attributes": {}
     }
   ],

--- a/idseq_dag/steps/generate_taxid_locator.py
+++ b/idseq_dag/steps/generate_taxid_locator.py
@@ -1,3 +1,5 @@
+import os
+
 from idseq_dag.engine.pipeline_step import PipelineStep
 import idseq_dag.util.command as command
 import json
@@ -5,46 +7,61 @@ import json
 
 class PipelineStepGenerateTaxidLocator(PipelineStep):
     def run(self):
-        input_fasta = ""
-        taxid_field = ""
-        hit_type = ""
-        output_fasta = ""
-        output_json = ""
-        TEMP_DIR = ""
+        # Setup
+        input_fa = self.input_files_local[0][0]
+        out_files = self.output_files_local()
+        tmp = os.path.join(self.output_dir_local, "scratch")
 
+        # Generate locator files for species NT, species NR, genus NT...
+        for level in ["species", "genus", "family"]:
+            for name in ("NT", "NR"):
+                taxid_field = f"{level}_{name.lower()}"
+                output_fa = out_files.pop(0)  # Pop from front
+                output_json = out_files.pop(0)
+                PipelineStepGenerateTaxidLocator.generate_locator_work(
+                    input_fa, taxid_field, name, output_fa, output_json, tmp)
+
+        # Cleanup
+        command.execute("cd %s; rm -rf *" % tmp)
+
+    @staticmethod
+    def generate_locator_work(input_fa, taxid_field, hit_type, output_fa,
+                              output_json, tmp):
         taxid_field_num = PipelineStepGenerateTaxidLocator.get_taxid_field_num(
-            taxid_field, input_fasta)
+            taxid_field, input_fa)
         # Put every 2-line fasta record on a single line with delimiter
         # ":lineseparator:":
-        cmd = "awk 'NR % 2 == 1 { o=$0 ; next } { print o \":lineseparator:\" $0 }' " + input_fasta
+        cmd = "awk 'NR % 2 == 1 { o=$0 ; next } "
+        cmd += "{ print o \":lineseparator:\" $0 }' " + input_fa
         # Sort the records based on the field containing the taxids
-        cmd += " | sort -T %s --key %s --field-separator ':' --numeric-sort" % (
-            TEMP_DIR, taxid_field_num)
+        cmd += f" | sort -T {tmp} --key {taxid_field_num} "
+        cmd += "--field-separator ':' --numeric-sort"
         # Split every record back over 2 lines
-        cmd += " | sed 's/:lineseparator:/\\n/g' > %s" % output_fasta
+        cmd += f" | sed 's/:lineseparator:/\\n/g' > {output_fa}"
         command.execute(cmd)
 
         # Make JSON file giving the byte range of the file corresponding to each
         # taxid
-        taxon_sequence_locations = []
-        f = open(output_fasta, 'rb')
-        sequence_name = f.readline()
-        sequence_data = f.readline()
+        taxon_seq_locations = []
+        out_f = open(output_fa, 'rb')
+        seq_name = out_f.readline()
+        seq_data = out_f.readline()
 
         taxid = PipelineStepGenerateTaxidLocator.get_taxid(
-            sequence_name, taxid_field)
+            seq_name, taxid_field)
         first_byte = 0
-        end_byte = first_byte + len(sequence_name) + len(sequence_data)
-        while len(sequence_name) > 0 and len(sequence_data) > 0:
-            sequence_name = f.readline()
-            sequence_data = f.readline()
+        end_byte = first_byte + len(seq_name) + len(seq_data)
+        while len(seq_name) > 0 and len(seq_data) > 0:
+            seq_name = out_f.readline()
+            seq_data = out_f.readline()
             new_taxid = PipelineStepGenerateTaxidLocator.get_taxid(
-                sequence_name, taxid_field)
+                seq_name, taxid_field)
+            summ = len(seq_name) + len(seq_data)
             if new_taxid != taxid:
                 # Note on boundary condition: when end of file is reached, then
-                # sequence_name == '' => new_taxid == 'none' => new_taxid != taxid
+                # seq_name == '' => new_taxid == 'none' => new_taxid != taxid
                 # so last record will be written to output correctly.
-                taxon_sequence_locations.append({
+                taxon_seq_locations.append({
                     'taxid': int(taxid),
                     'first_byte': first_byte,
                     'last_byte': end_byte - 1,
@@ -52,24 +69,24 @@ class PipelineStepGenerateTaxidLocator(PipelineStep):
                 })
                 taxid = new_taxid
                 first_byte = end_byte
-                end_byte = first_byte + len(sequence_name) + len(sequence_data)
+                end_byte = first_byte + summ
             else:
-                end_byte += len(sequence_name) + len(sequence_data)
-        f.close()
+                end_byte += summ
+        out_f.close()
 
-        with open(output_json, 'wb') as f:
-            json.dump(taxon_sequence_locations, f)
+        with open(output_json, 'w') as out_f:
+            json.dump(taxon_seq_locations, out_f)
 
     @staticmethod
     def get_taxid_field_num(taxid_field, input_fasta):
         with open(input_fasta) as f:
-            sequence_name = f.readline()
-        return sequence_name.replace('>',
-                                     ':').split(":").index(taxid_field) + 1
+            seq_name = f.readline()
+        return seq_name.replace('>', ':').split(":").index(taxid_field) + 1
 
     @staticmethod
-    def get_taxid(sequence_name, taxid_field):
-        parts = sequence_name.replace('>', ':').split(":%s:" % taxid_field)
+    def get_taxid(seq_name, taxid_field):
+        parts = seq_name.decode('utf-8').replace('>',
+                                                 ':').split(f":{taxid_field}:")
         if len(parts) <= 1:
             # Sequence_name empty or taxid_field not found
             return 'none'

--- a/idseq_dag/steps/generate_taxid_locator.py
+++ b/idseq_dag/steps/generate_taxid_locator.py
@@ -5,4 +5,75 @@ import json
 
 class PipelineStepGenerateTaxidLocator(PipelineStep):
     def run(self):
-        pass
+        input_fasta = ""
+        taxid_field = ""
+        hit_type = ""
+        output_fasta = ""
+        output_json = ""
+        TEMP_DIR = ""
+
+        taxid_field_num = PipelineStepGenerateTaxidLocator.get_taxid_field_num(
+            taxid_field, input_fasta)
+        # Put every 2-line fasta record on a single line with delimiter
+        # ":lineseparator:":
+        cmd = "awk 'NR % 2 == 1 { o=$0 ; next } { print o \":lineseparator:\" $0 }' " + input_fasta
+        # Sort the records based on the field containing the taxids
+        cmd += " | sort -T %s --key %s --field-separator ':' --numeric-sort" % (
+            TEMP_DIR, taxid_field_num)
+        # Split every record back over 2 lines
+        cmd += " | sed 's/:lineseparator:/\\n/g' > %s" % output_fasta
+        command.execute(cmd)
+
+        # Make JSON file giving the byte range of the file corresponding to each
+        # taxid
+        taxon_sequence_locations = []
+        f = open(output_fasta, 'rb')
+        sequence_name = f.readline()
+        sequence_data = f.readline()
+
+        taxid = PipelineStepGenerateTaxidLocator.get_taxid(
+            sequence_name, taxid_field)
+        first_byte = 0
+        end_byte = first_byte + len(sequence_name) + len(sequence_data)
+        while len(sequence_name) > 0 and len(sequence_data) > 0:
+            sequence_name = f.readline()
+            sequence_data = f.readline()
+            new_taxid = PipelineStepGenerateTaxidLocator.get_taxid(
+                sequence_name, taxid_field)
+            if new_taxid != taxid:
+                # Note on boundary condition: when end of file is reached, then
+                # sequence_name == '' => new_taxid == 'none' => new_taxid != taxid
+                # so last record will be written to output correctly.
+                taxon_sequence_locations.append({
+                    'taxid': int(taxid),
+                    'first_byte': first_byte,
+                    'last_byte': end_byte - 1,
+                    'hit_type': hit_type
+                })
+                taxid = new_taxid
+                first_byte = end_byte
+                end_byte = first_byte + len(sequence_name) + len(sequence_data)
+            else:
+                end_byte += len(sequence_name) + len(sequence_data)
+        f.close()
+
+        with open(output_json, 'wb') as f:
+            json.dump(taxon_sequence_locations, f)
+
+    @staticmethod
+    def get_taxid_field_num(taxid_field, input_fasta):
+        with open(input_fasta) as f:
+            sequence_name = f.readline()
+        return sequence_name.replace('>',
+                                     ':').split(":").index(taxid_field) + 1
+
+    @staticmethod
+    def get_taxid(sequence_name, taxid_field):
+        parts = sequence_name.replace('>', ':').split(":%s:" % taxid_field)
+        if len(parts) <= 1:
+            # Sequence_name empty or taxid_field not found
+            return 'none'
+        taxid = parts[1].split(":")[0]
+        # Example sequence_name: ">nr:-100:nt:684552:NR::NT:LT629734.1:HWI-ST640
+        # :828:H917FADXX:2:1101:1424:15119/1"
+        return taxid

--- a/idseq_dag/steps/run_star.py
+++ b/idseq_dag/steps/run_star.py
@@ -13,7 +13,7 @@ class PipelineStepRunStar(PipelineStep):
         # Setup
         input_files = self.input_files_local[0][0:2]
         num_inputs = len(self.input_files[0])
-        scratch_dir = os.path.join(self.output_dir_local, "scratch")
+        scratch_dir = os.path.join(self.output_dir_local, "scratch_star")
 
         total_counts_from_star = {}
         output_files_local = self.output_files_local()

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -7,7 +7,8 @@ from .run_lzw import RunLZWTest
 from .run_bowtie2 import RunBowtie2Test
 from .run_subsample import RunSubsampleTest
 from .run_gsnap_filter import RunGsnapFilterTest
-from .generate_taxid_fasta import RunGenerateTaxidFastaTest
+from .generate_taxid_fasta import GenerateTaxidFastaTest
+from .generate_taxid_locator import GenerateTaxidLocatorTest
 
 import idseq_dag.util.log as log
 

--- a/tests/generate_taxid_fasta.py
+++ b/tests/generate_taxid_fasta.py
@@ -4,7 +4,7 @@ from .idseq_step_setup import IdseqStepSetup
 from idseq_dag.steps.generate_taxid_fasta import PipelineStepGenerateTaxidFasta
 
 
-class RunGenerateTaxidFastaTest(unittest.TestCase):
+class GenerateTaxidFastaTest(unittest.TestCase):
     def test_step_single(self):
         run_step = IdseqStepSetup.get_step_object(PipelineStepGenerateTaxidFasta, "taxid_fasta_out", paired=False)
         run_step.start()

--- a/tests/generate_taxid_locator.py
+++ b/tests/generate_taxid_locator.py
@@ -4,9 +4,8 @@ from .idseq_step_setup import IdseqStepSetup
 from idseq_dag.steps.generate_taxid_locator import PipelineStepGenerateTaxidLocator
 
 
-class RunGenerateTaxidLocatorTest(unittest.TestCase):
-    @staticmethod
-    def test_step_single():
+class GenerateTaxidLocatorTest(unittest.TestCase):
+    def test_step_single(self):
         run_step = IdseqStepSetup.get_step_object(PipelineStepGenerateTaxidLocator, "taxid_locator_out", paired=False)
         run_step.start()
         run_step.wait_until_finished()

--- a/tests/idseq_step_setup.py
+++ b/tests/idseq_step_setup.py
@@ -15,7 +15,6 @@ class IdseqStepSetup(object):
             dag = IdseqStepSetup.paired_dag()
         else:
             dag = IdseqStepSetup.single_dag()
-        dag = IdseqStepSetup.postprocess_dag()
         step_info = {}
         for step in dag["steps"]:
             if step["out"] == step_name:
@@ -173,7 +172,7 @@ class IdseqStepSetup(object):
   }
         ''')
 
-    @staticmethod
-    def postprocess_dag():
-        with open("examples/postprocess_dag.json") as f:
-            return json.load(f)
+    # @staticmethod
+    # def postprocess_dag():
+    #     with open("examples/postprocess_dag.json") as f:
+    #         return json.load(f)

--- a/tests/idseq_step_setup.py
+++ b/tests/idseq_step_setup.py
@@ -15,6 +15,7 @@ class IdseqStepSetup(object):
             dag = IdseqStepSetup.paired_dag()
         else:
             dag = IdseqStepSetup.single_dag()
+        dag = IdseqStepSetup.postprocess_dag()
         step_info = {}
         for step in dag["steps"]:
             if step["out"] == step_name:
@@ -172,7 +173,7 @@ class IdseqStepSetup(object):
   }
         ''')
 
-    # @staticmethod
-    # def postprocess_dag():
-    #     with open("examples/postprocess_dag.json") as f:
-    #         return json.load(f)
+    @staticmethod
+    def postprocess_dag():
+        with open("examples/postprocess_dag.json") as f:
+            return json.load(f)


### PR DESCRIPTION
- I tested this with files from RR004 water sample and the file contents match up with what they're supposed to be.

- For generating these 12 files:
```
"taxid_annot_sorted_nt.fasta",
"taxid_locations_nt.json",
"taxid_annot_sorted_nr.fasta",
"taxid_locations_nr.json",
"taxid_annot_sorted_genus_nt.fasta",
"taxid_locations_genus_nt.json",
"taxid_annot_sorted_genus_nr.fasta",
"taxid_locations_genus_nr.json",
"taxid_annot_sorted_family_nt.fasta",
"taxid_locations_family_nt.json",
"taxid_annot_sorted_family_nr.fasta",
"taxid_locations_family_nr.json"
```