### PR TITLE
Add input file validation for pipeline steps.

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ TODO: Move this code over to the idseq-dag repo.
 ## Release notes
 
 - 3.7.3
-  - Add input file validation for pipeline steps. Output input_file_errors.json file if validation fails.
+  - Add input file validation for pipeline steps. Output invalid_input.json file if validation fails.
 
 - 3.7.2
   - Remove db_hack. Standardize db_open/db_assert_table/db_close log entries.

--- a/README.md
+++ b/README.md
@@ -226,6 +226,9 @@ TODO: Move this code over to the idseq-dag repo.
 
 ## Release notes
 
+- 3.7.3
+  - Add input file validation for pipeline steps. Output input_file_errors.json file if validation fails.
+
 - 3.7.2
   - Remove db_hack. Standardize db_open/db_assert_table/db_close log entries.
 

--- a/idseq_dag/__init__.py
+++ b/idseq_dag/__init__.py
@@ -1,4 +1,4 @@
 ''' idseq_dag '''
 
-__version__ = "3.7.2"
+__version__ = "3.7.3"
 

--- a/idseq_dag/engine/pipeline_flow.py
+++ b/idseq_dag/engine/pipeline_flow.py
@@ -9,7 +9,7 @@ import idseq_dag.util.s3
 import idseq_dag.util.command as command
 import idseq_dag.util.log as log
 import idseq_dag.util.count as count
-from idseq_dag.engine.pipeline_step import PipelineStep
+from idseq_dag.engine.pipeline_step import PipelineStep, InvalidInputFileError
 
 DEFAULT_OUTPUT_DIR_LOCAL = '/mnt/idseq/results/%d' % os.getpid()
 DEFAULT_REF_DIR_LOCAL = '/mnt/idseq/ref'
@@ -191,6 +191,18 @@ class PipelineFlow(object):
                                                target_name=target,
                                                max_fragments=self.given_targets[target]["max_fragments"])
 
+    def write_invalid_input_json(self, error_json):
+        ''' Upload an invalid_input.json file for this step, which can be detected by other services like idseq-web. '''
+        log.write("Writing invalid_input.json")
+        input_errors_file_basename = "invalid_input.json"
+        local_input_errors_file = "%s/%s" % (self.output_dir_local, input_errors_file_basename)
+        s3_input_errors_file = "%s/%s" % (self.output_dir_s3, input_errors_file_basename)
+
+        with open(local_input_errors_file, 'w') as input_errors_file:
+            json.dump(error_json, input_errors_file)
+
+        idseq_dag.util.s3.upload_with_retries(local_input_errors_file, s3_input_errors_file)
+
     def start(self):
         # Come up with the plan
         (step_list, self.large_file_list, covered_targets) = self.plan()
@@ -221,6 +233,9 @@ class PipelineFlow(object):
         for step in step_instances:
             try:
                 step.wait_until_all_done()
+            except InvalidInputFileError as e:
+                self.write_invalid_input_json(e.json)
+                raise e
             except Exception as e:
                 # Some exception thrown by one of the steps
                 traceback.print_exc()

--- a/idseq_dag/engine/pipeline_step.py
+++ b/idseq_dag/engine/pipeline_step.py
@@ -123,25 +123,10 @@ class PipelineStep(object):
             self.input_files_local.append(flist)
 
     def validate_input_files(self):
