### PR TITLE
Logging RLocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,15 +226,16 @@ TODO: Move this code over to the idseq-dag repo.
 
 ## Release notes
 
+- 3.6.1
+   - Extra logs to help detecting potential deadlocks in the pipeline (#144).
+
 - 3.6.0
    - Add pipeline step to generate data for coverage visualization for IDseq report page. Data includes an index
      file that maps taxons to accessions with available coverage data, as well as data files for each accession
      that list various metrics including the coverage of the accession.
 
-- 3.5.4
+- 3.5.0 ... 3.5.4
    - New log methods to write log events. Added and replaced a few log entries.
-
-- 3.5.0 ... 3.5.3
    - Add ability to run STAR further downstream from input validation. This can be used to filter human reads
      after the host has been filtered out (if host is non-human).
    - Handle absence of m8 hits in PipelineStepBlastContigs.

--- a/idseq_dag/__init__.py
+++ b/idseq_dag/__init__.py
@@ -1,2 +1,2 @@
 ''' idseq_dag '''
-__version__ = "3.6.0"
+__version__ = "3.6.1"

--- a/idseq_dag/steps/download_accessions.py
+++ b/idseq_dag/steps/download_accessions.py
@@ -1,16 +1,14 @@
-import json
 import os
 import threading
 import time
 import traceback
-from collections import defaultdict
 from idseq_dag.engine.pipeline_step import PipelineStep
 import idseq_dag.util.command as command
-import idseq_dag.util.count as count
 import idseq_dag.util.s3 as s3
 import idseq_dag.util.m8 as m8
 
-from idseq_dag.util.dict import IdSeqDict, IdSeqDictValue, open_file_db_by_extension
+from idseq_dag.util.dict import IdSeqDictValue, open_file_db_by_extension
+from idseq_dag.util.trace_lock import TraceLock
 
 MIN_ACCESSIONS_WHOLE_DB_DOWNLOAD = 5000
 MAX_ACCESSION_SEQUENCE_LEN = 100000000
@@ -58,7 +56,7 @@ class PipelineStepDownloadAccessions(PipelineStep):
         threads = []
         error_flags = {}
         semaphore = threading.Semaphore(64)
-        mutex = threading.RLock()
+        mutex = TraceLock("download_ref_sequences_from_s3", threading.RLock())
 
         bucket, key = db_s3_path[5:].split("/", 1)
         loc_dict = open_file_db_by_extension(loc_db, IdSeqDictValue.VALUE_TYPE_ARRAY)

--- a/idseq_dag/steps/fetch_tax_info.py
+++ b/idseq_dag/steps/fetch_tax_info.py
@@ -8,6 +8,7 @@ import idseq_dag.util.command as command
 import idseq_dag.util.log as log
 import idseq_dag.util.s3 as s3
 from idseq_dag.engine.pipeline_step import PipelineStep
+from idseq_dag.util.trace_lock import TraceLock
 
 
 class PipelineStepFetchTaxInfo(PipelineStep):
@@ -70,7 +71,7 @@ class PipelineStepFetchTaxInfo(PipelineStep):
         ''' Fetch wikipedia content based on taxid2wikidict '''
         threads = []
         semaphore = threading.Semaphore(num_threads)
-        mutex = threading.RLock()
+        mutex = TraceLock("fetch_wiki_content", threading.RLock())
         for taxid, url in taxid2wikidict.items():
             m = re.search("curid=(\d+)", url)
             pageid = None
@@ -130,7 +131,7 @@ class PipelineStepFetchTaxInfo(PipelineStep):
         ''' Use Entrez API to fetch taxonid -> wikipedia page mapping '''
         threads = []
         semaphore = threading.Semaphore(num_threads)
-        mutex = threading.RLock()
+        mutex = TraceLock("fetch_ncbi_wiki_map", threading.RLock())
         batch = []
         with open(taxid_list, 'r') as taxf:
             for line in taxf:

--- a/idseq_dag/steps/generate_alignment_viz.py
+++ b/idseq_dag/steps/generate_alignment_viz.py
@@ -10,6 +10,7 @@ import subprocess
 from idseq_dag.engine.pipeline_step import PipelineStep
 from idseq_dag.util.lineage import INVALID_CALL_BASE_ID
 import idseq_dag.util.log as log
+from idseq_dag.util.trace_lock import TraceLock
 import idseq_dag.util.command as command
 import idseq_dag.util.s3 as s3
 
@@ -300,7 +301,7 @@ class PipelineStepGenerateAlignmentViz(PipelineStep):
         threads = []
         error_flags = {}
         semaphore = threading.Semaphore(64)
-        mutex = threading.RLock()
+        mutex = TraceLock("get_sequences_by_accession_list_from_s3", threading.RLock())
         nt_bucket, nt_key = nt_s3_path[5:].split("/", 1)
         for accession_id, accession_info in accession_id_groups.items():
             semaphore.acquire()

--- a/idseq_dag/steps/run_alignment_remotely.py
+++ b/idseq_dag/steps/run_alignment_remotely.py
@@ -12,6 +12,7 @@ import idseq_dag.util.server as server
 import idseq_dag.util.log as log
 import idseq_dag.util.m8 as m8
 from idseq_dag.util.s3 import fetch_from_s3
+from idseq_dag.util.trace_lock import TraceLock
 
 MAX_CONCURRENT_CHUNK_UPLOADS = 4
 DEFAULT_BLACKLIST_S3 = 's3://idseq-database/taxonomy/2018-04-01-utc-1522569777-unixtime__2018-04-04-utc-1522862260-unixtime/taxon_blacklist.txt'
@@ -86,7 +87,7 @@ class PipelineStepRunAlignmentRemotely(PipelineStep):
         # Process chunks
         chunk_output_files = [None] * len(input_chunks)
         chunk_threads = []
-        mutex = threading.RLock()
+        mutex = TraceLock("run_remotely", threading.RLock())
         # Randomize execution order for performance
         randomized = list(enumerate(input_chunks))
         random.shuffle(randomized)

--- a/idseq_dag/util/command.py
+++ b/idseq_dag/util/command.py
@@ -222,8 +222,7 @@ def execute(command,
     execution with logging.
     """
     with CommandTracker() as ct:
-        with log.print_lock:
-            log.write("Command {}: {}".format(ct.id, command))
+        log.write("Command {}: {}".format(ct.id, command))
         with ProgressFile(progress_file):
             if timeout:
                 ct.timeout = timeout
@@ -245,6 +244,8 @@ def execute(command,
                 ct.proc = subprocess.Popen(command, shell=True)
                 ct.proc.wait()
                 stdout = None
+
+            log.write("Command {} completed. Return code {}".format(ct.id, ct.proc.returncode))
 
             if ct.proc.returncode:
                 raise subprocess.CalledProcessError(ct.proc.returncode,

--- a/idseq_dag/util/command.py
+++ b/idseq_dag/util/command.py
@@ -6,6 +6,7 @@ import threading
 import time
 from functools import wraps
 import idseq_dag.util.log as log
+from idseq_dag.util.trace_lock import TraceLock
 
 
 class Updater(object):
@@ -25,6 +26,7 @@ class Updater(object):
             t_elapsed = time.time() - self.t_start
             self.update_function(t_elapsed)
         self.timer_thread = threading.Timer(self.update_period, self.relaunch)
+        self.timer_thread.name = "TimerThread"
         self.timer_thread.start()
 
     def __enter__(self):
@@ -40,7 +42,7 @@ class CommandTracker(Updater):
     """CommandTracker is for running external and remote commands and
     monitoring their progress with log updates and timeouts.
     """
-    lock = multiprocessing.RLock()
+    lock = TraceLock("CommandTracker", multiprocessing.RLock())
     count = multiprocessing.Value('i', 0)
 
     def __init__(self, update_period=15):

--- a/idseq_dag/util/log.py
+++ b/idseq_dag/util/log.py
@@ -69,6 +69,44 @@ def log_event(event_name, values=None, start_time=None, warning=False, flush=Tru
     write(fmt_message, warning, flush)
     return datetime.datetime.now()
 
+def log_execution(values=None):
+    '''
+    Decorates a function and write to logs fn_start and fn_end events.
+
+    Parameters:
+    values(dict): Optional. Values associated to that event. Will be logged in json format.
+
+    Example:
+
+    from log import log_execution
+    @log_execution()
+    def my_function
+        # ...
+
+    The code above will generate two log entries:
+    Event fn_start {"n": "my_function"}
+    Event fn_end {"n": "my_function"} (0.3 sec)
+    '''
+    def decorator_fn(func):
+        @functools.wraps(func)
+        def wrapper_fn(*args, **kwargs):
+            if values is None:
+                val = {"name": func.__qualname__}
+            else:
+                val = {"name": func.__qualname__, "v": values}
+            start = log_event("fn_start", val)
+            try:
+                result = func(*args, **kwargs)
+                log_event("fn_end", val, start_time=start)
+                return result
+            except Exception as e:
+                val["error_type"] = type(e).__name__
+                val["error_args"] = e.args
+                log_event("fn_error", val, start_time=start)
+                raise e
+        return wrapper_fn
+    return decorator_fn
+
 @contextmanager
 def log_context(context_name, values=None, log_caller_info=True):
     '''

--- a/idseq_dag/util/log.py
+++ b/idseq_dag/util/log.py
@@ -5,6 +5,7 @@ import sys
 import json
 import datetime
 import math
+import functools
 
 from contextlib import contextmanager
 

--- a/idseq_dag/util/trace_lock.py
+++ b/idseq_dag/util/trace_lock.py
@@ -3,13 +3,59 @@ import threading
 import idseq_dag.util.log as log
 
 class TraceLock():
+    """
+    This class is a wrapper to RLocks that can log states of the lock for each thread.
+
+    TraceLock can be used in a `with` block, like a regular RLock:
+
+    ```
+    with TraceLock("my_lock_name"):
+        ... something that requires a lock
+    ```
+
+    This will generate log entries like:
+    ```
+        {"event":"trace_lock", values={"lock_name": "lock1", "thread_name": "Thread-1", "state": "acquired"})
+        {"event":"trace_lock", values={"lock_name": "lock1", "thread_name": "Thread-2", "state": "waiting"})
+        {"event":"trace_lock", values={"lock_name": "lock1", "thread_name": "Thread-1", "state": "released"})
+        {"event":"trace_lock", values={"lock_name": "lock1", "thread_name": "Thread-2", "state": "acquired_after_wait"})
+        {"event":"trace_lock", values={"lock_name": "lock1", "thread_name": "Thread-2", "state": "released"})
+    ```
+
+    State diagram:
+    ```
+           some thread is trying               
+             to acquire a lock                 
+                     ||                        
+                     /\                        
+           +-------- \/ --------+ lock is      
+ lock is   |                    | not available
+ available |              +-----v----+         
+           |              | waiting  |         
+           |              +-----|----+         
+           |                    | lock is now  
+           |                    | available    
+     +-----v----+     +---------v---------+    
+     | acquired |     |acquired_after_wait|    
+     +-----|----+     +---------|---------+    
+           |                    |              
+           |   thread realeases |              
+           |      the lock      |              
+           +-------->/\<--------+              
+                     \/                        
+                     ||                        
+                     vv                        
+              +--------------+                 
+              |   released   |                 
+              +--------------+
+    ```
+    """
     def __init__(self, lock_name, lock=multiprocessing.RLock()):
         self._lock = lock
         self._lock_name = lock_name
 
     def acquire(self):
         v = {"lock_name": self._lock_name, "thread_name": threading.current_thread().name}
-        log.log_event("trace_lock", values={**v, "state": "acquiring"})
         if self._lock.acquire(False):
             log.log_event("trace_lock", values={**v, "state": "acquired"})
         else:
@@ -23,7 +69,7 @@ class TraceLock():
     def release(self):
         log.log_event("trace_lock", values={"lock_name": self._lock_name,
                                             "thread_name": threading.current_thread().name,
-                                            "state": "release"})
+                                            "state": "released"})
         self._lock.release()
 
     def __exit__(self, exc_type, exc_value, exc_traceback):

--- a/idseq_dag/util/trace_lock.py
+++ b/idseq_dag/util/trace_lock.py
@@ -1,0 +1,30 @@
+import multiprocessing
+import threading
+import idseq_dag.util.log as log
+
+class TraceLock():
+    def __init__(self, lock_name, lock=multiprocessing.RLock()):
+        self._lock = lock
+        self._lock_name = lock_name
+
+    def acquire(self):
+        v = {"lock_name": self._lock_name, "thread_name": threading.current_thread().name}
+        log.log_event("trace_lock", values={**v, "state": "acquiring"})
+        if self._lock.acquire(False):
+            log.log_event("trace_lock", values={**v, "state": "acquired"})
+        else:
+            log.log_event("trace_lock", values={**v, "state": "waiting"})
+            self._lock.acquire(True)
+            log.log_event("trace_lock", values={**v, "state": "acquired_after_wait"})
+
+    def __enter__(self):
+        self.acquire()
+
+    def release(self):
+        log.log_event("trace_lock", values={"lock_name": self._lock_name,
+                                            "thread_name": threading.current_thread().name,
+                                            "state": "release"})
+        self._lock.release()
+
+    def __exit__(self, exc_type, exc_value, exc_traceback):
+        self.release()

--- a/tests/unit/util/test_trace_lock.py
+++ b/tests/unit/util/test_trace_lock.py
@@ -1,0 +1,56 @@
+import unittest
+from unittest.mock import patch, call
+
+# Collaborators to inject
+import threading
+import time
+
+# Class under test
+from idseq_dag.util.trace_lock import TraceLock
+
+class TestTraceLock(unittest.TestCase):
+    '''Tests for `util/trace_rlock.py`'''
+
+    @staticmethod
+    @patch('idseq_dag.util.log.log_event')
+    def test_aquire_free_lock(mock_log_event):
+        '''Test lock acquiring when lock is free'''
+        lock = TraceLock('free')
+
+        with lock:
+            pass
+
+        mock_log_event.assert_has_calls([
+            call('trace_lock', values={'state': 'acquiring', 'lock_name': 'free', 'thread_name': 'MainThread'}),
+            call('trace_lock', values={'state': 'acquired', 'lock_name': 'free', 'thread_name': 'MainThread'}),
+            call('trace_lock', values={'state': 'release', 'lock_name': 'free', 'thread_name': 'MainThread'})
+        ])
+
+    @staticmethod
+    @patch('idseq_dag.util.log.log_event')
+    def test_aquire_lock(mock_log_event):
+        '''Test waiting to acquire lock'''
+        lock = TraceLock('busy') # object under test
+        event = threading.Event()
+        def thread_run():
+            with lock: # lock acquired
+                event.set()
+                time.sleep(0.5) # make main thread wait for this lock a bit
+        first_thread = threading.Thread(target=thread_run)
+        first_thread.name = "Thread-1"
+        first_thread.start()
+
+        event.wait()  # wait first_thread acquire the lock
+
+        with lock: # lock will be held for a while we want
+            pass
+
+        mock_log_event.assert_has_calls([
+            call('trace_lock', values={'lock_name': 'busy', 'thread_name': 'Thread-1', 'state': 'acquiring'}),
+            call('trace_lock', values={'lock_name': 'busy', 'thread_name': 'Thread-1', 'state': 'acquired'}),
+            call('trace_lock', values={'lock_name': 'busy', 'thread_name': 'MainThread', 'state': 'acquiring'}),
+            call('trace_lock', values={'lock_name': 'busy', 'thread_name': 'MainThread', 'state': 'waiting'}),
+            call('trace_lock', values={'lock_name': 'busy', 'thread_name': 'Thread-1', 'state': 'release'}),
+            call('trace_lock', values={'lock_name': 'busy', 'thread_name': 'MainThread', 'state': 'acquired_after_wait'}),
+            call('trace_lock', values={'lock_name': 'busy', 'thread_name': 'MainThread', 'state': 'release'})
+        ])

--- a/tests/unit/util/test_trace_lock.py
+++ b/tests/unit/util/test_trace_lock.py
@@ -15,22 +15,21 @@ class TestTraceLock(unittest.TestCase):
     @patch('idseq_dag.util.log.log_event')
     def test_aquire_free_lock(mock_log_event):
         '''Test lock acquiring when lock is free'''
-        lock = TraceLock('free')
+        lock = TraceLock('lock1')
 
         with lock:
             pass
 
         mock_log_event.assert_has_calls([
-            call('trace_lock', values={'state': 'acquiring', 'lock_name': 'free', 'thread_name': 'MainThread'}),
-            call('trace_lock', values={'state': 'acquired', 'lock_name': 'free', 'thread_name': 'MainThread'}),
-            call('trace_lock', values={'state': 'release', 'lock_name': 'free', 'thread_name': 'MainThread'})
+            call('trace_lock', values={'state': 'acquired', 'lock_name': 'lock1', 'thread_name': 'MainThread'}),
+            call('trace_lock', values={'state': 'released', 'lock_name': 'lock1', 'thread_name': 'MainThread'})
         ])
 
     @staticmethod
     @patch('idseq_dag.util.log.log_event')
     def test_aquire_lock(mock_log_event):
         '''Test waiting to acquire lock'''
-        lock = TraceLock('busy') # object under test
+        lock = TraceLock('lock2') # object under test
         event = threading.Event()
         def thread_run():
             with lock: # lock acquired
@@ -46,11 +45,9 @@ class TestTraceLock(unittest.TestCase):
             pass
 
         mock_log_event.assert_has_calls([
-            call('trace_lock', values={'lock_name': 'busy', 'thread_name': 'Thread-1', 'state': 'acquiring'}),
-            call('trace_lock', values={'lock_name': 'busy', 'thread_name': 'Thread-1', 'state': 'acquired'}),
-            call('trace_lock', values={'lock_name': 'busy', 'thread_name': 'MainThread', 'state': 'acquiring'}),
-            call('trace_lock', values={'lock_name': 'busy', 'thread_name': 'MainThread', 'state': 'waiting'}),
-            call('trace_lock', values={'lock_name': 'busy', 'thread_name': 'Thread-1', 'state': 'release'}),
-            call('trace_lock', values={'lock_name': 'busy', 'thread_name': 'MainThread', 'state': 'acquired_after_wait'}),
-            call('trace_lock', values={'lock_name': 'busy', 'thread_name': 'MainThread', 'state': 'release'})
+            call('trace_lock', values={'lock_name': 'lock2', 'thread_name': 'Thread-1', 'state': 'acquired'}),
+            call('trace_lock', values={'lock_name': 'lock2', 'thread_name': 'MainThread', 'state': 'waiting'}),
+            call('trace_lock', values={'lock_name': 'lock2', 'thread_name': 'Thread-1', 'state': 'released'}),
+            call('trace_lock', values={'lock_name': 'lock2', 'thread_name': 'MainThread', 'state': 'acquired_after_wait'}),
+            call('trace_lock', values={'lock_name': 'lock2', 'thread_name': 'MainThread', 'state': 'released'})
         ])


### PR DESCRIPTION
This is a more aggressive strategy to map the lock issue for ticket IDSEQ-930.

We have a hunch that `blastx` command is hanging, but something is odd with our reports. If that were the case, we should be able to see `Command XXX still running` forever, which is not happening.

I can think in lots of possible causes, ex:
a) "still running" mechanism is not reporting properly (I don't think that's the case)
b) `blastx` command completed its execution and the code is stuck in a later step
c) some dead lock issue related to many threading.RLocks that we have spread throughout our code

I'm adding extra logs to map eventual dead lock conditions related to `threading.RLock` objects. 
This PR allows tracking lock waiting states. 

Also I added a "Command XXX completed with result Y", because we don't have this log entry being sent to our logs. Currently we only have the "Command XXX still running", but if that timer stops, it is hard to know if a command has actually been completed or if the process somehow died.

New event log entries looks like:
```
{"event":"trace_lock", values={"lock_name": "lock1", "thread_name": "Thread-1", "state": "acquired"})
{"event":"trace_lock", values={"lock_name": "lock1", "thread_name": "Thread-2", "state": "waiting"})
{"event":"trace_lock", values={"lock_name": "lock1", "thread_name": "Thread-1", "state": "released"})
{"event":"trace_lock", values={"lock_name": "lock1", "thread_name": "Thread-2", "state": "acquired_after_wait"})
{"event":"trace_lock", values={"lock_name": "lock1", "thread_name": "Thread-2", "state": "released"})
```

and it can log the following states:
```
    State diagram:

           some thread is trying               
             to acquire a lock                 
                     ||                        
                     /\                        
           +-------- \/ --------+ lock is      
 lock is   |                    | not available
 available |              +-----v----+         
           |              | waiting  |         
           |              +-----|----+         
           |                    | lock is now  
           |                    | available    
     +-----v----+     +---------v---------+    
     | acquired |     |acquired_after_wait|    
     +-----|----+     +---------|---------+    
           |                    |              
           |   thread realeases |              
           |      the lock      |              
           +-------->/\<--------+              
                     \/                        
                     ||                        
                     vv                        
              +--------------+                 
              |   released   |                 
              +--------------+
```

**Test plan:**
- Unit tested
- Executed tests in staging (ex: Sample:12595 , PipelineRun: 19011)
