### PR TITLE
Add logs to m8.generate_taxon_count_json_from_m8 and remove redundant locks.

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,13 +227,12 @@ TODO: Move this code over to the idseq-dag repo.
 ## Release notes
 
 <<<<<<< HEAD
-- 3.6.2
+- 3.6.3
+   - Extra logs to help detecting potential deadlocks in the pipeline
+
+- 3.6.0 .. 3.6.2
    - Address array index rounding error in coverage viz.
-
-- 3.6.1
    - Extra logs to help detecting potential deadlocks in the pipeline (#144).
-
-- 3.6.0
    - Add pipeline step to generate data for coverage visualization for IDseq report page. Data includes an index
      file that maps taxons to accessions with available coverage data, as well as data files for each accession
      that list various metrics including the coverage of the accession.

--- a/idseq_dag/__init__.py
+++ b/idseq_dag/__init__.py
@@ -1,2 +1,2 @@
 ''' idseq_dag '''
-__version__ = "3.6.1"
+__version__ = "3.6.3"

--- a/idseq_dag/steps/blast_contigs.py
+++ b/idseq_dag/steps/blast_contigs.py
@@ -9,6 +9,7 @@ import idseq_dag.util.command as command
 import idseq_dag.util.count as count
 import idseq_dag.util.s3 as s3
 import idseq_dag.util.m8 as m8
+import idseq_dag.util.log as log
 
 from idseq_dag.steps.run_assembly import PipelineStepRunAssembly
 
@@ -76,13 +77,13 @@ class PipelineStepBlastContigs(PipelineStep):
         with log.log_context("PipelineStepBlastContigs", {"substep": "generate_taxon_summary"}):
             contig_taxon_summary = self.generate_taxon_summary(read2contig, contig2lineage, updated_read_dict, added_reads, db_type)
 
-        with log.log_context("PipelineStepBlastContigs", {"substep": "generate_taxon_summary_json", "contig_summary_json": contig_summary_json})
+        with log.log_context("PipelineStepBlastContigs", {"substep": "generate_taxon_summary_json", "contig_summary_json": contig_summary_json}):
             with open(contig_summary_json, 'w') as contig_outf:
                 json.dump(contig_taxon_summary, contig_outf)
 
         # Upload additional file
-        with log.log_context("PipelineStepBlastContigs", {"substep": "contig2lineage_json", "contig2lineage_json": contig2lineage_json})
-            contig2lineage_json = os.path.join(os.path.dirname(contig_summary_json), f"contig2lineage.{db_type}.json")
+        contig2lineage_json = os.path.join(os.path.dirname(contig_summary_json), f"contig2lineage.{db_type}.json")
+        with log.log_context("PipelineStepBlastContigs", {"substep": "contig2lineage_json", "contig2lineage_json": contig2lineage_json}):
             with open(contig2lineage_json, 'w') as c2lf:
                 json.dump(contig2lineage, c2lf)
 

--- a/idseq_dag/steps/blast_contigs.py
+++ b/idseq_dag/steps/blast_contigs.py
@@ -195,7 +195,7 @@ class PipelineStepBlastContigs(PipelineStep):
             blast_type = 'prot'
             blast_command = 'blastx'
         command.execute(f"makeblastdb -in {reference_fasta} -dbtype {blast_type} -out {blast_index_path}")
-        command.execute(f"nice -n 1 {blast_command} -query {assembled_contig} -db {blast_index_path} -out {blast_m8} -outfmt 6 -num_alignments 5 -num_threads 16")
+        command.execute(f"{blast_command} -query {assembled_contig} -db {blast_index_path} -out {blast_m8} -outfmt 6 -num_alignments 5 -num_threads 16")
         # further processing of getting the top m8 entry for each contig.
         PipelineStepBlastContigs.get_top_m8(blast_m8, blast_top_m8)
 

--- a/idseq_dag/util/command.py
+++ b/idseq_dag/util/command.py
@@ -162,9 +162,11 @@ def run_in_subprocess(target):
 
     @wraps(target)
     def wrapper(*args, **kwargs):
-        p = multiprocessing.Process(target=target, args=args, kwargs=kwargs)
-        p.start()
-        p.join()
+        with log.log_context("run_in_subprocess", {"substep": "start", "target": target.__qualname__}):
+            p = multiprocessing.Process(target=target, args=args, kwargs=kwargs)
+            p.start()
+        with log.log_context("run_in_subprocess", {"substep": "join", "target": target.__qualname__}):
+            p.join()
         if p.exitcode != 0:
             raise RuntimeError("Failed {} on {}, {}".format(
                 target.__name__, args, kwargs))

--- a/idseq_dag/util/log.py
+++ b/idseq_dag/util/log.py
@@ -132,8 +132,9 @@ def log_context(context_name, values=None, log_caller_info=True):
     '''
     extra_fields = {"context_name": context_name}
     if log_caller_info:
-        f_code = sys._getframe(2).f_code
-        extra_fields["caller"] = {"filename": os.path.basename(f_code.co_filename), "method": f_code.co_name}
+        frame = sys._getframe(2)
+        f_code = frame.f_code
+        extra_fields["caller"] = {"filename": os.path.basename(f_code.co_filename), "method": f_code.co_name, "f_lineno": frame.f_lineno}
     start = log_event("ctx_start", values, extra_fields=extra_fields)
     try:
         yield

--- a/idseq_dag/util/log.py
+++ b/idseq_dag/util/log.py
@@ -9,8 +9,7 @@ import functools
 
 from contextlib import contextmanager
 
-print_lock = multiprocessing.RLock()
-
+__print_lock = multiprocessing.RLock()
 
 def configure_logger(log_file=None):
     logger = logging.getLogger()
@@ -31,8 +30,8 @@ def configure_logger(log_file=None):
 
 
 def write(message, warning=False, flush=True):
-    logger = logging.getLogger()
-    with print_lock:
+    with __print_lock:
+        logger = logging.getLogger()
         if warning:
             logger.warning(message)
         else:


### PR DESCRIPTION
I have identified the hanging postprocess issue is associated to execution of `m8.generate_taxon_count_json_from_m8` method.  

This PR is adding extra logs to `m8.generate_taxon_count_json_from_m8` method to pinpoint which part of it is failing (it has multiple steps). This method is executed in a subprocess, and it is not easy to reproduce deadlocks. However, I know for sure the issue is here because I logged into production and inspected the local folder checking one by one all files generated after `blastx`, and detected the result files from this method are missing. I also manually killed the subprocess on which that method was running and I got a clear error message about `generate_taxon_count_json_from_m8` failure (Production Sample 15139, Pipeline Run 27212). The process was locked in that method.

Although the motivation for this PR is adding extra logs to this method to narrow down the issue, there is a chance the lock issue is associated to some redundant `print_lock` blocks from that I'm removing from `command.py`. They are not really necessary and potentially harmful.

**Test plan:**
- Executed local using a bogus pipeline step
- Uploaded a large sample in staging and processed it with success (Staging sample 12626, Pipeline Run: 19029)