### PR TITLE
Fix division by zero error in generate_coverage_viz.

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,9 +226,12 @@ TODO: Move this code over to the idseq-dag repo.
 
 ## Release notes
 
+- 3.7.1
+   - Fix division by zero error in coverage viz step.
+
 - 3.7.0
-   - Modify trimmomatic command to reduce MINLEN parameter to 35 and allow reads from fragments with small 
-     insert sizes (where R1 and R2 are reverse complements of each other) through the QC steps. 
+   - Modify trimmomatic command to reduce MINLEN parameter to 35 and allow reads from fragments with small
+     insert sizes (where R1 and R2 are reverse complements of each other) through the QC steps.
 
 - 3.6.6
    - Another fix related to sqlite3 concurrency

--- a/idseq_dag/__init__.py
+++ b/idseq_dag/__init__.py
@@ -1,4 +1,4 @@
 ''' idseq_dag '''
 
-__version__ = "3.7.0"
+__version__ = "3.7.1"
 

--- a/tests/generate_coverage_viz.py
+++ b/tests/generate_coverage_viz.py
@@ -607,6 +607,42 @@ class GenerateCoverageViz(unittest.TestCase):
         self.assertEqual(bin_size, 2)
 
 
+    # This test was created in response to a division by zero bug.
+    # This bug is caused by a rounding error when calculating the bins in the accession that a contig overlaps.
+    # This test verifies that this bug is no longer occurring.
+    def test_calculate_accession_coverage_rounding_error(self):
+        accession_data = {
+            "total_length": 545,
+            "contigs": ["CONTIG_1"],
+            "reads": [],
+        }
+
+        contig_data = {
+            "CONTIG_1": {
+                "total_length": 400,
+                "accession": "ACCESSION_1",
+                "query_start": 320,
+                "query_end": 322,
+                "subject_start": 221,
+                "subject_end": 219,
+                "coverage": [1] * 400
+            }
+        }
+
+        read_data = {}
+
+        (coverage, bin_size) = PipelineStepGenerateCoverageViz.calculate_accession_coverage(
+            "ACCESSION_1", accession_data, contig_data, read_data, 500
+        )
+
+        self.assertEqual(coverage, [
+            [200, 1.0, 1.0, 1, 0],
+            [201, 1.0, 1.0, 1, 0],
+            [202, 0.75, 0.752, 1, 0]
+        ])
+        self.assertEqual(bin_size, 1.09)
+
+
     # Tests for calculate_accession_stats.
     def test_calculate_accession_stats_basic(self):
         accession_data = {


### PR DESCRIPTION
See comment for explanation of issue. It was basically another rounding error that happens rarely.

Wrote test that failed before the fix, and succeeds after the fix.

Verification:
* Tested in DAGTEST (using example json) that generate_coverage_viz for sample 18263 failed before the fix, and now succeeds.
* Tested in staging that using markzhang/fix-division-by-zero branch succeeds and gives identical coverage results to before.