### PR TITLE
get best accession for each taxid

### DIFF
--- a/examples/postprocess_dag.json
+++ b/examples/postprocess_dag.json
@@ -23,7 +23,10 @@
       "taxid_locations_family_nr.json",
       "taxid_locations_combined.json"
     ],
-    "alignment_viz_out": ["align_viz.summary"]
+    "alignment_viz_out": [
+      "align_viz.summary",
+      "taxid_locations_combined_with_accessions.json"
+    ]
   },
   "steps": [
     {

--- a/examples/postprocess_dag.json
+++ b/examples/postprocess_dag.json
@@ -53,10 +53,10 @@
       "class": "PipelineStepGenerateAlignmentViz",
       "module": "idseq_dag.steps.generate_alignment_viz",
       "additional_files": {
-        "nt_loc_db": "s3://idseq-database/20170824/blast_db/nt_loc.db"
+        "nt_loc_db": "s3://idseq-database/alignment_data/2018-04-01-utc-1522569777-unixtime__2018-04-04-utc-1522862260-unixtime/nt_loc.db"
       },
       "additional_attributes": {
-        "nt_db": "s3://idseq-database/20170824/blast_db/nt"
+        "nt_db": "s3://idseq-database/alignment_data/2018-04-01-utc-1522569777-unixtime__2018-04-04-utc-1522862260-unixtime/nt"
       }
     }
   ],

--- a/idseq_dag/steps/generate_alignment_viz.py
+++ b/idseq_dag/steps/generate_alignment_viz.py
@@ -260,7 +260,7 @@ class PipelineStepGenerateAlignmentViz(PipelineStep):
             }
           }
         '''
-        best_accession_by_taxid = defaultdict(lambda: {"accession": None, "max_num_reads": 0})
+        best_accession_by_taxid = defaultdict(lambda: {"accession": "", "max_num_reads": 0})
         for (family_id, family_dict) in result_dict.items():
             for (genus_id, genus_dict) in family_dict.items():
                 for (species_id, species_dict) in genus_dict.items():

--- a/idseq_dag/steps/generate_alignment_viz.py
+++ b/idseq_dag/steps/generate_alignment_viz.py
@@ -83,7 +83,7 @@ class PipelineStepGenerateAlignmentViz(PipelineStep):
 
         taxon_byteranges_output = self.output_files_local()[1]
         taxon_byteranges_input = self.input_files_local[1][-1]
-        self.dump_best_accession(taxon_byteranges_input, result_dir, taxon_byteranges_output)
+        self.dump_best_accession(taxon_byteranges_input, result_dict, taxon_byteranges_output)
 
         deleter_thread.join()
 
@@ -237,10 +237,11 @@ class PipelineStepGenerateAlignmentViz(PipelineStep):
                         json.dump(species_dict, out_f)
                     self.additional_files_to_upload.append(fn)
 
-    def dump_best_accession(taxon_byteranges_input, result_dir, taxon_byteranges_output):
+    @staticmethod
+    def dump_best_accession(taxon_byteranges_input, result_dict, taxon_byteranges_output):
         '''
         Augment taxon_byteranges with best_accession.
-        result_dir is a dictionary like:
+        result_dict is a dictionary like:
           { "family taxid 1": {
               "genus taxid 1": {
                 "species taxid 1": {
@@ -275,8 +276,8 @@ class PipelineStepGenerateAlignmentViz(PipelineStep):
         with open(taxon_byteranges_input) as f:
             taxon_byteranges = json.load(f)
         for tbr in taxon_byteranges:
-            taxid =  tbr["taxid"]
-            tbr["best_accession"] = best_accession_by_taxid[taxid]["accession"]
+            taxid = tbr["taxid"]
+            tbr["best_accession"] = best_accession_by_taxid[str(taxid)]["accession"]
         with open(taxon_byteranges_output, 'w') as f:
             json.dump(taxon_byteranges, f)
 


### PR DESCRIPTION
goes with https://github.com/chanzuckerberg/idseq-web/pull/1687

TODO:
```
actually i think you should just generate that based on the hitsummary
rather than alignment_viz
because hit_summary gives you the accession (at least for 3.X version)
then you can just look into the refined hitsummary and find the most abundant accession for each taxon
https://github.com/chanzuckerberg/idseq-dag/pull/86/files#diff-08c75eb4dcd0f23c68c7ebcb122c1613R319
new hit_summary format
```