-        '''
-            Validate input files before running the step
-            Should assign any error encountered to self.input_file_error
+        ''' Validate input files before running the step.
+        Should assign any error encountered to self.input_file_error
         '''
         pass
-
-    @staticmethod
-    def validate_input_files_min_reads(input_files, min_reads):
-        '''
-            Checks whether input files (fa, fasta, fq, fastq) have the minimum number of reads.
-            Useful helper method that pipeline steps can use for validation.
-        '''
-
-        for index, input_file in enumerate(input_files):
-            num_reads = count.reads(input_file, max_reads=min_reads)
-            if num_reads < min_reads:
-                return False
-
-        return True
 
     def save_progress(self):
         ''' save progress after step run '''

--- a/idseq_dag/engine/pipeline_step.py
+++ b/idseq_dag/engine/pipeline_step.py
@@ -6,8 +6,9 @@ import time
 import idseq_dag.util.command as command
 import idseq_dag.util.log as log
 from abc import abstractmethod
-from enum import IntEnum
+from enum import Enum, IntEnum
 
+import idseq_dag.util.count as count
 import idseq_dag.util.s3
 
 class StepStatus(IntEnum):
@@ -15,6 +16,11 @@ class StepStatus(IntEnum):
     STARTED = 1 # step.start() called
     FINISHED = 2 # step.run() finished
     UPLOADED = 3 # all results uploaded to s3
+
+class InputErrorType(Enum):
+    ''' This error type will be used by the front-end to display a user-friendly error message '''
+    NO_ERROR =  "NO_ERROR" # Placeholder value.
+    INSUFFICIENT_READS = "INSUFFICIENT_READS"
 
 class PipelineStep(object):
     ''' Each Pipeline Run Step i.e. run_star, run_bowtie2, etc '''
@@ -43,7 +49,6 @@ class PipelineStep(object):
         self.counts_dict = {}
         self.should_terminate = False
         self.should_count_reads = False
-
 
     @abstractmethod
     def run(self):
@@ -89,15 +94,13 @@ class PipelineStep(object):
         s3_path = os.path.join(self.output_dir_s3, relative_path)
         return s3_path
 
-
     @staticmethod
     def done_file(filename):
         ''' get the done file for a particular local file '''
         return "%s.done" % filename
 
-
     def wait_for_input_files(self):
-        ''' wait for all the input files to be avaiable and update input_files_local '''
+        ''' wait for all the input files to be available and update input_files_local '''
         for fl in self.input_files:
             flist = []
             for f in fl:
@@ -113,6 +116,54 @@ class PipelineStep(object):
                         time.sleep(5)
             self.input_files_local.append(flist)
 
+    def validate_input_files(self):
+        ''' Validate input files before running the step '''
+        errors = self.get_input_file_validation_errors()
+        if errors and "error_type" in errors and errors["error_type"] != InputErrorType.NO_ERROR:
+            log.write("Invalid input detected for step %s" % self.name)
+            self.write_input_errors_json({
+                "step": self.name,
+                "errors": errors["errors"] if "errors" in errors else [],
+                "error_type": errors["error_type"].name
+            })
+            raise RuntimeError("input files for step %s were not valid" % self.name)
+
+    def get_input_file_validation_errors(self):
+        ''' Return any input file validation errors'''
+        # Steps should overwrite this method if necessary.
+        return {
+            # Step-specific error messages.
+            "errors": [],
+            # The broad type of error that occurred.
+            "error_type": InputErrorType.NO_ERROR
+        }
+
+    def write_input_errors_json(self, error_json):
+        ''' Write an input_file_errors.json file to the output_dir_s3 for this step, which can be detected by other services like idseq-web. '''
+        log.write("Writing input_file_errors.json for step %s" % self.name)
+        input_errors_file_basename = "input_file_errors.json"
+        local_input_errors_file = "%s/%s" % (self.output_dir_local, input_errors_file_basename)
+        s3_input_errors_file = "%s/%s" % (self.output_dir_s3, input_errors_file_basename)
+
+        with open(local_input_errors_file, 'w') as input_errors_file:
+            json.dump(error_json, input_errors_file)
+
+        idseq_dag.util.s3.upload_with_retries(local_input_errors_file, s3_input_errors_file)
+
+    @staticmethod
+    def validate_input_files_min_reads(input_files, min_reads):
+        '''
+            Checks whether input files (fa, fasta, fq, fastq) have the minimum number of reads.
+            Useful helper method that pipeline steps can use for validation.
+        '''
+        errors = []
+
+        for index, input_file in enumerate(input_files):
+            num_reads = count.reads(input_file)
+            if num_reads < min_reads:
+                errors.append("Input file %s requires at least %s reads (%s found)" % (index + 1, min_reads, num_reads))
+
+        return errors
 
     def save_progress(self):
         ''' save progress after step run '''
@@ -150,6 +201,8 @@ class PipelineStep(object):
         with log.log_context("dag_step", v):
             with log.log_context("substep_wait_for_input_files", v):
                 self.wait_for_input_files()
+            with log.log_context("validate_input_files", v):
+                self.validate_input_files()
             with log.log_context("substep_run", v):
                 self.run()
             with log.log_context("substep_validate", v):
@@ -163,7 +216,7 @@ class PipelineStep(object):
         self.status = StepStatus.FINISHED
 
     def start(self):
-        ''' function to be called after instanitation to start running the step '''
+        ''' function to be called after instantiation to start running the step '''
         self.exec_thread = threading.Thread(target=self.thread_run)
         self.exec_thread.start()
 

--- a/idseq_dag/steps/run_alignment_remotely.py
+++ b/idseq_dag/steps/run_alignment_remotely.py
@@ -5,7 +5,7 @@ import random
 import traceback
 import multiprocessing
 
-from idseq_dag.engine.pipeline_step import PipelineStep, InputErrorType
+from idseq_dag.engine.pipeline_step import PipelineStep, InputFileErrors
 
 import idseq_dag.util.command as command
 import idseq_dag.util.server as server
@@ -22,17 +22,11 @@ class PipelineStepRunAlignmentRemotely(PipelineStep):
     Run gsnap/rapsearch2 remotely
     '''
 
