### PR TITLE
split read id at underscore before checking pairing

### DIFF
--- a/idseq_dag/steps/run_star.py
+++ b/idseq_dag/steps/run_star.py
@@ -192,12 +192,12 @@ class PipelineStepRunStar(PipelineStep):
         line = f.readline()
         if line:
             if line[0] == 64:  # Equivalent to '@', fastq format
-                rid = line.decode('utf-8').split('\t', 1)[0].strip()
+                rid = line.decode('utf-8').split('\t', 1)[0].split('_', 1)[0].strip()
                 read.append(line)
                 for i in range(3):
                     read.append(f.readline())
             elif line[0] == 62: # Equivalent to '>', fasta format
-                rid = line.decode('utf-8').split('\t', 1)[0].strip()
+                rid = line.decode('utf-8').split('\t', 1)[0].split('_', 1)[0].strip()
                 read.append(line)
                 read.append(f.readline())
             else:


### PR DESCRIPTION
New inputs had "_" as a delimiter before the pair mate (1 / 2) information, causing sync_pairs to think all the pairs were broken because read IDs didn't match expectations. Try splitting the read ID not just at tab, but also at underscore before comparing mates.

I don't think underscores should normally appear in the core read ID (haven't seen that), so my fix should be fine, but I may need to double-check on a wider range of samples. 