### PR TITLE
Fix an issue with the log event when trying to log non json serializable fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,10 +227,12 @@ TODO: Move this code over to the idseq-dag repo.
 ## Release notes
 
 <<<<<<< HEAD
-- 3.6.4
-   - A possible fix to some hanging issues in the pipeline which seem to be related to sqlite3 concurrency.
 
-- 3.6.0 .. 3.6.3
+- 3.6.5
+   - Fix an issue with the log event function when trying to log non json serializable fields.
+
+- 3.6.0 .. 3.6.4
+   - A possible fix to some hanging issues in the pipeline that seem to be related to sqlite3 concurrency.
    - Address array index rounding error in coverage viz.
    - Extra logs to help detecting potential deadlocks in the pipeline
    - Add pipeline step to generate data for coverage visualization for IDseq report page. Data includes an index

--- a/idseq_dag/__init__.py
+++ b/idseq_dag/__init__.py
@@ -1,2 +1,2 @@
 ''' idseq_dag '''
-__version__ = "3.6.4"
+__version__ = "3.6.5"

--- a/idseq_dag/util/log.py
+++ b/idseq_dag/util/log.py
@@ -58,15 +58,16 @@ def log_event(event_name, values=None, start_time=None, warning=False, flush=Tru
     log_event("downloaded_completed", {"file":"abc"}, start_time=start)
     '''
     log_line = {"event": event_name, **extra_fields}
+    default = lambda o: f"<<non-serializable: {type(o).__qualname__}>>"
     if values is not None:
         log_line["values"] = values
     if start_time is None:
-        fmt_message = json.dumps(log_line)
+        fmt_message = json.dumps(log_line, default=default)
     else:
         duration = (datetime.datetime.now()-start_time).total_seconds()
         log_line["duration_ms"] = math.floor(duration * 1000)
-        fmt_message = "%s (%.1f seconds)" % (json.dumps(log_line), duration)
-    write(fmt_message, warning, flush)
+        fmt_message = "%s (%.1f seconds)" % (json.dumps(log_line, default=default), duration)
+    write(fmt_message, warning=warning, flush=flush)
     return datetime.datetime.now()
 
 def log_execution(values=None):

--- a/tests/unit/util/test_log.py
+++ b/tests/unit/util/test_log.py
@@ -22,6 +22,7 @@ class TestLog(unittest.TestCase):
     def test_log_event_2(mock_log_write):
         '''Test log event with a non serializable field'''
         invalid_field = bytes()
+
         log.log_event('fake_event_name', values={"name_a": invalid_field, "name_b": "fake_string", "name_c": 3.1415})
 
         mock_log_write.assert_has_calls([

--- a/tests/unit/util/test_log.py
+++ b/tests/unit/util/test_log.py
@@ -1,0 +1,29 @@
+import unittest
+from unittest.mock import patch, call
+
+# Module under test
+import idseq_dag.util.log as log
+
+class TestLog(unittest.TestCase):
+    '''Tests for `util/log.py`'''
+
+    @staticmethod
+    @patch('idseq_dag.util.log.write')
+    def test_log_event(mock_log_write):
+        '''Test a successful log event'''
+        log.log_event('fake_event_name', values={"name_a": 1, "name_b": "fake_string", "name_c": 3.1415}, warning=True, flush=False, extra_fields={"extra_field_1": "abc"})
+
+        mock_log_write.assert_has_calls([
+            call('{"event": "fake_event_name", "extra_field_1": "abc", "values": {"name_a": 1, "name_b": "fake_string", "name_c": 3.1415}}', warning=True, flush=False)
+        ])
+
+    @staticmethod
+    @patch('idseq_dag.util.log.write')
+    def test_log_event_2(mock_log_write):
+        '''Test log event with a non serializable field'''
+        invalid_field = bytes()
+        log.log_event('fake_event_name', values={"name_a": invalid_field, "name_b": "fake_string", "name_c": 3.1415})
+
+        mock_log_write.assert_has_calls([
+            call('{"event": "fake_event_name", "values": {"name_a": "<<non-serializable: bytes>>", "name_b": "fake_string", "name_c": 3.1415}}', warning=False, flush=True)
+        ])


### PR DESCRIPTION
We are using `json.dumps` to serialize the log entry to json format, which has a default behavior of failing with an exception whenever it founds a field that is not serializable to JSON by default (ex: bytes).

This PR is adding a default handler for such cases, that will write the value `<<non-serializable: TYPE_NAME>>` for such fields.

**Test plan:**
- Unit tested