-    def get_input_file_validation_errors(self):
-        # Return errors if either input file is empty.
-        errors = PipelineStep.validate_input_files_min_reads(self.get_input_fas(), 1)
+    def validate_input_files(self):
+        if not PipelineStep.validate_input_files_min_reads(self.input_files_local[0][0:2], 1):
+            self.input_file_error = InputFileErrors.INSUFFICIENT_READS
 
-        if errors:
-            return {
-                "errors": errors,
-                "error_type": InputErrorType.INSUFFICIENT_READS
-            }
-
-        return None
+        super().validate_input_files()
 
     def __init__(self, *args, **kwrds):
         PipelineStep.__init__(self, *args, **kwrds)

--- a/idseq_dag/steps/run_alignment_remotely.py
+++ b/idseq_dag/steps/run_alignment_remotely.py
@@ -8,6 +8,7 @@ import multiprocessing
 from idseq_dag.engine.pipeline_step import PipelineStep, InputFileErrors
 
 import idseq_dag.util.command as command
+import idseq_dag.util.count as count
 import idseq_dag.util.server as server
 import idseq_dag.util.log as log
 import idseq_dag.util.m8 as m8
@@ -23,10 +24,8 @@ class PipelineStepRunAlignmentRemotely(PipelineStep):
     '''
 
     def validate_input_files(self):
-        if not PipelineStep.validate_input_files_min_reads(self.input_files_local[0][0:2], 1):
+        if not count.files_have_min_reads(self.input_files_local[0][0:2], 1):
             self.input_file_error = InputFileErrors.INSUFFICIENT_READS
-
-        super().validate_input_files()
 
     def __init__(self, *args, **kwrds):
         PipelineStep.__init__(self, *args, **kwrds)

--- a/idseq_dag/steps/run_alignment_remotely.py
+++ b/idseq_dag/steps/run_alignment_remotely.py
@@ -5,7 +5,7 @@ import random
 import traceback
 import multiprocessing
 
-from idseq_dag.engine.pipeline_step import PipelineStep
+from idseq_dag.engine.pipeline_step import PipelineStep, InputErrorType
 
 import idseq_dag.util.command as command
 import idseq_dag.util.server as server
@@ -21,6 +21,18 @@ class PipelineStepRunAlignmentRemotely(PipelineStep):
     '''
     Run gsnap/rapsearch2 remotely
     '''
+
+    def get_input_file_validation_errors(self):
+        # Return errors if either input file is empty.
+        errors = PipelineStep.validate_input_files_min_reads(self.get_input_fas(), 1)
+
+        if errors:
+            return {
+                "errors": errors,
+                "error_type": InputErrorType.INSUFFICIENT_READS
+            }
+
+        return None
 
     def __init__(self, *args, **kwrds):
         PipelineStep.__init__(self, *args, **kwrds)

--- a/idseq_dag/steps/run_bowtie2.py
+++ b/idseq_dag/steps/run_bowtie2.py
@@ -2,6 +2,7 @@ import os
 import multiprocessing
 from idseq_dag.engine.pipeline_step import PipelineStep, InputFileErrors
 import idseq_dag.util.command as command
+import idseq_dag.util.count as count
 import idseq_dag.util.convert as convert
 import idseq_dag.util.log as log
 import idseq_dag.util.count as count
@@ -10,10 +11,8 @@ from idseq_dag.util.s3 import fetch_from_s3
 
 class PipelineStepRunBowtie2(PipelineStep):
     def validate_input_files(self):
-        if not PipelineStep.validate_input_files_min_reads(self.input_files_local[0][0:2], 1):
+        if not count.files_have_min_reads(self.input_files_local[0][0:2], 1):
             self.input_file_error = InputFileErrors.INSUFFICIENT_READS
-
-        super().validate_input_files()
 
     def run(self):
         input_fas = self.input_files_local[0][0:2]

--- a/idseq_dag/steps/run_bowtie2.py
+++ b/idseq_dag/steps/run_bowtie2.py
@@ -1,6 +1,6 @@
 import os
 import multiprocessing
-from idseq_dag.engine.pipeline_step import PipelineStep
+from idseq_dag.engine.pipeline_step import PipelineStep, InputFileErrors
 import idseq_dag.util.command as command
 import idseq_dag.util.convert as convert
 import idseq_dag.util.log as log
@@ -9,17 +9,11 @@ from idseq_dag.util.s3 import fetch_from_s3
 
 
 class PipelineStepRunBowtie2(PipelineStep):
-    def get_input_file_validation_errors(self):
-        # Return errors if either input file is empty.
-        errors = PipelineStep.validate_input_files_min_reads(self.input_files_local[0][0:2], 1)
+    def validate_input_files(self):
+        if not PipelineStep.validate_input_files_min_reads(self.input_files_local[0][0:2], 1):
+            self.input_file_error = InputFileErrors.INSUFFICIENT_READS
 
-        if errors:
-            return {
-                "errors": errors,
-                "error_type": InputErrorType.INSUFFICIENT_READS
-            }
-
-        return None
+        super().validate_input_files()
 
     def run(self):
         input_fas = self.input_files_local[0][0:2]

--- a/idseq_dag/steps/run_bowtie2.py
+++ b/idseq_dag/steps/run_bowtie2.py
@@ -9,6 +9,18 @@ from idseq_dag.util.s3 import fetch_from_s3
 
 
 class PipelineStepRunBowtie2(PipelineStep):
+    def get_input_file_validation_errors(self):
+        # Return errors if either input file is empty.
+        errors = PipelineStep.validate_input_files_min_reads(self.input_files_local[0][0:2], 1)
+
+        if errors:
+            return {
+                "errors": errors,
+                "error_type": InputErrorType.INSUFFICIENT_READS
+            }
+
+        return None
+
     def run(self):
         input_fas = self.input_files_local[0][0:2]
         output_fas = self.output_files_local()

--- a/idseq_dag/steps/run_cdhitdup.py
+++ b/idseq_dag/steps/run_cdhitdup.py
@@ -1,4 +1,4 @@
-from idseq_dag.engine.pipeline_step import PipelineStep, InputErrorType
+from idseq_dag.engine.pipeline_step import PipelineStep, InputFileErrors
 import idseq_dag.util.command as command
 import idseq_dag.util.count as count
 
@@ -8,17 +8,11 @@ class PipelineStepRunCDHitDup(PipelineStep):
     Two FASTA inputs means paired reads.
     See: http://weizhongli-lab.org/cd-hit/
     '''
