### PR TITLE
scale-in / do not dispatch to draining servers, add job-tag to selected server

### DIFF
--- a/examples/non_host_alignment_dag.json
+++ b/examples/non_host_alignment_dag.json
@@ -57,7 +57,7 @@
         "chunks_in_flight": 32,
         "chunk_size": 15000,
         "max_concurrent": 3,
-        "environment": "prod"
+        "environment": "staging"
       }
     },
     {
@@ -77,7 +77,7 @@
         "chunks_in_flight": 32,
         "chunk_size": 10000,
         "max_concurrent": 6,
-        "environment": "prod"
+        "environment": "staging"
       }
     },
     {

--- a/examples/non_host_alignment_dag.json
+++ b/examples/non_host_alignment_dag.json
@@ -57,7 +57,11 @@
         "chunks_in_flight": 32,
         "chunk_size": 15000,
         "max_concurrent": 3,
-        "environment": "staging"
+        "environment": "staging",
+        "max_interval_between_describe_instances": 900,
+        "job_tag_prefix": "RunningIDseqBatchJob_",
+        "job_tag_refresh_seconds": 600,
+        "draining_tag": "draining"      
       }
     },
     {
@@ -77,7 +81,11 @@
         "chunks_in_flight": 32,
         "chunk_size": 10000,
         "max_concurrent": 6,
-        "environment": "staging"
+        "environment": "staging",
+        "max_interval_between_describe_instances": 900,
+        "job_tag_prefix": "RunningIDseqBatchJob_",
+        "job_tag_refresh_seconds": 600,
+        "draining_tag": "draining"
       }
     },
     {

--- a/examples/non_host_alignment_dag.json
+++ b/examples/non_host_alignment_dag.json
@@ -61,7 +61,8 @@
         "max_interval_between_describe_instances": 900,
         "job_tag_prefix": "RunningIDseqBatchJob_",
         "job_tag_refresh_seconds": 600,
-        "draining_tag": "draining"      
+        "draining_tag": "draining",
+        "index_dir_suffix": "2018-04-01"
       }
     },
     {
@@ -85,7 +86,8 @@
         "max_interval_between_describe_instances": 900,
         "job_tag_prefix": "RunningIDseqBatchJob_",
         "job_tag_refresh_seconds": 600,
-        "draining_tag": "draining"
+        "draining_tag": "draining",
+        "index_dir_suffix": "2018-04-01"
       }
     },
     {

--- a/examples/non_host_alignment_dag.json
+++ b/examples/non_host_alignment_dag.json
@@ -1,5 +1,5 @@
 {
-  "output_dir_s3": "s3://idseq-samples-prod/samples/12/5815/results_test",
+  "output_dir_s3": "s3://idseq-samples-staging/samples/114/1118/results_test",
   "targets": {
     "host_filter_out": [
 
@@ -135,7 +135,7 @@
   ],
   "given_targets": {
     "host_filter_out": {
-      "s3_dir": "s3://idseq-samples-prod/samples/12/5815/results/2.4"
+      "s3_dir": "s3://idseq-samples-staging/samples/114/1118/results/2.11"
     }
   }
 }

--- a/idseq_dag/steps/run_alignment_remotely.py
+++ b/idseq_dag/steps/run_alignment_remotely.py
@@ -292,13 +292,10 @@ class PipelineStepRunAlignmentRemotely(PipelineStep):
                 max_concurrent = self.additional_attributes["max_concurrent"]
                 environment = self.additional_attributes["environment"]
 
-                instance_ip = server.wait_for_server_ip(service, key_path,
-                                                        remote_username, environment,
-                                                        max_concurrent, chunk_id)
-                log.write("starting alignment for chunk %s on %s server %s" %
-                             (chunk_id, service, instance_ip))
-                instance_iD, job_tag = server.register_job_tag(instance_ip)
-                command.execute(command.remote(commands, key_path, remote_username, instance_ip))
+                with ASGInstance(service, key_path,
+                                 remote_username, environment,
+                                 max_concurrent, chunk_id) as server_ip:
+                    command.execute(command.remote(commands, key_path, remote_username, instance_ip))
 
                 if service == "gsnap":
                     verification_command = "cat %s" % multihit_remote_outfile
@@ -312,7 +309,6 @@ class PipelineStepRunAlignmentRemotely(PipelineStep):
                     min_column_number_string, correct_number_of_output_columns,
                     try_number)
 
-                server.delete_job_tag(instance_iD, job_tag)
                 try_number += 1
 
             # Move output from remote machine to local machine

--- a/idseq_dag/steps/run_alignment_remotely.py
+++ b/idseq_dag/steps/run_alignment_remotely.py
@@ -298,7 +298,7 @@ class PipelineStepRunAlignmentRemotely(PipelineStep):
                 log.write("starting alignment for chunk %s on %s server %s" %
                              (chunk_id, service, instance_ip))
                 command.execute(command.remote(commands, key_path, remote_username, instance_ip))
-                server.register_job_tag(instance_ip)
+                instance_iD, job_tag = server.register_job_tag(instance_ip)
 
                 if service == "gsnap":
                     verification_command = "cat %s" % multihit_remote_outfile
@@ -311,6 +311,8 @@ class PipelineStepRunAlignmentRemotely(PipelineStep):
                 min_column_number = interpret_min_column_number_string(
                     min_column_number_string, correct_number_of_output_columns,
                     try_number)
+
+                server.delete_job_tag(instance_iD, job_tag)
                 try_number += 1
 
             # Move output from remote machine to local machine

--- a/idseq_dag/steps/run_alignment_remotely.py
+++ b/idseq_dag/steps/run_alignment_remotely.py
@@ -292,7 +292,7 @@ class PipelineStepRunAlignmentRemotely(PipelineStep):
                 max_concurrent = self.additional_attributes["max_concurrent"]
                 environment = self.additional_attributes["environment"]
 
-                with ASGInstance(service, key_path,
+                with server.ASGInstance(service, key_path,
                                  remote_username, environment,
                                  max_concurrent, chunk_id) as server_ip:
                     command.execute(command.remote(commands, key_path, remote_username, instance_ip))

--- a/idseq_dag/steps/run_alignment_remotely.py
+++ b/idseq_dag/steps/run_alignment_remotely.py
@@ -297,8 +297,8 @@ class PipelineStepRunAlignmentRemotely(PipelineStep):
                                                         max_concurrent, chunk_id)
                 log.write("starting alignment for chunk %s on %s server %s" %
                              (chunk_id, service, instance_ip))
-                command.execute(command.remote(commands, key_path, remote_username, instance_ip))
                 instance_iD, job_tag = server.register_job_tag(instance_ip)
+                command.execute(command.remote(commands, key_path, remote_username, instance_ip))
 
                 if service == "gsnap":
                     verification_command = "cat %s" % multihit_remote_outfile

--- a/idseq_dag/steps/run_alignment_remotely.py
+++ b/idseq_dag/steps/run_alignment_remotely.py
@@ -294,20 +294,20 @@ class PipelineStepRunAlignmentRemotely(PipelineStep):
 
                 with server.ASGInstance(service, key_path,
                                  remote_username, environment,
-                                 max_concurrent, chunk_id) as server_ip:
+                                 max_concurrent, chunk_id) as instance_ip:
                     command.execute(command.remote(commands, key_path, remote_username, instance_ip))
 
