### PR TITLE
Revert align viz to using Unix commands

### DIFF
--- a/idseq_dag/steps/generate_alignment_viz.py
+++ b/idseq_dag/steps/generate_alignment_viz.py
@@ -354,21 +354,21 @@ class PipelineStepGenerateAlignmentViz(PipelineStep):
         num_retries = 3
         for attempt in range(num_retries):
             try:
-                pipe_file = f'pipe-{attempt}-accession-{accession_id}'
+                range_file = f'pipe-{attempt}-accession-{accession_id}'
                 range_end = range_start + name_length + seq_len - 1
                 get_range = f"aws s3api get-object " \
                             f"--range bytes={range_start}-{range_end} " \
                             f"--bucket {nt_bucket} " \
-                            f"--key {nt_key} {pipe_file}"
+                            f"--key {nt_key} {range_file}"
                 command.execute(get_range)
 
                 # (1) Take everything below the first two lines, remove the
                 # newlines chars, and put the sequence into accession_file
                 # (2) Send the first line to stdout
-                cmd = """cat {pipe_file} |tail -n+2 |tr -d '\\n' > {accession_file}; cat {pipe_file} |head -1""".format(pipe_file=pipe_file, accession_file=accession_file)
+                cmd = """cat {range_file} |tail -n+2 |tr -d '\\n' > {accession_file}; cat {range_file} |head -1""".format(range_file=range_file, accession_file=accession_file)
                 seq_name = subprocess.check_output(
                     cmd, executable='/bin/bash', shell=True).decode("utf-8").split(" ", 1)[1]
-                os.remove(pipe_file)
+                os.remove(range_file)
 
                 # Get the sequence length based on the file size
                 seq_len = os.stat(accession_file).st_size
@@ -381,7 +381,7 @@ class PipelineStepGenerateAlignmentViz(PipelineStep):
                     raise RuntimeError(msg)
             finally:
                 try:
-                    os.remove(pipe_file)
+                    os.remove(range_file)
                     pass
                 except:
                     pass

--- a/idseq_dag/steps/generate_alignment_viz.py
+++ b/idseq_dag/steps/generate_alignment_viz.py
@@ -368,7 +368,6 @@ class PipelineStepGenerateAlignmentViz(PipelineStep):
                 cmd = """cat {range_file} |tail -n+2 |tr -d '\\n' > {accession_file}; cat {range_file} |head -1""".format(range_file=range_file, accession_file=accession_file)
                 seq_name = subprocess.check_output(
                     cmd, executable='/bin/bash', shell=True).decode("utf-8").split(" ", 1)[1]
-                os.remove(range_file)
 
                 # Get the sequence length based on the file size
                 seq_len = os.stat(accession_file).st_size

--- a/idseq_dag/steps/generate_alignment_viz.py
+++ b/idseq_dag/steps/generate_alignment_viz.py
@@ -354,7 +354,7 @@ class PipelineStepGenerateAlignmentViz(PipelineStep):
         num_retries = 3
         for attempt in range(num_retries):
             try:
-                range_file = f'pipe-{attempt}-accession-{accession_id}'
+                range_file = f'range-{attempt}-accession-{accession_id}'
                 range_end = range_start + name_length + seq_len - 1
                 get_range = f"aws s3api get-object " \
                             f"--range bytes={range_start}-{range_end} " \


### PR DESCRIPTION
- Boris was right that using the Python funcs slowed down the postprocessing performance (e.g. on sample "4000". Took 40 hours but was supposed to be 8 hrs). So I tested this with the Unix commands but removing the "tee" and it seems to work still. Hopefully will be back to original speed.