-    def get_input_file_validation_errors(self):
-        # Return errors if either input file has less than 2 reads.
-        errors = PipelineStep.validate_input_files_min_reads(self.input_files_local[0], 2)
+    def validate_input_files(self):
+        if not PipelineStep.validate_input_files_min_reads(self.input_files_local[0], 2):
+            self.input_file_error = InputFileErrors.INSUFFICIENT_READS
 
-        if errors:
-            return {
-                "errors": errors,
-                "error_type": InputErrorType.INSUFFICIENT_READS
-            }
-
-        return None
+        super().validate_input_files()
 
     def run(self):
         ''' Invoking cd-hit-dup '''

--- a/idseq_dag/steps/run_cdhitdup.py
+++ b/idseq_dag/steps/run_cdhitdup.py
@@ -1,4 +1,4 @@
-from idseq_dag.engine.pipeline_step import PipelineStep
+from idseq_dag.engine.pipeline_step import PipelineStep, InputErrorType
 import idseq_dag.util.command as command
 import idseq_dag.util.count as count
 
@@ -8,6 +8,18 @@ class PipelineStepRunCDHitDup(PipelineStep):
     Two FASTA inputs means paired reads.
     See: http://weizhongli-lab.org/cd-hit/
     '''
+    def get_input_file_validation_errors(self):
+        # Return errors if either input file has less than 2 reads.
+        errors = PipelineStep.validate_input_files_min_reads(self.input_files_local[0], 2)
+
+        if errors:
+            return {
+                "errors": errors,
+                "error_type": InputErrorType.INSUFFICIENT_READS
+            }
+
+        return None
+
     def run(self):
         ''' Invoking cd-hit-dup '''
         input_fas = self.input_files_local[0]

--- a/idseq_dag/steps/run_cdhitdup.py
+++ b/idseq_dag/steps/run_cdhitdup.py
@@ -9,10 +9,8 @@ class PipelineStepRunCDHitDup(PipelineStep):
     See: http://weizhongli-lab.org/cd-hit/
     '''
     def validate_input_files(self):