-                if service == "gsnap":
-                    verification_command = "cat %s" % multihit_remote_outfile
-                else:
-                    # For rapsearch, first remove header lines starting with '#'
-                    verification_command = "grep -v '^#' %s" % multihit_remote_outfile
-                verification_command += " | awk '{print NF}' | sort -nu | head -n 1"
-                min_column_number_string = command.execute_with_output(
-                    command.remote(verification_command, key_path, remote_username, instance_ip))
-                min_column_number = interpret_min_column_number_string(
-                    min_column_number_string, correct_number_of_output_columns,
-                    try_number)
+                    if service == "gsnap":
+                        verification_command = "cat %s" % multihit_remote_outfile
+                    else:
+                        # For rapsearch, first remove header lines starting with '#'
+                        verification_command = "grep -v '^#' %s" % multihit_remote_outfile
+                    verification_command += " | awk '{print NF}' | sort -nu | head -n 1"
+                    min_column_number_string = command.execute_with_output(
+                        command.remote(verification_command, key_path, remote_username, instance_ip))
+                    min_column_number = interpret_min_column_number_string(
+                        min_column_number_string, correct_number_of_output_columns,
+                        try_number)
 
                 try_number += 1
 

--- a/idseq_dag/steps/run_alignment_remotely.py
+++ b/idseq_dag/steps/run_alignment_remotely.py
@@ -298,6 +298,7 @@ class PipelineStepRunAlignmentRemotely(PipelineStep):
                 log.write("starting alignment for chunk %s on %s server %s" %
                              (chunk_id, service, instance_ip))
                 command.execute(command.remote(commands, key_path, remote_username, instance_ip))
+                server.register_job_tag(instance_ip)
 
                 if service == "gsnap":
                     verification_command = "cat %s" % multihit_remote_outfile

