### PR TITLE
Another attempt to fix the sqlite3 multiprocessing lock issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,10 +228,11 @@ TODO: Move this code over to the idseq-dag repo.
 
 <<<<<<< HEAD
 
-- 3.6.5
-   - Fix an issue with the log event function when trying to log non json serializable fields.
+- 3.6.6
+   - Another fix related to sqlite3 concurrency
 
-- 3.6.0 .. 3.6.4
+- 3.6.0 .. 3.6.5
+   - Fix an issue with the log event function when trying to log non json serializable fields.
    - A possible fix to some hanging issues in the pipeline that seem to be related to sqlite3 concurrency.
    - Address array index rounding error in coverage viz.
    - Extra logs to help detecting potential deadlocks in the pipeline

--- a/idseq_dag/__init__.py
+++ b/idseq_dag/__init__.py
@@ -1,2 +1,2 @@
 ''' idseq_dag '''
-__version__ = "3.6.5"
+__version__ = "3.6.6"

--- a/idseq_dag/util/command.py
+++ b/idseq_dag/util/command.py
@@ -5,6 +5,7 @@ import sys
 import os
 import threading
 import time
+import sqlite3
 from functools import wraps
 import idseq_dag.util.log as log
 from idseq_dag.util.trace_lock import TraceLock
@@ -166,6 +167,7 @@ def run_in_subprocess(target):
         frame = sys._getframe(2)
         f_code = frame.f_code
         original_caller = {"filename": os.path.basename(f_code.co_filename), "method": f_code.co_name, "f_lineno": frame.f_lineno}
+        sqlite3.connect(':memory:').close() # sqlite3 multiprocess bug workaround: https://bugs.python.org/issue27126
         def subprocess_scope(*args, **kwargs):
             with log.log_context("subprocess_scope", {"target": target.__qualname__, "original_caller": original_caller}):
                 target(*args, **kwargs)

--- a/idseq_dag/util/command.py
+++ b/idseq_dag/util/command.py
@@ -167,7 +167,8 @@ def run_in_subprocess(target):
         frame = sys._getframe(2)
         f_code = frame.f_code
         original_caller = {"filename": os.path.basename(f_code.co_filename), "method": f_code.co_name, "f_lineno": frame.f_lineno}
-        sqlite3.connect(':memory:').close() # sqlite3 multiprocess bug workaround: https://bugs.python.org/issue27126
+        with log.log_context("db_hack", {"target": target.__qualname__, "original_caller": original_caller}):
+            sqlite3.connect(':memory:').close() # sqlite3 multiprocess bug workaround: https://bugs.python.org/issue27126
         def subprocess_scope(*args, **kwargs):
             with log.log_context("subprocess_scope", {"target": target.__qualname__, "original_caller": original_caller}):
                 target(*args, **kwargs)


### PR DESCRIPTION
After a discussion with @boris-dimitrov about the multiprocessing sqlite3 lock issue, he found a discussion that seems to be related to the problem I've been inspecting:

https://bugs.python.org/issue20353:
> I believe the root cause of this bug is the following issue: http://bugs.python.org/issue27126 ; a workaround is to run the following code before forking any subprocesses: `sqlite3.connect(':memory:').close()`" 

This PR adds the suggested workaround to the wrapper function  `run_in_subprocess`.