### PR TITLE
Open sqlite3 dbs in readonly mode whenever possible

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,12 +227,12 @@ TODO: Move this code over to the idseq-dag repo.
 ## Release notes
 
 <<<<<<< HEAD
-- 3.6.3
-   - Extra logs to help detecting potential deadlocks in the pipeline
+- 3.6.4
+   - A possible fix to some hanging issues in the pipeline which seem to be related to sqlite3 concurrency.
 
-- 3.6.0 .. 3.6.2
+- 3.6.0 .. 3.6.3
    - Address array index rounding error in coverage viz.
-   - Extra logs to help detecting potential deadlocks in the pipeline (#144).
+   - Extra logs to help detecting potential deadlocks in the pipeline
    - Add pipeline step to generate data for coverage visualization for IDseq report page. Data includes an index
      file that maps taxons to accessions with available coverage data, as well as data files for each accession
      that list various metrics including the coverage of the accession.

--- a/idseq_dag/__init__.py
+++ b/idseq_dag/__init__.py
@@ -1,2 +1,2 @@
 ''' idseq_dag '''
-__version__ = "3.6.3"
+__version__ = "3.6.4"

--- a/idseq_dag/steps/generate_alignment_viz.py
+++ b/idseq_dag/steps/generate_alignment_viz.py
@@ -14,7 +14,7 @@ from idseq_dag.util.trace_lock import TraceLock
 import idseq_dag.util.command as command
 import idseq_dag.util.s3 as s3
 
-from idseq_dag.util.dict import IdSeqDict, IdSeqDictValue, open_file_db_by_extension
+from idseq_dag.util.dict import IdSeqDictValue, open_file_db_by_extension
 
 MIN_ACCESSIONS_WHOLE_DB_DOWNLOAD = 5000
 

--- a/idseq_dag/steps/generate_loc_db.py
+++ b/idseq_dag/steps/generate_loc_db.py
@@ -23,8 +23,8 @@ class PipelineStepGenerateLocDB(PipelineStep):
 
     @run_in_subprocess
     def generate_loc_db(self, db_file, loc_db_file, info_db_file):
-        loc_db = IdSeqDict(loc_db_file, IdSeqDictValue.VALUE_TYPE_ARRAY)
-        info_db = IdSeqDict(info_db_file, IdSeqDictValue.VALUE_TYPE_ARRAY)
+        loc_db = IdSeqDict(loc_db_file, IdSeqDictValue.VALUE_TYPE_ARRAY, read_only=False)
+        info_db = IdSeqDict(info_db_file, IdSeqDictValue.VALUE_TYPE_ARRAY, read_only=False)
         loc_batch_list = []
         info_batch_list = []
         with open(db_file) as dbf:

--- a/idseq_dag/steps/generate_phylo_tree.py
+++ b/idseq_dag/steps/generate_phylo_tree.py
@@ -15,7 +15,7 @@ import idseq_dag.util.log as log
 import idseq_dag.util.count as count
 import idseq_dag.util.convert as convert
 
-from idseq_dag.util.dict import IdSeqDict, IdSeqDictValue, open_file_db_by_extension
+from idseq_dag.util.dict import IdSeqDictValue, open_file_db_by_extension
 
 class PipelineStepGeneratePhyloTree(PipelineStep):
     '''

--- a/idseq_dag/steps/generate_taxid_fasta.py
+++ b/idseq_dag/steps/generate_taxid_fasta.py
@@ -2,7 +2,7 @@ from idseq_dag.engine.pipeline_step import PipelineStep
 import idseq_dag.util.lineage as lineage
 import idseq_dag.util.s3 as s3
 
-from idseq_dag.util.dict import IdSeqDict, IdSeqDictValue, open_file_db_by_extension
+from idseq_dag.util.dict import IdSeqDictValue, open_file_db_by_extension
 
 
 class PipelineStepGenerateTaxidFasta(PipelineStep):

--- a/idseq_dag/util/dict.py
+++ b/idseq_dag/util/dict.py
@@ -1,6 +1,10 @@
 import sqlite3
 import shelve
+import pathlib
+
 from enum import IntEnum
+
+import idseq_dag.util.log as log
 
 DICT_DELIMITER = chr(1) # Delimiter for an array of values
 class IdSeqDictValue(IntEnum):
@@ -14,29 +18,62 @@ class IdSeqDict(object):
         key has to be a string
         value could be either array of strings or a string
     '''
-    def __init__(self, db_path, value_type):
+    def __init__(self, db_path, value_type, read_only=True):
         self.db_path = db_path
         self.value_type = value_type
-        self.db_conn = sqlite3.connect(db_path, check_same_thread=False) # make it thread safe
-        cursor = self.db_conn.cursor()
-        cursor.execute(f"CREATE TABLE IF NOT EXISTS {SQLITE_TABLE_NAME} (dict_key VARCHAR(255) PRIMARY KEY, dict_value text)")
-        self.db_conn.commit()
+        self.read_only = read_only
+        self.uri_db_path = pathlib.Path(self.db_path).as_uri()
+        if self.read_only:
+            self.uri_db_path += "?mode=ro"
+
+        with log.log_context(f"open db", {"db_path": self.db_path, "read_only": self.read_only}):
+            self.db_conn = sqlite3.connect(self.uri_db_path, check_same_thread=False, uri=True) # make it thread safe
+        self._open = True
+        with log.log_context(f"assert_db_table", {"db_path": self.db_path, "read_only": self.read_only}):
+            with self.db_conn.cursor() as cursor:
+                if not self.read_only:
+                    res = cursor.execute(f"SELECT count(*) FROM sqlite_master WHERE type='table' AND name='{SQLITE_TABLE_NAME}';")
+                    v = res.fetchone()
+                    if v[0] == 0:
+                        raise Exception(f"table {SQLITE_TABLE_NAME} doesn't exist in db {self.db_path}")
+                else:
+                    cursor.execute(f"CREATE TABLE IF NOT EXISTS {SQLITE_TABLE_NAME} (dict_key VARCHAR(255) PRIMARY KEY, dict_value text)")
+                    self.db_conn.commit()
+
+    def __enter__(self):
+        ''' context manager enter '''
+        return self
+
+    def __exit__(self):
+        ''' context manager exit '''
+        self.close()
 
     def __del__(self):
         ''' destructor '''
-        self.db_conn.commit()
-        self.db_conn.close()
+        self.close()
+
+    def close(self):
+        ''' close db if it is open. If the db is not read-only, it also performs a commit before closing it. '''
+        if self._open:
+            if not self.read_only:
+                with log.log_context("db_commit", {"db_path": self.db_path, "read_only": self.read_only}):
+                    self.db_conn.commit()
+            with log.log_context("db_close", {"db_path": self.db_path, "read_only": self.read_only}):
+                self.db_conn.close()
+            self._open = False
 
     def update(self, key, value):
         ''' Update a particular key value pair '''
-        cursor = self.db_conn.cursor()
-        val = value
-        if self.value_type == IdSeqDictValue.VALUE_TYPE_ARRAY:
-            val = DICT_DELIMITER.join([str(v) for v in value])
-        cursor.execute(f"INSERT OR REPLACE INTO {SQLITE_TABLE_NAME} VALUES ('{key}', '{val}')")
+        with self.db_conn.cursor() as cursor:
+            val = value
+            if self.value_type == IdSeqDictValue.VALUE_TYPE_ARRAY:
+                val = DICT_DELIMITER.join([str(v) for v in value])
+            cursor.execute(f"INSERT OR REPLACE INTO {SQLITE_TABLE_NAME} VALUES ('{key}', '{val}')")
 
     def batch_inserts(self, tuples):
         ''' Insert multiple records at a time '''
+        if self.read_only:
+            raise Exception(f"db {self.db_path} is open in read-only mode")
         if len(tuples) == 0:
             return
         def tuple_to_sql_str(user_tuple):
@@ -59,19 +96,19 @@ class IdSeqDict(object):
 
     def get(self, key, default_value=None):
         ''' Emulate get as a python dictionary  '''
-        cursor = self.db_conn.cursor()
-        res = cursor.execute(f"SELECT dict_value FROM idseq_dict where dict_key = '{key}'")
-        v = res.fetchone()
-        if v is None:
-            return default_value
-        value = v[0]
-        if self.value_type == IdSeqDictValue.VALUE_TYPE_ARRAY:
-            return value.split(DICT_DELIMITER)
-        return value
+        with self.db_conn.cursor() as cursor:
+            res = cursor.execute(f"SELECT dict_value FROM idseq_dict where dict_key = '{key}'")
+            v = res.fetchone()
+            if v is None:
+                return default_value
+            value = v[0]
+            if self.value_type == IdSeqDictValue.VALUE_TYPE_ARRAY:
+                return value.split(DICT_DELIMITER)
+            return value
 
-def open_file_db_by_extension(db_path, value_type=IdSeqDictValue.VALUE_TYPE_SCALAR):
+def open_file_db_by_extension(db_path, value_type=IdSeqDictValue.VALUE_TYPE_SCALAR, read_only=True):
     ''' if extension is .sqlite3 open it as an IdSeqDict, otherwise, open as shelve in read mode '''
     if db_path[-8:] == '.sqlite3': # sqlite3 format
-        return IdSeqDict(db_path, value_type)
+        return IdSeqDict(db_path, value_type, read_only)
     # shelve format
     return shelve.open(db_path.replace('.db', ''), 'r')

--- a/idseq_dag/util/dict.py
+++ b/idseq_dag/util/dict.py
@@ -24,8 +24,8 @@ class IdSeqDict(object):
         self.read_only = read_only
         self.uri_db_path = pathlib.Path(self.db_path).as_uri()
         if self.read_only:
-            self.uri_db_path += "?mode=ro"
-        with log.log_context(f"open db", {"db_path": self.db_path, "read_only": self.read_only}):
+            self.uri_db_path += "?mode=ro&immutable=1&nolock=1&cache=private"
+        with log.log_context(f"open db", {"db_path": self.db_path, "read_only": self.read_only, "uri_db_path": self.uri_db_path}):
             self.db_conn = sqlite3.connect(self.uri_db_path, check_same_thread=False, uri=True) # make it thread safe
         self._open = True
         with log.log_context(f"assert_db_table", {"db_path": self.db_path, "read_only": self.read_only}):

--- a/idseq_dag/util/m8.py
+++ b/idseq_dag/util/m8.py
@@ -13,7 +13,7 @@ import idseq_dag.util.command as command
 import idseq_dag.util.log as log
 import idseq_dag.util.lineage as lineage
 
-from idseq_dag.util.dict import IdSeqDict, IdSeqDictValue, open_file_db_by_extension
+from idseq_dag.util.dict import IdSeqDictValue, open_file_db_by_extension
 
 def log_corrupt(m8_file, line):
     msg = m8_file + " is corrupt at line:\n" + line + "\n----> delete it and its corrupt ancestors before restarting run"
@@ -438,6 +438,8 @@ def generate_taxon_count_json_from_m8(
 
                     hit_line = hit_f.readline()
                     m8_line = m8_f.readline()
+
+            lineage_map.close()
 
     # Produce the final output
     taxon_counts_attributes = []


### PR DESCRIPTION
This is an attempt to fix the lock issue in the post-process stage. The issues seems to be related to the fact sqlite3 doesn't like multiple subprocesses handling a db in read-write mode.

Since we only require db to be open in read-write mode during a few generate_... steps, I'm replacing that logic to make it open in read only mode by default.

I also added some extra logic to have better control of closing the database. The previous logic was entirely based on a destructor, which is only executed during garbage collection (and somewhat unpredictable). You I added two other ways: you can use a context (`with IdSeqDict(...) as db:`) or you can manually invoke the `.close` method. Ideally, we should always try using the context version, but for now I've just added the close method in a few places. The rest is still using the destructor.

*Test plan:*
- Tested in staging, sample: 12628, pipeline run: 19051
- Tested `IdSeqDict` locally using a dummy pipeline stage