### PR TITLE
Change username for gsnap running on Amazon Linux 2

### DIFF
--- a/idseq_dag/steps/run_alignment_remotely.py
+++ b/idseq_dag/steps/run_alignment_remotely.py
@@ -73,13 +73,11 @@ class PipelineStepRunAlignmentRemotely(PipelineStep):
         sample_name = self.output_dir_s3.rstrip('/').replace('s3://', '').replace('/', '-')
         chunk_size = self.additional_attributes["chunk_size"]
         index_dir_suffix = self.additional_attributes.get("index_dir_suffix")
+        remote_username = "ec2-user"
+        remote_home_dir = "/home/%s" % remote_username
         if service == "gsnap":
-            remote_username = "ec2-user"
-            remote_home_dir = "/home/%s" % remote_username
             remote_index_dir = "%s/share" % remote_home_dir
         elif service == "rapsearch2":
-            remote_username = "ec2-user"
-            remote_home_dir = "/home/%s" % remote_username
             remote_index_dir = "%s/references/nr_rapsearch" % remote_home_dir
 
         if index_dir_suffix:

--- a/idseq_dag/steps/run_alignment_remotely.py
+++ b/idseq_dag/steps/run_alignment_remotely.py
@@ -74,7 +74,7 @@ class PipelineStepRunAlignmentRemotely(PipelineStep):
         chunk_size = self.additional_attributes["chunk_size"]
         index_dir_suffix = self.additional_attributes.get("index_dir_suffix")
         if service == "gsnap":
-            remote_username = "ubuntu"
+            remote_username = "ec2-user"
             remote_home_dir = "/home/%s" % remote_username
             remote_index_dir = "%s/share" % remote_home_dir
         elif service == "rapsearch2":


### PR DESCRIPTION
This is the corresponding change for <https://github.com/chanzuckerberg/idseq-infra/pull/153> when changing GSNAP-L to run on an up-to-date security patched version of Amazon Linux 2, since the user name changes.