-        if not PipelineStep.validate_input_files_min_reads(self.input_files_local[0], 2):
+        if not count.files_have_min_reads(self.input_files_local[0], 2):
             self.input_file_error = InputFileErrors.INSUFFICIENT_READS
-
-        super().validate_input_files()
 
     def run(self):
         ''' Invoking cd-hit-dup '''

--- a/idseq_dag/steps/run_gsnap_filter.py
+++ b/idseq_dag/steps/run_gsnap_filter.py
@@ -1,5 +1,5 @@
 import os
-from idseq_dag.engine.pipeline_step import PipelineStep, InputErrorType
+from idseq_dag.engine.pipeline_step import PipelineStep, InputFileErrors
 import idseq_dag.util.command as command
 import idseq_dag.util.convert as convert
 import idseq_dag.util.log as log
@@ -17,17 +17,11 @@ class PipelineStepRunGsnapFilter(PipelineStep):
     http://research-pub.gene.com/gmap/
     """
 
-    def get_input_file_validation_errors(self):
-        # Return errors if either input file is empty.
-        errors = PipelineStep.validate_input_files_min_reads(self.input_files_local[0][0:2], 1)
+    def validate_input_files(self):
+        if not PipelineStep.validate_input_files_min_reads(self.input_files_local[0][0:2], 1):
+            self.input_file_error = InputFileErrors.INSUFFICIENT_READS
 
-        if errors:
-            return {
-                "errors": errors,
-                "error_type": InputErrorType.INSUFFICIENT_READS
-            }
-
-        return None
+        super().validate_input_files()
 
     def run(self):
         input_fas = self.input_files_local[0][0:2]

--- a/idseq_dag/steps/run_gsnap_filter.py
+++ b/idseq_dag/steps/run_gsnap_filter.py
@@ -1,5 +1,5 @@
 import os
-from idseq_dag.engine.pipeline_step import PipelineStep
+from idseq_dag.engine.pipeline_step import PipelineStep, InputErrorType
 import idseq_dag.util.command as command
 import idseq_dag.util.convert as convert
 import idseq_dag.util.log as log
@@ -16,6 +16,19 @@ class PipelineStepRunGsnapFilter(PipelineStep):
 
     http://research-pub.gene.com/gmap/
     """
+
+    def get_input_file_validation_errors(self):
+        # Return errors if either input file is empty.
+        errors = PipelineStep.validate_input_files_min_reads(self.input_files_local[0][0:2], 1)
+
+        if errors:
+            return {
+                "errors": errors,
+                "error_type": InputErrorType.INSUFFICIENT_READS
+            }
+
+        return None
+
     def run(self):
         input_fas = self.input_files_local[0][0:2]
         output_fas = self.output_files_local()

