### PR TITLE
deploy 2018-10-26 gsnap to prod and bump version to 3.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,13 @@ TODO: Move this code over to the idseq-dag repo.
 
 ## Release notes
 
+- 3.3.0
+   - Upgrade GSNAP executable to version 2018-10-26.  Index remains unchanged at 2018-12-01.
+     In comprehensive testing on a diverse set of samples, this has shown just a few minor
+     effects on overall results, mostly for reads that align at the limit of detection.
+     The benefit of the change is 3x-8x faster performance.  A/B test data is archived
+     in slack channel #idseq-benchmarking.
+
 - 3.2.5-3.2.1 only affect staging environment
    - 3.2.5 GSNAP Pre-release 2018-10-26, this time for real.
    - 3.2.4 Revert 3.2.3.

--- a/idseq_dag/__init__.py
+++ b/idseq_dag/__init__.py
@@ -1,2 +1,2 @@
 ''' idseq_dag '''
-__version__ = "3.2.5"
+__version__ = "3.3.0"

--- a/idseq_dag/steps/run_alignment_remotely.py
+++ b/idseq_dag/steps/run_alignment_remotely.py
@@ -235,11 +235,7 @@ class PipelineStepRunAlignmentRemotely(PipelineStep):
         base_str = "mkdir -p {remote_work_dir} ; {download_input_from_s3} ; "
         environment = self.additional_attributes["environment"]
         if service == "gsnap":
-            if environment == "staging":   # Keep this around for gsnap pre-release testing.
-                commands = base_str + "{remote_home_dir}/bin/gsnapl -A m8 --batch=0 --use-shared-memory=0 --gmap-mode=none --npaths=100 --ordered -t 36 --max-mismatches=40 -D {remote_index_dir} -d nt_k16 {remote_input_files} > {multihit_remote_outfile}"
-            else:
-                # max_search argument is still required in prod, until we upgrade to 2018-10-20 gsnap
-                commands = base_str + "{remote_home_dir}/bin/gsnapl -A m8 --batch=0 --use-shared-memory=0 --gmap-mode=none --npaths=100 --ordered -t 36 --maxsearch=1000 --max-mismatches=40 -D {remote_index_dir} -d nt_k16 {remote_input_files} > {multihit_remote_outfile}"
+            commands = base_str + "{remote_home_dir}/bin/gsnapl -A m8 --batch=0 --use-shared-memory=0 --gmap-mode=none --npaths=100 --ordered -t 36 --max-mismatches=40 -D {remote_index_dir} -d nt_k16 {remote_input_files} > {multihit_remote_outfile}"
         else:
             commands = base_str + "/usr/local/bin/rapsearch -d {remote_index_dir}/nr_rapsearch -e -6 -l 10 -a T -b 0 -v 50 -z 24 -q {remote_input_files} -o {multihit_remote_outfile}"
 


### PR DESCRIPTION
the comprehensive testing of result quality is nearly complete -- when it is completed later tonight, i will deploy this

performance testing is very promising, most samples benefit 3x to 8x even for very small chunks;  these gains will be magnified even more when the chunks increase in size from 15,000 to 100,000 reads as the app init costs would then become fully amortized

stability testing is complete, with crash probability less than 0.6% per 15k read chunk;  given 66 chunks per sample, a single retry at the chunk level is sufficient to ensure sample crash probability below 0.01%.