### PR TITLE
fix unbound variable

### DIFF
--- a/idseq_dag/steps/run_validate_input.py
+++ b/idseq_dag/steps/run_validate_input.py
@@ -113,7 +113,7 @@ class PipelineStepRunValidateInput(PipelineStep):
                          # non-standard fragment lengths require more detailed examination
                         return False
 
-                if fragment_length != len(read_l) or fragment_length != len(quality_l):
+                if fragment_length != len(read_l) or (is_fastq and fragment_length != len(quality_l)):
                      # file does not meet "quick check" requirements since fragments/quality
                      # scores are not all of same length
                     return False


### PR DESCRIPTION
Any validation condition involving a reference to quality scores needs to be wrapped in an is_fastq condition (fasta doesn't have quality scores)