--- a/idseq_dag/steps/run_alignment_remotely.py
+++ b/idseq_dag/steps/run_alignment_remotely.py
@@ -293,8 +293,12 @@ class PipelineStepRunAlignmentRemotely(PipelineStep):
                 environment = self.additional_attributes["environment"]
 
                 with server.ASGInstance(service, key_path,
-                                 remote_username, environment,
-                                 max_concurrent, chunk_id) as instance_ip:
+                                        remote_username, environment,
+                                        max_concurrent, chunk_id,
+                                        self.additional_attributes["max_interval_between_describe_instances"],
+                                        self.additional_attributes["job_tag_prefix"],
+                                        self.additional_attributes["job_tag_refresh_seconds"],
+                                        self.additional_attributes["draining_tag"]) as instance_ip:
                     command.execute(command.remote(commands, key_path, remote_username, instance_ip))
 
                     if service == "gsnap":

--- a/idseq_dag/util/periodic_thread.py
+++ b/idseq_dag/util/periodic_thread.py
@@ -1,5 +1,6 @@
 import threading
 import time
+import traceback
 
 class PeriodicThread(threading.Thread):
     '''
@@ -31,5 +32,9 @@ class PeriodicThread(threading.Thread):
 
     def run(self) -> None:
         while not self.stopped():
-            self.target(*self.args, **self.kwargs)
-            time.sleep(self.sleep_seconds)
+            try:
+                self.target(*self.args, **self.kwargs)
+            except: #pylint: disable=bare-except
+                traceback.print_exc()
+            finally:
+                time.sleep(self.sleep_seconds)

--- a/idseq_dag/util/periodic_thread.py
+++ b/idseq_dag/util/periodic_thread.py
@@ -1,0 +1,31 @@
+import threading
+import time
+
+class PeriodicThread(threading.Thread):
+    '''
+    Thread that keeps executing its target func periodically until it is told to stop.
+    Usage example:
+        t = PeriodicThread(target=poll_something, sleep_seconds=60, args=(some_argument_1, some_argument_2))
+        t.start()
+        ...
+        t.stop()
+        t.join()
+    '''
+
+    def __init__(self, target, sleep_seconds, args=(), kwargs=None):
+        super(PeriodicThread, self).__init__()
+        self.target = target
+        self.sleep_seconds = sleep_seconds
+        self.args = args
+        self._stop_event = threading.Event()
+
+    def stop(self):
+        self._stop_event.set()
+
+    def stopped(self):
+        return self._stop_event.is_set()
+
+    def run(self) -> None:
+        while not self.stopped():
+            self.target(*self.args, **self.kwargs)
+            time.sleep(self.sleep_seconds)

--- a/idseq_dag/util/periodic_thread.py
+++ b/idseq_dag/util/periodic_thread.py
@@ -17,7 +17,10 @@ class PeriodicThread(threading.Thread):
         self.target = target
         self.sleep_seconds = sleep_seconds
         self.args = args
-        self.kwargs = kwargs
+        if kwargs is None:
+            self.kwargs = {}
+        else:
+            self.kwargs = kwargs
         self._stop_event = threading.Event()
 
     def stop(self):

--- a/idseq_dag/util/periodic_thread.py
+++ b/idseq_dag/util/periodic_thread.py
@@ -6,17 +6,18 @@ class PeriodicThread(threading.Thread):
     '''
     Thread that keeps executing its target func periodically until it is told to stop.
     Usage example:
