### PR TITLE
modify Trimmomatic command; allow small insert-size (rev. complement) reads through QC

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,10 @@ TODO: Move this code over to the idseq-dag repo.
 ## Release notes
 
 <<<<<<< HEAD
+- 3.7.0
+   - Modify trimmomatic command to reduce MINLEN parameter to 35 and allow reads from fragments with small 
+     insert sizes (where R1 and R2 are reverse complements of each other) through the QC steps. 
+
 - 3.6.3
    - Extra logs to help detecting potential deadlocks in the pipeline
 

--- a/idseq_dag/__init__.py
+++ b/idseq_dag/__init__.py
@@ -1,2 +1,2 @@
 ''' idseq_dag '''
-__version__ = "3.6.3"
+__version__ = "3.7.0"

--- a/idseq_dag/steps/run_trimmomatic.py
+++ b/idseq_dag/steps/run_trimmomatic.py
@@ -44,11 +44,13 @@ class PipelineStepRunTrimmomatic(PipelineStep):
             "-phred33",
             *input_files,
             *output_args,
-            f"ILLUMINACLIP:{adapter_fasta}:2:30:10",
+            f"ILLUMINACLIP:{adapter_fasta}:2:30:10:8:true",
             # Remove Illumina adapters provided in the fasta file. Initially, look for seed matches
             # allowing maximally *2* mismatches. These seeds will be extended and clipped if in the case of paired end
             # reads a score of *30* is reached, or in the case of single ended reads a
             # score of *10*.
+            # additional parameters: minAdapterLength = 8, keepBothReads = true; these are set to require pairs to be 
+            #    kept even when an adapter read-through occurs and R2 is a direct reverse complement of R1.
             "MINLEN:35"
             # Discard reads which are less than *75* bases long after these steps.
         ])

--- a/idseq_dag/steps/run_trimmomatic.py
+++ b/idseq_dag/steps/run_trimmomatic.py
@@ -49,7 +49,7 @@ class PipelineStepRunTrimmomatic(PipelineStep):
             # allowing maximally *2* mismatches. These seeds will be extended and clipped if in the case of paired end
             # reads a score of *30* is reached, or in the case of single ended reads a
             # score of *10*.
-            "MINLEN:75"
+            "MINLEN:35"
             # Discard reads which are less than *75* bases long after these steps.
         ])
         command.execute(cmd)


### PR DESCRIPTION
# Description

Several users have recently had issues with samples where % Pass QC is low ( < 25% ). Many reads were being removed during the trimmomatic step of QC due to trimmomatic default behavior to remove R2 reads that are the reverse complement of the R1, thus making them "orphan reads". These orphaned reads were then being filtered out. We would rather keep both R1 and R2 in these cases as they still provide useful information (effectively comparable to a SE read). Additionally, the MINLEN parameter has been reduced to 35 given that we enable L filtering downstream.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix a feature that knowingly causes existing functionality to not work as expected)

# Test and Reproduce
Outline the steps to test or reproduce the PR here.

1. Trimmomatic was run manually using the pre-existing command (results below).

`java -jar ~/Documents/TOOLS/Trimmomatic-0.39/trimmomatic-0.39.jar PE -phred33 -trimlog logfile -summary statsummary unmapped1.fastq.gz unmapped2.fastq.gz unmapped_paired_out1.fq.gz unmapped_unpaired_out1.fq.gz unmapped_paired_out2.fq.gz unmapped_unpaired_out2.fq.gz ILLUMINACLIP:illumina_TruSeq3-PE-2_NexteraPE-PE.fasta:2:30:10 MINLEN:75`

`Input Read Pairs: 20510 Both Surviving: 3900 (19.02%) Forward Only Surviving: 10966 (53.47%) Reverse Only Surviving: 32 (0.16%) Dropped: 5612 (27.36%)`

2. The command was updated and re-run manually (results below) and the results were compared.

`java -jar ~/Documents/TOOLS/Trimmomatic-0.39/trimmomatic-0.39.jar PE -phred33 -trimlog logfile -summary statsummary unmapped1.fastq.gz unmapped2.fastq.gz unmapped_paired_out1.fq.gz unmapped_unpaired_out1.fq.gz unmapped_paired_out2.fq.gz unmapped_unpaired_out2.fq.gz ILLUMINACLIP:illumina_TruSeq3-PE-2_NexteraPE-PE.fasta:2:30:10:8:true MINLEN:75`

`Input Read Pairs: 20510 Both Surviving: 14862 (72.46%) Forward Only Surviving: 4 (0.02%) Reverse Only Surviving: 32 (0.16%) Dropped: 5612 (27.36%)`

3. I used this branch to re-run all the samples in project Rapid Response RR025, and the % Passed QC increased from ~5-10% to ~85-90%.

## Impacted Areas in Application

List general components of the application that this PR will affect:

- QC metrics


# Checklist:

- [ ] I have run through the testing script to make sure current functionality is unchanged
- [x] I have done relevant tests that prove my fix is effective or that my feature works
- [x] I have spent time testing out edge cases for my feature
- [ ] I have updated the test script or pull request template if necessary
- [ ] New and existing unit tests pass locally with my changes

