### PR TITLE
get reference accessions from hitsummary2 instead of align_viz files

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,11 @@ IDseq DAGs require the use of several indices prepared from files in NCBI. If yo
 TODO: Move this code over to the idseq-dag repo.
 
 ## Release notes
+- 3.5.2
+   - Choose most-represented accessions of assembly/gsnap.hitsummary2.tab add assembly/rapsearch2.hitsummary2.tab
+     as the NCBI references to include on phylogenetic trees, as opposed to making the choice based on pre-assembly
+     align_viz files.
+
 - 3.5.1
    - Handle absence of m8 hits in PipelineStepBlastContigs.
 

--- a/examples/phylo_tree_dag.json
+++ b/examples/phylo_tree_dag.json
@@ -77,10 +77,14 @@
         "superkingdom_name": "Bacteria",
         "nt_db": "s3://idseq-database/20170824/blast_db/nt",
         "hitsummary2_files": {
-          "1019": "s3://idseq-samples-development/samples/84/860/postprocess/2.4/assembly/gsnap.hitsummary2.tab",
-          "1020": "s3://idseq-samples-development/samples/84/857/postprocess/2.4/assembly/gsnap.hitsummary2.tab",
-          "1021": "s3://idseq-samples-development/samples/84/858/postprocess/2.4/assembly/gsnap.hitsummary2.tab",
-          "1029": "s3://idseq-samples-development/samples/84/872/postprocess/2.4/assembly/gsnap.hitsummary2.tab"
+          "1019": ["s3://idseq-samples-development/samples/84/860/postprocess/2.4/assembly/gsnap.hitsummary2.tab",
+                   "s3://idseq-samples-development/samples/84/860/postprocess/2.4/assembly/rapsearch2.hitsummary2.tab"],
+          "1020": ["s3://idseq-samples-development/samples/84/857/postprocess/2.4/assembly/gsnap.hitsummary2.tab",
+                   "s3://idseq-samples-development/samples/84/857/postprocess/2.4/assembly/rapsearch2.hitsummary2.tab"],
+          "1021": ["s3://idseq-samples-development/samples/84/858/postprocess/2.4/assembly/gsnap.hitsummary2.tab",
+                   "s3://idseq-samples-development/samples/84/858/postprocess/2.4/assembly/rapsearch2.hitsummary2.tab"],
+          "1029": ["s3://idseq-samples-development/samples/84/872/postprocess/2.4/assembly/gsnap.hitsummary2.tab",
+                   "s3://idseq-samples-development/samples/84/872/postprocess/2.4/assembly/rapsearch2.hitsummary2.tab"]
         }
       }
     }

--- a/examples/phylo_tree_dag.json
+++ b/examples/phylo_tree_dag.json
@@ -76,11 +76,11 @@
         "reference_taxids": [573],
         "superkingdom_name": "Bacteria",
         "nt_db": "s3://idseq-database/20170824/blast_db/nt",
-        "align_viz_files": {
-          "1019": "s3://idseq-samples-development/samples/84/860/postprocess/2.4/align_viz/nt.species.573.align_viz.json",
-          "1020": "s3://idseq-samples-development/samples/84/857/postprocess/2.4/align_viz/nt.species.573.align_viz.json",
-          "1021": "s3://idseq-samples-development/samples/84/858/postprocess/2.4/align_viz/nt.species.573.align_viz.json",
-          "1029": "s3://idseq-samples-development/samples/84/872/postprocess/2.4/align_viz/nt.species.573.align_viz.json"
+        "hitsummary2_files": {
+          "1019": "s3://idseq-samples-development/samples/84/860/postprocess/2.4/assembly/gsnap.hitsummary2.tab",
+          "1020": "s3://idseq-samples-development/samples/84/857/postprocess/2.4/assembly/gsnap.hitsummary2.tab",
+          "1021": "s3://idseq-samples-development/samples/84/858/postprocess/2.4/assembly/gsnap.hitsummary2.tab",
+          "1029": "s3://idseq-samples-development/samples/84/872/postprocess/2.4/assembly/gsnap.hitsummary2.tab"
         }
       }
     }

--- a/idseq_dag/__init__.py
+++ b/idseq_dag/__init__.py
@@ -1,2 +1,2 @@
 ''' idseq_dag '''
-__version__ = "3.5.1"
+__version__ = "3.5.2"

--- a/idseq_dag/steps/generate_alignment_viz.py
+++ b/idseq_dag/steps/generate_alignment_viz.py
@@ -353,7 +353,7 @@ class PipelineStepGenerateAlignmentViz(PipelineStep):
         seq_name = ''
         entry = nt_loc_dict.get(accession_id)
         if not entry:
-            return seq_len, seq_name
+            return seq_len, seq_name, None
 
         range_start, name_length, seq_len = [int(e) for e in entry]
 

--- a/idseq_dag/steps/generate_phylo_tree.py
+++ b/idseq_dag/steps/generate_phylo_tree.py
@@ -219,7 +219,7 @@ class PipelineStepGeneratePhyloTree(PipelineStep):
                     os.path.join(self.ref_dir_local, local_basename))
                 if local_file is None:
                     continue