-        t = PeriodicThread(target=poll_something, sleep_seconds=60, args=(some_argument_1, some_argument_2))
+        t = PeriodicThread(target=poll_something, wait_seconds=60, stop_latency_seconds=10, args=(some_argument_1, some_argument_2))
         t.start()
         ...
         t.stop()
         t.join()
     '''
 
-    def __init__(self, target, sleep_seconds, args=(), kwargs=None):
+    def __init__(self, target, wait_seconds, stop_latency_seconds, args=(), kwargs=None):
         super(PeriodicThread, self).__init__()
         self.target = target
-        self.sleep_seconds = sleep_seconds
+        self.wait_seconds = wait_seconds
+        self.stop_latency_seconds = stop_latency_seconds
         self.args = args
         if kwargs is None:
             self.kwargs = {}
@@ -31,10 +32,14 @@ class PeriodicThread(threading.Thread):
         return self._stop_event.is_set()
 
     def run(self) -> None:
+        last_target_run_unixtime = int(time.time()) - self.stop_latency_seconds
         while not self.stopped():
-            try:
-                self.target(*self.args, **self.kwargs)
-            except: #pylint: disable=bare-except
-                traceback.print_exc()
-            finally:
-                time.sleep(self.sleep_seconds)
+            unixtime_now = int(time.time())
+            if unixtime_now - last_target_run_unixtime >= self.wait_seconds:
+                try:
+                    self.target(*self.args, **self.kwargs)
+                except: #pylint: disable=bare-except
+                    traceback.print_exc()
+                finally:
+                    last_target_run_time = unixtime_now
+            time.sleep(self.stop_latency_seconds)

--- a/idseq_dag/util/periodic_thread.py
+++ b/idseq_dag/util/periodic_thread.py
@@ -17,6 +17,7 @@ class PeriodicThread(threading.Thread):
         self.target = target
         self.sleep_seconds = sleep_seconds
         self.args = args
+        self.kwargs = kwargs
         self._stop_event = threading.Event()
 
     def stop(self):

--- a/idseq_dag/util/server.py
+++ b/idseq_dag/util/server.py
@@ -206,8 +206,8 @@ def create_tag(instance_iD, tag_key, tag_value_func):
     command.execute(f"aws ec2 create-tags --resources {instance_iD} --tags Key={tag_key},Value={tag_value_func()}")
 
 
-def delete_tag(instance_iD, tag_key):
-    command.execute(f"aws ec2 delete-tags --resources {instance_iD} --tags Key={tag_key}")
+def delete_tag_with_retries(instance_iD, tag_key):
+    command.execute_with_retries(f"aws ec2 delete-tags --resources {instance_iD} --tags Key={tag_key}")
 
 
 @contextmanager
@@ -228,4 +228,4 @@ def ASGInstance(service, key_path, remote_username, environment, max_concurrent,
     finally:
         t.stop()
         t.join()
-        delete_tag(instance_iD, job_tag_key)
+        delete_tag_with_retries(instance_iD, job_tag_key)

--- a/idseq_dag/util/server.py
+++ b/idseq_dag/util/server.py
@@ -8,6 +8,8 @@ import multiprocessing
 
 from contextlib import contextmanager
 
+from idseq_dag.util.periodic_thread import PeriodicThread
+
 import idseq_dag.util.command as command
 import idseq_dag.util.log as log
 

--- a/idseq_dag/util/server.py
+++ b/idseq_dag/util/server.py
@@ -191,7 +191,7 @@ def get_instance_iD_from_iP(instance_iP):
 def register_job_tag(instance_iP):
     batch_job_id = os.environ.get('AWS_BATCH_JOB_ID', 'local')
     job_tag = f"{JOB_TAG_PREFIX}{batch_job_id}"
-    id = get_instance_id_from_ip(instance_iP)
+    id = get_instance_iD_from_iP(instance_iP)
     unixtime = int(time.time())
     command.execute(f"aws ec2 create-tags --resources {id} --tags Key={job_tag},Value={unixtime}")
     return id, job_tag

--- a/idseq_dag/util/server.py
+++ b/idseq_dag/util/server.py
@@ -34,11 +34,12 @@ def get_server_ips_work(service_name, environment):
         for instance in reservation["Instances"]
         if DRAINING_TAG not in [tag["Key"] for tag in instance["Tags"]]
     ]
-    print(f'CHARLES: {[
+    tag_list = [
         (instance["NetworkInterfaces"][0]["PrivateIpAddress"], instance["Tags"])
         for reservation in describe_json["Reservations"] 
         for instance in reservation["Instances"]
-    ]}')
+    ]
+    print(tag_list)
     print(f"CHARLES: {server_ips}")
     return server_ips
 

--- a/idseq_dag/util/server.py
+++ b/idseq_dag/util/server.py
@@ -32,6 +32,7 @@ def get_server_ips_work(service_name, environment):
         instance["NetworkInterfaces"][0]["PrivateIpAddress"]
         for reservation in describe_json["Reservations"] 
         for instance in reservation["Instances"]
+        if DRAINING_TAG not in [tag["Key"] for tag in instance["Tags"]]
     ]
     
     return server_ips

--- a/idseq_dag/util/server.py
+++ b/idseq_dag/util/server.py
@@ -197,4 +197,4 @@ def register_job_tag(instance_iP):
     return instance_iD, job_tag
 
 def delete_job_tag(instance_iD, job_tag):
-    command.execute(f"aws ec2 delete-tags --resources {instance_iD} --tags Key={job_tag}"
+    command.execute(f"aws ec2 delete-tags --resources {instance_iD} --tags Key={job_tag}")

--- a/idseq_dag/util/server.py
+++ b/idseq_dag/util/server.py
@@ -82,7 +82,7 @@ def wait_for_server_ip_work(service_name,
             service_name, environment, aggressive=had_to_wait[0])
         instance_ips = random.sample(instance_ip_id_dict.keys(),
                                      min(MAX_INSTANCES_TO_POLL,
-                                         len(instance_ips)))
+                                         len(instance_ip_id_dict)))
         ip_nproc_dict = {}
         dict_mutex = threading.RLock()
         dict_writable = True

--- a/idseq_dag/util/server.py
+++ b/idseq_dag/util/server.py
@@ -218,9 +218,9 @@ def ASGInstance(service, key_path, remote_username, environment, max_concurrent,
     t = PeriodicThread(target=create_tag, sleep_seconds=job_tag_refresh_seconds,
                        args=(instance_iD, job_tag_key, job_tag_value))
     t.start()
-
-    yield instance_ip
-
-    t.stop()
-    t.join()
-    delete_tag(instance_iD, job_tag_key)
+    try:
+        yield instance_ip
+    finally:
+        t.stop()
+        t.join()
+        delete_tag(instance_iD, job_tag_key)

--- a/idseq_dag/util/server.py
+++ b/idseq_dag/util/server.py
@@ -34,7 +34,12 @@ def get_server_ips_work(service_name, environment):
         for instance in reservation["Instances"]
         if DRAINING_TAG not in [tag["Key"] for tag in instance["Tags"]]
     ]
-    
+    print(f"CHARLES: {[
+        (instance["NetworkInterfaces"][0]["PrivateIpAddress"], instance["Tags"])
+        for reservation in describe_json["Reservations"] 
+        for instance in reservation["Instances"]
+    ]}")
+    print(f"CHARLES: {server_ips}")
     return server_ips
 
 

--- a/idseq_dag/util/server.py
+++ b/idseq_dag/util/server.py
@@ -220,7 +220,7 @@ def ASGInstance(service, key_path, remote_username, environment, max_concurrent,
         max_interval_between_describe_instances, draining_tag)
     log.write(f"starting alignment for chunk {chunk_id} on {service} server {instance_ip}")
     job_tag_key, job_tag_value_func = build_job_tag(job_tag_prefix, chunk_id)
-    t = PeriodicThread(target=create_tag, sleep_seconds=job_tag_refresh_seconds,
+    t = PeriodicThread(target=create_tag, wait_seconds=job_tag_refresh_seconds, stop_latency_seconds=60,
                        args=(instance_iD, job_tag_key, job_tag_value_func))
     t.start()
     try:

--- a/idseq_dag/util/server.py
+++ b/idseq_dag/util/server.py
@@ -34,11 +34,11 @@ def get_server_ips_work(service_name, environment):
         for instance in reservation["Instances"]
         if DRAINING_TAG not in [tag["Key"] for tag in instance["Tags"]]
     ]
-    print(f"CHARLES: {[
+    print(f'CHARLES: {[
         (instance["NetworkInterfaces"][0]["PrivateIpAddress"], instance["Tags"])
         for reservation in describe_json["Reservations"] 
         for instance in reservation["Instances"]
-    ]}")
+    ]}')
     print(f"CHARLES: {server_ips}")
     return server_ips
 

--- a/idseq_dag/util/server.py
+++ b/idseq_dag/util/server.py
@@ -191,10 +191,10 @@ def get_instance_iD_from_iP(instance_iP):
 def register_job_tag(instance_iP):
     batch_job_id = os.environ.get('AWS_BATCH_JOB_ID', 'local')
     job_tag = f"{JOB_TAG_PREFIX}{batch_job_id}"
-    id = get_instance_iD_from_iP(instance_iP)
+    instance_iD = get_instance_iD_from_iP(instance_iP)
     unixtime = int(time.time())
-    command.execute(f"aws ec2 create-tags --resources {id} --tags Key={job_tag},Value={unixtime}")
-    return id, job_tag
+    command.execute(f"aws ec2 create-tags --resources {instance_iD} --tags Key={job_tag},Value={unixtime}")
+    return instance_iD, job_tag
 
 def delete_job_tag(instance_iD, job_tag):
     command.execute(f"aws ec2 delete-tags --resources {instance_iD} --tags Key={job_tag}"


### PR DESCRIPTION
This works.
Goes with:
https://github.com/chanzuckerberg/idseq-web/pull/1698
https://github.com/chanzuckerberg/idseq-infra/pull/148
but can semi-safely be deployed first. Only risk is if a lot of jobs are crashing in gsnap/rapsearch we could end up with too many tags on the instances so the cleanup script in idseq-web diff is needed