--- a/idseq_dag/steps/run_gsnap_filter.py
+++ b/idseq_dag/steps/run_gsnap_filter.py
@@ -18,10 +18,8 @@ class PipelineStepRunGsnapFilter(PipelineStep):
     """
 
     def validate_input_files(self):
-        if not PipelineStep.validate_input_files_min_reads(self.input_files_local[0][0:2], 1):
+        if not count.files_have_min_reads(self.input_files_local[0][0:2], 1):
             self.input_file_error = InputFileErrors.INSUFFICIENT_READS
-
-        super().validate_input_files()
 
     def run(self):
         input_fas = self.input_files_local[0][0:2]

--- a/idseq_dag/steps/run_lzw.py
+++ b/idseq_dag/steps/run_lzw.py
@@ -1,7 +1,7 @@
 from multiprocessing import cpu_count
 from typing import Iterator
 import os
-from idseq_dag.engine.pipeline_step import PipelineStep
+from idseq_dag.engine.pipeline_step import PipelineStep, InputFileErrors
 import idseq_dag.util.command as command
 from idseq_dag.util.command import run_in_subprocess
 import idseq_dag.util.log as log
@@ -25,17 +25,11 @@ class PipelineStepRunLZW(PipelineStep):
 
     NUM_SLICES = min(MAX_SUBPROCS, REAL_CORES)
 
-    def get_input_file_validation_errors(self):
-        # Return errors if either input file is empty.
-        errors = PipelineStep.validate_input_files_min_reads(self.input_files_local[0], 1)
+    def validate_input_files(self):
+        if not PipelineStep.validate_input_files_min_reads(self.input_files_local[0], 1):
+            self.input_file_error = InputFileErrors.INSUFFICIENT_READS
 
-        if errors:
-            return {
-                "errors": errors,
-                "error_type": InputErrorType.INSUFFICIENT_READS
-            }
-
-        return None
+        super().validate_input_files()
 
     def run(self):
         input_fas = self.input_files_local[0]

--- a/idseq_dag/steps/run_lzw.py
+++ b/idseq_dag/steps/run_lzw.py
@@ -25,6 +25,18 @@ class PipelineStepRunLZW(PipelineStep):
 
     NUM_SLICES = min(MAX_SUBPROCS, REAL_CORES)
 
+    def get_input_file_validation_errors(self):
+        # Return errors if either input file is empty.
+        errors = PipelineStep.validate_input_files_min_reads(self.input_files_local[0], 1)
+
+        if errors:
+            return {
+                "errors": errors,
+                "error_type": InputErrorType.INSUFFICIENT_READS
+            }
+
+        return None
+
     def run(self):
         input_fas = self.input_files_local[0]
         output_fas = self.output_files_local()
@@ -69,7 +81,7 @@ class PipelineStepRunLZW(PipelineStep):
 
         if seq_length > threshold_readlength:
             # Make sure longer reads don't get excessively penalized
-            adjustment_heuristic = (1 + (seq_length - threshold_readlength) / 1000) # TODO: revisit 
+            adjustment_heuristic = (1 + (seq_length - threshold_readlength) / 1000) # TODO: revisit
             score = lzw_fraction * adjustment_heuristic
         else:
             score = lzw_fraction

--- a/idseq_dag/steps/run_lzw.py
+++ b/idseq_dag/steps/run_lzw.py
@@ -26,10 +26,8 @@ class PipelineStepRunLZW(PipelineStep):
     NUM_SLICES = min(MAX_SUBPROCS, REAL_CORES)
 
     def validate_input_files(self):
-        if not PipelineStep.validate_input_files_min_reads(self.input_files_local[0], 1):
+        if not count.files_have_min_reads(self.input_files_local[0], 1):
             self.input_file_error = InputFileErrors.INSUFFICIENT_READS
-
-        super().validate_input_files()
 
     def run(self):
         input_fas = self.input_files_local[0]

--- a/idseq_dag/steps/run_priceseq.py
+++ b/idseq_dag/steps/run_priceseq.py
@@ -1,7 +1,7 @@
 ''' Run PriceSeq Filter '''
 import os
 
-from idseq_dag.engine.pipeline_step import PipelineStep, InputErrorType
+from idseq_dag.engine.pipeline_step import PipelineStep, InputFileErrors
 import idseq_dag.util.command as command
 import idseq_dag.util.log as log
 import idseq_dag.util.count as count
@@ -9,18 +9,11 @@ import idseq_dag.util.fasta as fasta
 
 class PipelineStepRunPriceSeq(PipelineStep):
     ''' PriceSeq PipelineStep implementation '''
+    def validate_input_files(self):
+        if not PipelineStep.validate_input_files_min_reads(self.input_files_local[0][0:2], 1):
+            self.input_file_error = InputFileErrors.INSUFFICIENT_READS
 
-    def get_input_file_validation_errors(self):
-        # Return errors if either input file is empty.
-        errors = PipelineStep.validate_input_files_min_reads(self.input_files_local[0][0:2], 1)
-
-        if errors:
-            return {
-                "errors": errors,
-                "error_type": InputErrorType.INSUFFICIENT_READS
-            }
-
-        return None
+        super().validate_input_files()
 
     def run(self):
         """PriceSeqFilter is used to filter input data based on quality. Two FASTQ

--- a/idseq_dag/steps/run_priceseq.py
+++ b/idseq_dag/steps/run_priceseq.py
@@ -10,10 +10,8 @@ import idseq_dag.util.fasta as fasta
 class PipelineStepRunPriceSeq(PipelineStep):
     ''' PriceSeq PipelineStep implementation '''
     def validate_input_files(self):
-        if not PipelineStep.validate_input_files_min_reads(self.input_files_local[0][0:2], 1):
+        if not count.files_have_min_reads(self.input_files_local[0][0:2], 1):
             self.input_file_error = InputFileErrors.INSUFFICIENT_READS
