### PR TITLE
Log improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,10 @@ IDseq DAGs require the use of several indices prepared from files in NCBI. If yo
 TODO: Move this code over to the idseq-dag repo.
 
 ## Release notes
+
+- 3.5.4
+   - New log methods to write log events. Added and replaced a few log entries.
+
 - 3.5.0 ... 3.5.3
    - Add ability to run STAR further downstream from input validation. This can be used to filter human reads
      after the host has been filtered out (if host is non-human).

--- a/idseq_dag/__init__.py
+++ b/idseq_dag/__init__.py
@@ -1,2 +1,2 @@
 ''' idseq_dag '''
-__version__ = "3.5.3"
+__version__ = "3.5.4"

--- a/idseq_dag/engine/pipeline_step.py
+++ b/idseq_dag/engine/pipeline_step.py
@@ -146,13 +146,18 @@ class PipelineStep(object):
     def thread_run(self):
         ''' Actually running the step '''
         self.status = StepStatus.STARTED
-        self.wait_for_input_files()
-        log.write("START STEP %s" % self.name)
-        self.run()
-        self.validate()
-        self.save_progress()
-        self.save_counts()
-        log.write("FINISH STEP %s" % self.name)
+        v = {"step": self.name}
+        with log.log_context("dag_step", v):
+            with log.log_context("substep_wait_for_input_files", v):
+                self.wait_for_input_files()
+            with log.log_context("substep_run", v):
+                self.run()
+            with log.log_context("substep_validate", v):
+                self.validate()
+            with log.log_context("substep_save_progress", v):
+                self.save_progress()
+            with log.log_context("substep_save_counts", v):
+                self.save_counts()
         self.upload_thread = threading.Thread(target=self.uploading_results)
         self.upload_thread.start()
         self.status = StepStatus.FINISHED

--- a/idseq_dag/util/log.py
+++ b/idseq_dag/util/log.py
@@ -2,6 +2,11 @@ import logging
 import multiprocessing
 import os
 import sys
+import json
+import datetime
+import functools
+
+from contextlib import contextmanager
 
 print_lock = multiprocessing.RLock()
 
@@ -34,6 +39,70 @@ def write(message, warning=False, flush=True):
         if flush:
             sys.stdout.flush()
 
+def log_event(event_name, values=None, start_time=None, warning=False, flush=True):
+    '''
+    Write a new log event.
+
+    Parameters:
+    event_name (str): name of the event
+    values(dict): Optional. Values associated to that event. Will be logged in json format.
+    start_time(datetime): Optional. If given, it will calc the elapsed time from this datetime to now and write it to the log line.
+
+    Returns:
+    datetime: Now. It can be used to pass to parameter start_time in a future log_event call.
+
+    Example:
+    start = log_event("downloaded_started", {"file":"abc"})
+    # ... download your file here ...
+    log_event("downloaded_completed", {"file":"abc"}, start_time=start)
+    '''
+    fmt_values = "{}" if values is None else json.dumps(values)
+    if start_time is None:
+        fmt_message = "Event '%s' %s" % (event_name, fmt_values)
+    else:
+        duration = (datetime.datetime.now()-start_time).total_seconds()
+        fmt_message = "Event '%s' %s (%.1f seconds)" % (event_name, fmt_values, duration)
+    write(fmt_message, warning, flush)
+    return datetime.datetime.now()
+
+@contextmanager
+def log_context(context_name, values=None, log_caller_info=True):
+    '''
+    Log context manager to track started and completed events for a block of code
+
+    Parameters:
+    context_name (str): Name for this context.
+    values(dict): Optional. Values associated to that event. Will be logged in json format.
+    log_caller_info(bool): Log the caller file_name and method name.
+
+    Example:
+    # some_file.py
+    from log import log_context
+
+    def some_method
+        # ... some code here ...
+        with log_context("sub_step", {"abc": "123"}):
+            # ... your code goes here ...
+
+    The code above will generate two log entries:
+    Event ctx_start {"n": "sub_step", "v": {abc": 123}, "caller": {"f": ["some_file.py", "some_method"]}
+    Event ctx_end {"n": "sub_step", "v": {abc": 123}, "caller": {"f": ["some_file.py", "some_method"]} (0.3 sec)
+    '''
+    val = {"n": context_name}
+    if values is not None:
+        val["v"] = values
+    if log_caller_info:
+        f_code = sys._getframe(2).f_code
+        val["caller"] = {"f": [os.path.basename(f_code.co_filename), f_code.co_name]}
+    start = log_event("ctx_start", val)
+    try:
+        yield
+        log_event("ctx_end", val, start_time=start)
+    except Exception as e:
+        val["error_type"] = type(e).__name__
+        val["error_args"] = e.args
+        log_event("ctx_error", val, start_time=start)
+        raise e
 
 def set_up_stdout():
     # Unbuffer stdout and redirect stderr into stdout. This helps observe logged

--- a/idseq_dag/util/log.py
+++ b/idseq_dag/util/log.py
@@ -12,14 +12,14 @@ def configure_logger(log_file=None):
 
     if log_file:
         handler = logging.FileHandler(log_file)
-        formatter = logging.Formatter("%(asctime)s: %(message)s")
+        formatter = logging.Formatter("%(asctime)s: [%(threadName)12s] %(message)s")
         handler.setFormatter(formatter)
         logger.addHandler(handler)
 
     # Echo to stdout so they get to CloudWatch
     handler = logging.StreamHandler(sys.stdout)
     handler.setLevel(logging.INFO)
-    formatter = logging.Formatter("%(asctime)s: %(message)s")
+    formatter = logging.Formatter("%(asctime)s: [%(threadName)12s] %(message)s")
     handler.setFormatter(formatter)
     logger.addHandler(handler)
 


### PR DESCRIPTION
Added two new log methods to log.py and some extra log event to pipleline_flow and pipeline_step.

With this change, logging and measuring execution of code fragments is much easier.
Example:
```python
# some_file.py
from log import log_context

def some_method
    # ... some code here ...
    with log_context("sub_step", {"abc": "123"}):
        # ... your code fragment goes here ...
```
The code above will generate two log entries before and after executing the code fragment:
```
Event ctx_start {"n": "sub_step", "v": {abc": 123}, "caller": {"f": ["some_file.py", "some_method"]}
Event ctx_end {"n": "sub_step", "v": {abc": 123}, "caller": {"f": ["some_file.py", "some_method"]} (0.3 sec)
```