### PR TITLE
Suppress s3api calls output

### DIFF
--- a/idseq_dag/steps/generate_alignment_viz.py
+++ b/idseq_dag/steps/generate_alignment_viz.py
@@ -353,7 +353,7 @@ class PipelineStepGenerateAlignmentViz(PipelineStep):
         range_start, name_length, seq_len = entry
 
         accession_file = f'accession-{accession_id}'
-        num_retries = 10
+        num_retries = 3
         for attempt in range(num_retries):
             try:
                 range_file = f'range-{attempt}-accession-{accession_id}'
@@ -373,7 +373,7 @@ class PipelineStepGenerateAlignmentViz(PipelineStep):
                 break
             except Exception as e:
                 if attempt + 1 < num_retries:  # Exponential backoff
-                    time.sleep(1.0 * (1.5**attempt))
+                    time.sleep(1.0 * (4**attempt))
                 else:
                     msg = f"All retries failed for getting sequence by accession ID {accession_id}: {e}"
                     raise RuntimeError(msg)

--- a/idseq_dag/steps/generate_alignment_viz.py
+++ b/idseq_dag/steps/generate_alignment_viz.py
@@ -53,9 +53,11 @@ class PipelineStepGenerateAlignmentViz(PipelineStep):
             annotated_m8, read2seq)
 
         if nt_db.startswith("s3://"):
+            log.write("Getting sequences by accession list from S3...")
             PipelineStepGenerateAlignmentViz.get_sequences_by_accession_list_from_s3(
                 groups, nt_loc_dict, nt_db)
         else:
+            log.write("Getting sequences by accession list from file...")
             PipelineStepGenerateAlignmentViz.get_sequences_by_accession_list_from_file(
                 groups, nt_loc_dict, nt_db)
 
@@ -351,7 +353,7 @@ class PipelineStepGenerateAlignmentViz(PipelineStep):
         range_start, name_length, seq_len = entry
 
         accession_file = f'accession-{accession_id}'
-        num_retries = 3
+        num_retries = 10
         for attempt in range(num_retries):
             try:
                 range_file = f'range-{attempt}-accession-{accession_id}'
@@ -371,9 +373,9 @@ class PipelineStepGenerateAlignmentViz(PipelineStep):
                 break
             except Exception as e:
                 if attempt + 1 < num_retries:  # Exponential backoff
-                    time.sleep(1.0 * (4**attempt))
+                    time.sleep(1.0 * (1.5**attempt))
                 else:
-                    msg = f"All retries failed for getting sequence by accession ID: {e}"
+                    msg = f"All retries failed for getting sequence by accession ID {accession_id}: {e}"
                     raise RuntimeError(msg)
             finally:
                 try:

--- a/idseq_dag/util/s3.py
+++ b/idseq_dag/util/s3.py
@@ -146,12 +146,15 @@ def fetch_from_s3(src,
                     os.remove(dst)
                 return None
 
+
 def fetch_byterange(first_byte, last_byte, bucket, key, output_file):
     get_range = f"aws s3api get-object " \
                 f"--range bytes={first_byte}-{last_byte} " \
                 f"--bucket {bucket} " \
                 f"--key {key} {output_file}"
-    command.execute(get_range)
+    get_range_proc = subprocess.Popen(get_range, shell=True, stdout=subprocess.DEVNULL)
+    get_range_proc.wait()
+
 
 @command.retry
 def upload_with_retries(from_f, to_f):


### PR DESCRIPTION
- Goes to devnull like before so it doesn't clutter the logs
- Test run for this branch: https://staging.idseq.net/samples/989