-
-        super().validate_input_files()
 
     def run(self):
         """PriceSeqFilter is used to filter input data based on quality. Two FASTQ

--- a/idseq_dag/steps/run_priceseq.py
+++ b/idseq_dag/steps/run_priceseq.py
@@ -1,7 +1,7 @@
 ''' Run PriceSeq Filter '''
 import os
 
-from idseq_dag.engine.pipeline_step import PipelineStep
+from idseq_dag.engine.pipeline_step import PipelineStep, InputErrorType
 import idseq_dag.util.command as command
 import idseq_dag.util.log as log
 import idseq_dag.util.count as count
@@ -9,6 +9,19 @@ import idseq_dag.util.fasta as fasta
 
 class PipelineStepRunPriceSeq(PipelineStep):
     ''' PriceSeq PipelineStep implementation '''
+
+    def get_input_file_validation_errors(self):
+        # Return errors if either input file is empty.
+        errors = PipelineStep.validate_input_files_min_reads(self.input_files_local[0][0:2], 1)
+
+        if errors:
+            return {
+                "errors": errors,
+                "error_type": InputErrorType.INSUFFICIENT_READS
+            }
+
+        return None
+
     def run(self):
         """PriceSeqFilter is used to filter input data based on quality. Two FASTQ
         inputs means paired reads.

--- a/idseq_dag/steps/run_subsample.py
+++ b/idseq_dag/steps/run_subsample.py
@@ -1,6 +1,6 @@
 import random
 
-from idseq_dag.engine.pipeline_step import PipelineStep
+from idseq_dag.engine.pipeline_step import PipelineStep, InputFileErrors
 import idseq_dag.util.command as command
 import idseq_dag.util.log as log
 import idseq_dag.util.count as count
@@ -10,17 +10,11 @@ class PipelineStepRunSubsample(PipelineStep):
     Subsample the input data to max_fragments
     '''
 
-    def get_input_file_validation_errors(self):
-        # Return errors if either input file is empty.
-        errors = PipelineStep.validate_input_files_min_reads(self.input_files_local[0][0:2], 1)
+    def validate_input_files(self):
+        if not PipelineStep.validate_input_files_min_reads(self.input_files_local[0][0:2], 1):
+            self.input_file_error = InputFileErrors.INSUFFICIENT_READS
 
-        if errors:
-            return {
-                "errors": errors,
-                "error_type": InputErrorType.INSUFFICIENT_READS
-            }
-
-        return None
+        super().validate_input_files()
 
     def run(self):
         ''' Invoking subsampling '''

--- a/idseq_dag/steps/run_subsample.py
+++ b/idseq_dag/steps/run_subsample.py
@@ -11,10 +11,8 @@ class PipelineStepRunSubsample(PipelineStep):
     '''
 
     def validate_input_files(self):
-        if not PipelineStep.validate_input_files_min_reads(self.input_files_local[0][0:2], 1):
+        if not count.files_have_min_reads(self.input_files_local[0][0:2], 1):
             self.input_file_error = InputFileErrors.INSUFFICIENT_READS
-
-        super().validate_input_files()
 
     def run(self):
         ''' Invoking subsampling '''

--- a/idseq_dag/steps/run_subsample.py
+++ b/idseq_dag/steps/run_subsample.py
@@ -9,6 +9,19 @@ class PipelineStepRunSubsample(PipelineStep):
     '''
     Subsample the input data to max_fragments
     '''
+
+    def get_input_file_validation_errors(self):
+        # Return errors if either input file is empty.
+        errors = PipelineStep.validate_input_files_min_reads(self.input_files_local[0][0:2], 1)
+
+        if errors:
+            return {
+                "errors": errors,
+                "error_type": InputErrorType.INSUFFICIENT_READS
+            }
+
+        return None
+
     def run(self):
         ''' Invoking subsampling '''
         input_fas = self.input_files_local[0]

--- a/idseq_dag/steps/run_trimmomatic.py
+++ b/idseq_dag/steps/run_trimmomatic.py
@@ -9,10 +9,8 @@ import idseq_dag.util.fasta as fasta
 class PipelineStepRunTrimmomatic(PipelineStep):
     ''' Trimmomatic PipelineStep implementation '''
     def validate_input_files(self):
-        if not PipelineStep.validate_input_files_min_reads(self.input_files_local[0][0:2], 1):
+        if not count.files_have_min_reads(self.input_files_local[0][0:2], 1):
             self.input_file_error = InputFileErrors.INSUFFICIENT_READS
-
-        super().validate_input_files()
 
     def run(self):
         """

--- a/idseq_dag/steps/run_trimmomatic.py
+++ b/idseq_dag/steps/run_trimmomatic.py
@@ -8,6 +8,19 @@ import idseq_dag.util.fasta as fasta
 
 class PipelineStepRunTrimmomatic(PipelineStep):
     ''' Trimmomatic PipelineStep implementation '''
+
+    def get_input_file_validation_errors(self):
+        # Return errors if either input file is empty.
+        errors = PipelineStep.validate_input_files_min_reads(self.input_files_local[0][0:2], 1)
+
+        if errors:
+            return {
+                "errors": errors,
+                "error_type": InputErrorType.INSUFFICIENT_READS
+            }
+
+        return None
+
     def run(self):
         """
         Trim any residual Illumina adapters.
