### PR TITLE
Optimize downloads and uploads in alignment viz step

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,17 +225,14 @@ IDseq DAGs require the use of several indices prepared from files in NCBI. If yo
 TODO: Move this code over to the idseq-dag repo.
 
 ## Release notes
-- 3.5.2
-   - Choose most-represented accessions of assembly/gsnap.hitsummary2.tab add assembly/rapsearch2.hitsummary2.tab
-     as the NCBI references to include on phylogenetic trees, as opposed to making the choice based on pre-assembly
-     align_viz files.
-
-- 3.5.1
-   - Handle absence of m8 hits in PipelineStepBlastContigs.
-
-- 3.5.0
+- 3.5.0 ... 3.5.3
    - Add ability to run STAR further downstream from input validation. This can be used to filter human reads
      after the host has been filtered out (if host is non-human).
+   - Handle absence of m8 hits in PipelineStepBlastContigs.
+   - Choose most-represented accessions of assembly/gsnap.hitsummary2.tab and assembly/rapsearch2.hitsummary2.tab
+     as the NCBI references to include on phylogenetic trees, as opposed to making the choice based on pre-assembly
+     align_viz files.
+   - Improve the efficiency of S3 downloads and uploads in PipelineStepGenerateAlignmentViz.
 
 - 3.4.0
    - switch from shelve to sqlite3 for all the lookup tables

--- a/idseq_dag/__init__.py
+++ b/idseq_dag/__init__.py
@@ -1,2 +1,2 @@
 ''' idseq_dag '''
-__version__ = "3.5.2"
+__version__ = "3.5.3"

--- a/idseq_dag/engine/pipeline_step.py
+++ b/idseq_dag/engine/pipeline_step.py
@@ -39,6 +39,7 @@ class PipelineStep(object):
         self.input_files_local = []
         self.additional_files_to_upload = []
         self.optional_files_to_upload = []
+        self.additional_folders_to_upload = []
         self.counts_dict = {}
         self.should_terminate = False
         self.should_count_reads = False
@@ -79,6 +80,8 @@ class PipelineStep(object):
             # upload to S3 - TODO(Boris): parallelize the following with better calls
             s3_path = self.s3_path(f)
             idseq_dag.util.s3.upload_with_retries(f, s3_path)
+        for f in self.additional_folders_to_upload:
+            idseq_dag.util.s3.upload_folder_with_retries(f, self.s3_path(f))
         self.status = StepStatus.UPLOADED
 
     def s3_path(self, local_path):

--- a/idseq_dag/steps/generate_alignment_viz.py
+++ b/idseq_dag/steps/generate_alignment_viz.py
@@ -234,19 +234,17 @@ class PipelineStepGenerateAlignmentViz(PipelineStep):
             fn = align_viz_name("family", family_id)
             with open(fn, 'w') as out_f:
                 json.dump(family_dict, out_f)
-            self.additional_files_to_upload.append(fn)
 
             for (genus_id, genus_dict) in family_dict.items():
                 fn = align_viz_name("genus", genus_id)
                 with open(fn, 'w') as out_f:
                     json.dump(genus_dict, out_f)
-                self.additional_files_to_upload.append(fn)
 
                 for (species_id, species_dict) in genus_dict.items():
                     fn = align_viz_name("species", species_id)
                     with open(fn, 'w') as out_f:
                         json.dump(species_dict, out_f)
-                    self.additional_files_to_upload.append(fn)
+        self.additional_folders_to_upload.append(output_json_dir)
 
     @staticmethod
     def parse_reads(annotated_fasta, db_type):

--- a/idseq_dag/steps/generate_alignment_viz.py
+++ b/idseq_dag/steps/generate_alignment_viz.py
@@ -15,6 +15,8 @@ import idseq_dag.util.s3 as s3
 
 from idseq_dag.util.dict import IdSeqDict, IdSeqDictValue, open_file_db_by_extension
 
+MIN_ACCESSIONS_WHOLE_DB_DOWNLOAD = 5000
+
 class PipelineStepGenerateAlignmentViz(PipelineStep):
     """Pipeline step to generate JSON file for read alignment visualizations to
     be consumed by the web app.
@@ -51,19 +53,27 @@ class PipelineStepGenerateAlignmentViz(PipelineStep):
         groups, line_count = self.process_reads_from_m8_file(
             annotated_m8, read2seq)
 
-        # check if nt_db is already downloaded
-        if nt_db.startswith("s3://"):
+        # Check if nt_db is already downloaded
+        is_nt_local = (not nt_db.startswith("s3://"))
+        if not is_nt_local:
             potential_nt_db = os.path.join(self.ref_dir_local, os.path.basename(nt_db))
             if os.path.isfile(potential_nt_db):
                 nt_db = potential_nt_db
+                is_nt_local = True
 
-        if nt_db.startswith("s3://"):
-            log.write("Getting sequences by accession list from S3...")
-            PipelineStepGenerateAlignmentViz.get_sequences_by_accession_list_from_s3(
-                groups, nt_loc_dict, nt_db)
-        else:
+        # If nt_db is not yet downloaded, but there are too many accessions to be fetched,
+        # then do download nt_db here
+        if not is_nt_local and len(groups) >= MIN_ACCESSIONS_WHOLE_DB_DOWNLOAD:
+            nt_db = s3.fetch_from_s3(nt_db, self.ref_dir_local, allow_s3mi=True)
+            is_nt_local = True
+
+        if is_nt_local:
             log.write("Getting sequences by accession list from file...")
             PipelineStepGenerateAlignmentViz.get_sequences_by_accession_list_from_file(
+                groups, nt_loc_dict, nt_db)
+        else:
+            log.write("Getting sequences by accession list from S3...")
+            PipelineStepGenerateAlignmentViz.get_sequences_by_accession_list_from_s3(
                 groups, nt_loc_dict, nt_db)
 
         for accession_id, ad in groups.items():

--- a/idseq_dag/util/s3.py
+++ b/idseq_dag/util/s3.py
@@ -161,6 +161,9 @@ def fetch_byterange(first_byte, last_byte, bucket, key, output_file):
 def upload_with_retries(from_f, to_f):
     command.execute(f"aws s3 cp --only-show-errors {from_f} {to_f}")
 
+@command.retry
+def upload_folder_with_retries(from_f, to_f):
+    command.execute(f"aws s3 cp --only-show-errors --recursive {from_f.rsplit('/')}/ {to_f.rsplit('/')}/")
 
 def upload(from_f, to_f, status, status_lock=threading.RLock()):
     try:


### PR DESCRIPTION
1. Download the entire nt_db instead of making hundreds of thousands of requests for byteranges to S3. Reduces duration of experimental stage by several days.
2. Upload all the small align_viz files in a single request. Reduces duration of experimental stage by several hours.

Test plan:
- fixes the problem on a large sample (17368) 