### PR TITLE
Address bug in coverage viz rounding error code.

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,10 @@ TODO: Move this code over to the idseq-dag repo.
 
 ## Release notes
 
+<<<<<<< HEAD
+- 3.6.2
+   - Address array index rounding error in coverage viz.
+
 - 3.6.1
    - Extra logs to help detecting potential deadlocks in the pipeline (#144).
 


### PR DESCRIPTION
Code that was supposed to prevent rounding errors was causing a bug.

The code would round 9.999 to 10 before taking a floor or ceiling.
The issue was that sometimes, a read would be so close to the end of
an accession that the bin it got assigned to would get rounded up,
causing an out-of-index error.

We change the code so that now, we just specify a min and max for the
floor and ceil function, to prevent out of index errors directly and
more safely.

Verification:
* Verified that sample which was failing before now passes for this pipeline step.
* Verified that tests still pass.
* Verified that benchmark sample runs on staging.