### PR TITLE
Upload all align viz files in a single request

### DIFF
--- a/idseq_dag/engine/pipeline_step.py
+++ b/idseq_dag/engine/pipeline_step.py
@@ -39,6 +39,7 @@ class PipelineStep(object):
         self.input_files_local = []
         self.additional_files_to_upload = []
         self.optional_files_to_upload = []
+        self.additional_folders_to_upload = []
         self.counts_dict = {}
         self.should_terminate = False
         self.should_count_reads = False
@@ -79,6 +80,8 @@ class PipelineStep(object):
             # upload to S3 - TODO(Boris): parallelize the following with better calls
             s3_path = self.s3_path(f)
             idseq_dag.util.s3.upload_with_retries(f, s3_path)
+        for f in self.additional_folders_to_upload:
+            idseq_dag.util.s3.upload_folder_with_retries(f, self.s3_path(f))
         self.status = StepStatus.UPLOADED
 
     def s3_path(self, local_path):

--- a/idseq_dag/steps/generate_alignment_viz.py
+++ b/idseq_dag/steps/generate_alignment_viz.py
@@ -234,7 +234,7 @@ class PipelineStepGenerateAlignmentViz(PipelineStep):
                     fn = align_viz_name("species", species_id)
                     with open(fn, 'w') as out_f:
                         json.dump(species_dict, out_f)
-        self.additional_folder_to_upload.append(output_json_dir)
+        self.additional_folders_to_upload.append(output_json_dir)
 
     @staticmethod
     def parse_reads(annotated_fasta, db_type):

--- a/idseq_dag/steps/generate_alignment_viz.py
+++ b/idseq_dag/steps/generate_alignment_viz.py
@@ -224,19 +224,17 @@ class PipelineStepGenerateAlignmentViz(PipelineStep):
             fn = align_viz_name("family", family_id)
             with open(fn, 'w') as out_f:
                 json.dump(family_dict, out_f)
-            self.additional_files_to_upload.append(fn)
 
             for (genus_id, genus_dict) in family_dict.items():
                 fn = align_viz_name("genus", genus_id)
                 with open(fn, 'w') as out_f:
                     json.dump(genus_dict, out_f)
-                self.additional_files_to_upload.append(fn)
 
                 for (species_id, species_dict) in genus_dict.items():
                     fn = align_viz_name("species", species_id)
                     with open(fn, 'w') as out_f:
                         json.dump(species_dict, out_f)
-                    self.additional_files_to_upload.append(fn)
+        self.additional_folder_to_upload.append(output_json_dir)
 
     @staticmethod
     def parse_reads(annotated_fasta, db_type):

--- a/idseq_dag/util/s3.py
+++ b/idseq_dag/util/s3.py
@@ -161,6 +161,9 @@ def fetch_byterange(first_byte, last_byte, bucket, key, output_file):
 def upload_with_retries(from_f, to_f):
     command.execute(f"aws s3 cp --only-show-errors {from_f} {to_f}")
 
+@command.retry
+def upload_folder_with_retries(from_f, to_f):
+    command.execute(f"aws s3 cp --only-show-errors --recursive {from_f.rsplit('/')}/ {to_f.rsplit('/')}/")
 
 def upload(from_f, to_f, status, status_lock=threading.RLock()):
     try:


### PR DESCRIPTION
The pipeline_engine uploads each file in `additional_files_to_upload` to S3 individually, which makes sense for a small number of large files, but not a large number of small files. This PR should reduce the duration of experimental stage by several hours.