@@ -49,7 +62,7 @@ class PipelineStepRunTrimmomatic(PipelineStep):
             # allowing maximally *2* mismatches. These seeds will be extended and clipped if in the case of paired end
             # reads a score of *30* is reached, or in the case of single ended reads a
             # score of *10*.
-            # additional parameters: minAdapterLength = 8, keepBothReads = true; these are set to require pairs to be 
+            # additional parameters: minAdapterLength = 8, keepBothReads = true; these are set to require pairs to be
             #    kept even when an adapter read-through occurs and R2 is a direct reverse complement of R1.
             "MINLEN:35"
             # Discard reads which are less than *75* bases long after these steps.

--- a/idseq_dag/steps/run_trimmomatic.py
+++ b/idseq_dag/steps/run_trimmomatic.py
@@ -1,5 +1,5 @@
 ''' Run Trimmomatic '''
-from idseq_dag.engine.pipeline_step import PipelineStep
+from idseq_dag.engine.pipeline_step import PipelineStep, InputFileErrors
 import idseq_dag.util.command as command
 import idseq_dag.util.count as count
 import idseq_dag.util.s3 as s3
@@ -8,18 +8,11 @@ import idseq_dag.util.fasta as fasta
 
 class PipelineStepRunTrimmomatic(PipelineStep):
     ''' Trimmomatic PipelineStep implementation '''
+    def validate_input_files(self):
+        if not PipelineStep.validate_input_files_min_reads(self.input_files_local[0][0:2], 1):
+            self.input_file_error = InputFileErrors.INSUFFICIENT_READS
 
-    def get_input_file_validation_errors(self):
-        # Return errors if either input file is empty.
-        errors = PipelineStep.validate_input_files_min_reads(self.input_files_local[0][0:2], 1)
-
-        if errors:
-            return {
-                "errors": errors,
-                "error_type": InputErrorType.INSUFFICIENT_READS
-            }
-
-        return None
+        super().validate_input_files()
 
     def run(self):
         """

--- a/idseq_dag/util/count.py
+++ b/idseq_dag/util/count.py
@@ -67,3 +67,14 @@ def reads2lines(read_count, file_format):
         # Assumes the format is single-line fasta rather than multiline fasta
         line_count = 2 * read_count
     return line_count
+
+def files_have_min_reads(input_files, min_reads):
+    """ Checks whether fa/fasta/fq/fastq have the minimum number of reads.
+    Pipeline steps can use this method for input validation.
+    """
+    for input_file in input_files:
+        num_reads = reads(input_file, max_reads=min_reads)
+        if num_reads < min_reads:
+            return False
+    return True
+


### PR DESCRIPTION
If input file validation fails, a special input_errors.json file
will be written to the output directory. This file can be
used by other services to determine the cause of failure.

Note:
I did **input** file validation instead of output file validation because one step (cd-hit-dup) fails when a file with one read is passed to it. Since the requirements for input files varies by pipeline step, it made more sense to do input file validation, since a pipeline step can't know which step will consume its output files next.

Verification:
* Ran the samples that failed last week with no reads left on staging, and verified in the Cloudwatch logs that those samples still fail but take the new code path and output an input_errors.json.
* Ran the benchmark sample on staging and verified that it succeeds with identical results to before.

Example input_errors.json:

```
{
  "step": "priceseq_out", 
  "errors": [
    "Input file 1 requires at least 1 reads (0 found)", 
    "Input file 2 requires at least 1 reads (0 found)"
  ], 
  "error_type": "INSUFFICIENT_READS"
}
```

Additional notes:
* The plan is to have `idseq-web` detect this file and set an alternate `job_status` value. And also use the `error_type` to display an error message.
* I added input validation to all the host filtering steps (except the first two), and the first alignment step (PipelineStepRunAlignmentRemotely) since that one was also failing. 
* I didn't add input validation to the first two host filtering steps (validate_input and star). validate_input should fail on empty files, and star should receive non-empty files since they just went through validate_input. Also, adding input validation to star is non-trivial because star has three different ways it can be run, with different input files for each (RunStarUpstream, RunStarDownstream)
* Would be great to refactor validate_input step to use the same `input_errors.json` mechanism for consistency, but that is non-trivial as well.