-                with open(local_file, 'rb') as f:
+                with open(local_file, 'r') as f:
                     for line in f:
                         acc, species_taxid, genus_taxid, family_taxid = line.rstrip().split("\t")[3:7]
                         if any(int(hit_taxid) == taxid for hit_taxid in [species_taxid, genus_taxid, family_taxid]):

--- a/idseq_dag/steps/generate_phylo_tree.py
+++ b/idseq_dag/steps/generate_phylo_tree.py
@@ -50,7 +50,7 @@ class PipelineStepGeneratePhyloTree(PipelineStep):
         # Retrieve NCBI NT references for the accessions in the alignment viz files.
         # These are the accessions (not necessarily full genomes) that were actually matched
         # by the sample's reads during GSNAP alignment.
-        accession_fastas = self.get_accession_sequences(input_dir_for_ksnp3, 10)
+        accession_fastas = self.get_accession_sequences(input_dir_for_ksnp3, taxid, 10)
 
         # Retrieve NCBI metadata for the accessions
         metadata_by_node = self.get_metadata_by_tree_node({**accession_fastas, **genbank_fastas})
@@ -192,7 +192,7 @@ class PipelineStepGeneratePhyloTree(PipelineStep):
             for key2, sub_dict in current_dict.items():
                 PipelineStepGeneratePhyloTree.parse_tree(sub_dict, results, key2)
 
-    def get_accession_sequences(self, dest_dir, n=10):
+    def get_accession_sequences(self, dest_dir, taxid, n=10):
         '''
         Retrieve NCBI NT references for the most-matched accession in each hitsummary2 file, up to a maximum of n references.
         Write each reference to a separate fasta file.

--- a/idseq_dag/steps/generate_phylo_tree.py
+++ b/idseq_dag/steps/generate_phylo_tree.py
@@ -224,6 +224,9 @@ class PipelineStepGeneratePhyloTree(PipelineStep):
                         acc, species_taxid, genus_taxid, family_taxid = line.rstrip().split("\t")[3:7]
                         if any(int(hit_taxid) == taxid for hit_taxid in [species_taxid, genus_taxid, family_taxid]):
                             tally[acc] += 1
+
+            print(f"CHARLES: tally: {tally}")
+
             if tally:
                 best_acc, max_count = max(tally.items(), key=lambda x: x[1])
                 accessions[best_acc] += max_count

--- a/idseq_dag/steps/generate_phylo_tree.py
+++ b/idseq_dag/steps/generate_phylo_tree.py
@@ -240,6 +240,9 @@ class PipelineStepGeneratePhyloTree(PipelineStep):
         # Put 1 fasta file per accession into the destination directory
         accession_fastas = {}
         for acc, info in accession2info.items():
+            if info['seq_file'] is None:
+                log.write(f"WARNING: No sequence retrieved for {acc}")
+                continue
             clean_accession = self.clean_name_for_ksnp3(acc)
             local_fasta = f"{dest_dir}/NCBI_NT_accession_{clean_accession}.fasta"
             command.execute(f"ln -s {info['seq_file']} {local_fasta}")

--- a/idseq_dag/steps/generate_phylo_tree.py
+++ b/idseq_dag/steps/generate_phylo_tree.py
@@ -22,7 +22,7 @@ class PipelineStepGeneratePhyloTree(PipelineStep):
     Generate a phylogenetic tree from the input fasta files using kSNP3:
     http://gensoft.pasteur.fr/docs/kSNP3/01/kSNP3.01%20User%20Guide%20.pdf
     Augment the inputs with
-      (a) NCBI sequences for the accession IDs specified in align_viz_json
+      (a) NCBI sequences for the top accession IDs found in hitsummary2_files
     and/or
       (b) Genbank full reference genomes from the same taxid.
     '''
@@ -230,6 +230,8 @@ class PipelineStepGeneratePhyloTree(PipelineStep):
         if len(accessions) > n:
             accessions = dict(sorted(accessions.items(), key=lambda x: x[1], reverse=True)[:n])
         accessions = set(accessions.keys())
+
+        print(f"CHARLES: accessions: {accessions}")
 
         # Make map of accession to sequence file
         accession2info = dict((acc, {}) for acc in accessions)

--- a/idseq_dag/steps/generate_phylo_tree.py
+++ b/idseq_dag/steps/generate_phylo_tree.py
@@ -224,17 +224,12 @@ class PipelineStepGeneratePhyloTree(PipelineStep):
                         acc, species_taxid, genus_taxid, family_taxid = line.rstrip().split("\t")[3:7]
                         if any(int(hit_taxid) == taxid for hit_taxid in [species_taxid, genus_taxid, family_taxid]):
                             tally[acc] += 1
-
-            print(f"CHARLES: tally: {tally}")
-
             if tally:
                 best_acc, max_count = max(tally.items(), key=lambda x: x[1])
                 accessions[best_acc] += max_count
         if len(accessions) > n:
             accessions = dict(sorted(accessions.items(), key=lambda x: x[1], reverse=True)[:n])
         accessions = set(accessions.keys())
-
-        print(f"CHARLES: accessions: {accessions}")
 
         # Make map of accession to sequence file
         accession2info = dict((acc, {}) for acc in accessions)


### PR DESCRIPTION
Choose NCBI references to include on the tree by counting the hits in the refined m8 (hitsummary2) rather than the align_viz files (which do not incorporate the refinement based on assembly).