### PR TITLE
require minimum LZW vocabulary length (JIRA-625)

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,8 @@ IDseq DAGs require the use of several indices prepared from files in NCBI. If yo
 TODO: Move this code over to the idseq-dag repo.
 
 ## Release notes
+- 2.10.0
+   - Relax LZW filter for reads longer than 150 bp, linearly with read length. 
 
 - 2.9.0
    - Change how blacklist filter works so that if a read maps both to

--- a/examples/host_filter_dag.json
+++ b/examples/host_filter_dag.json
@@ -69,7 +69,7 @@
       "class": "PipelineStepRunLZW",
       "module": "idseq_dag.steps.run_lzw",
       "additional_files": {},
-      "additional_attributes": { "thresholds": [67.5, 63.0] }
+      "additional_attributes": { "thresholds": [0.45, 0.42] }
     },
     {
       "in": ["lzw_out"],

--- a/examples/host_filter_dag.json
+++ b/examples/host_filter_dag.json
@@ -69,7 +69,7 @@
       "class": "PipelineStepRunLZW",
       "module": "idseq_dag.steps.run_lzw",
       "additional_files": {},
-      "additional_attributes": { "thresholds": [0.45, 0.42] }
+      "additional_attributes": { "thresholds": [67.5, 63.0] }
     },
     {
       "in": ["lzw_out"],

--- a/idseq_dag/__init__.py
+++ b/idseq_dag/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "2.9"
+__version__ = "2.10"
 ''' idseq_dag '''

--- a/idseq_dag/steps/run_lzw.py
+++ b/idseq_dag/steps/run_lzw.py
@@ -62,7 +62,16 @@ class PipelineStepRunLZW(PipelineStep):
                 word = c
         if word != "":
             results.append(dictionary[word])
-        return float(len(results))
+
+        seq_length = len(sequence)
+        lzw_fraction = float(len(results)) / seq_length
+        if seq_length > 150:
+            # Make sure longer reads don't get excessively penalized
+            adjustment_heuristic = (1 + (seq_length - 150) / 1000) # TODO: revisit 
+            score = lzw_fraction * adjustment_heuristic
+        else:
+            score = lzw_fraction
+        return score
 
     @staticmethod
     def lzw_compute(input_files, slice_step=NUM_SLICES):

--- a/idseq_dag/steps/run_lzw.py
+++ b/idseq_dag/steps/run_lzw.py
@@ -28,15 +28,15 @@ class PipelineStepRunLZW(PipelineStep):
     def run(self):
         input_fas = self.input_files_local[0]
         output_fas = self.output_files_local()
-        cutoff_fractions = self.additional_attributes["thresholds"]
-        PipelineStepRunLZW.generate_lzw_filtered(input_fas, output_fas, cutoff_fractions)
+        cutoff_scores = self.additional_attributes["thresholds"]
+        PipelineStepRunLZW.generate_lzw_filtered(input_fas, output_fas, cutoff_scores)
 
     def count_reads(self):
         self.should_count_reads = True
         self.counts_dict[self.name] = count.reads_in_group(self.output_files_local()[0:2])
 
     @staticmethod
-    def lzw_fraction(sequence):
+    def lzw_score(sequence):
         sequence = str(sequence)
         if sequence == "":
             return 0.0
@@ -62,7 +62,7 @@ class PipelineStepRunLZW(PipelineStep):
                 word = c
         if word != "":
             results.append(dictionary[word])
-        return float(len(results)) / len(sequence)
+        return float(len(results))
 
     @staticmethod
     def lzw_compute(input_files, slice_step=NUM_SLICES):
@@ -76,13 +76,13 @@ class PipelineStepRunLZW(PipelineStep):
         @run_in_subprocess
         def lzw_compute_slice(slice_start):
             """For each read, or read pair, in input_files, such that read_index % slice_step == slice_start,
-            output the lzw fraction for the read, or the min lzw fraction for the pair."""
-            lzw_fraction = PipelineStepRunLZW.lzw_fraction
+            output the lzw score for the read, or the min lzw score for the pair."""
+            lzw_score = PipelineStepRunLZW.lzw_score
             with open(temp_file_names[slice_start], "a") as slice_output:
                 for i, reads in enumerate(fasta.synchronized_iterator(input_files)):
                     if i % slice_step == slice_start:
-                        lzw_min_fraction = min(lzw_fraction(r.sequence) for r in reads)
-                        slice_output.write(str(lzw_min_fraction) + "\n")
+                        lzw_min_score = min(lzw_score(r.sequence) for r in reads)
+                        slice_output.write(str(lzw_min_score) + "\n")
 
         # slices run in parallel
         mt_map(lzw_compute_slice, range(slice_step))
@@ -96,19 +96,19 @@ class PipelineStepRunLZW(PipelineStep):
         return coalesced_score_file
 
     @staticmethod
-    def generate_lzw_filtered(fasta_files, output_files, cutoff_fractions):
+    def generate_lzw_filtered(fasta_files, output_files, cutoff_scores):
         assert len(fasta_files) == len(output_files)
 
         # This is the bulk of the computation.  Everything else below is just binning by cutoff score.
         coalesced_score_file = PipelineStepRunLZW.lzw_compute(fasta_files)
 
-        cutoff_fractions.sort(reverse=True) # Make sure cutoff is from high to low
+        cutoff_scores.sort(reverse=True) # Make sure cutoff is from high to low
 
         readcount_list = [] # one item per cutoff
         outstreams_list = [] # one item per cutoff
         outfiles_list = [] # one item per cutoff
 
-        for cutoff in cutoff_fractions:
+        for cutoff in cutoff_scores:
             readcount_list.append(0)
             outstreams = []
             outfiles = []
@@ -120,7 +120,7 @@ class PipelineStepRunLZW(PipelineStep):
             outstreams_list.append(outstreams)
             outfiles_list.append(outfiles)
 
-        outstreams_for_cutoff = list(zip(outstreams_list, cutoff_fractions))
+        outstreams_for_cutoff = list(zip(outstreams_list, cutoff_scores))
 
         def score_iterator(score_file: str) -> Iterator[float]:
             with open(score_file, "r") as sf:
@@ -128,10 +128,10 @@ class PipelineStepRunLZW(PipelineStep):
                     yield float(line)
 
         total_reads = 0
-        for reads, fraction in zip(fasta.synchronized_iterator(fasta_files), score_iterator(coalesced_score_file)):
+        for reads, score in zip(fasta.synchronized_iterator(fasta_files), score_iterator(coalesced_score_file)):
             total_reads += 1
             for i, (outstreams, cutoff) in enumerate(outstreams_for_cutoff):
-                if fraction > cutoff:
+                if score > cutoff:
                     readcount_list[i] += 1
                     for ostr, r in zip(outstreams, reads):
                         ostr.write(r.header + "\n")
@@ -148,7 +148,7 @@ class PipelineStepRunLZW(PipelineStep):
         kept_count = 0
         filtered = total_reads
         cutoff_frac = None
-        for cutoff_frac, readcount, outfiles in zip(cutoff_fractions, readcount_list, outfiles_list):
+        for cutoff_frac, readcount, outfiles in zip(cutoff_scores, readcount_list, outfiles_list):
             if readcount > 0:
                 # found the right bin
                 kept_count = readcount


### PR DESCRIPTION
When reads are longer than 150bp, adjust their LZW upwards, otherwise threshold is too stringent