### PR TITLE
Fix for hanging issue

### DIFF
--- a/idseq_dag/steps/blast_contigs.py
+++ b/idseq_dag/steps/blast_contigs.py
@@ -69,9 +69,9 @@ class PipelineStepBlastContigs(PipelineStep):
             deuterostome_db = s3.fetch_from_s3(self.additional_files["deuterostome_db"],
                                                self.ref_dir_local, allow_s3mi=True)
         with log.log_context("PipelineStepBlastContigs", {"substep": "generate_taxon_count_json_from_m8", "db_type": db_type, "refined_counts": refined_counts}):
-            m8.generate_taxon_count_json_from_m8(refined_m8, refined_hit_summary,
-                                                evalue_type, db_type.upper(),
-                                                lineage_db, deuterostome_db, refined_counts)
+            command.run_in_subprocess(m8.generate_taxon_count_json_from_m8)(refined_m8, refined_hit_summary,
+                                                                            evalue_type, db_type.upper(),
+                                                                            lineage_db, deuterostome_db, refined_counts)
 
         # generate contig stats at genus/species level
         with log.log_context("PipelineStepBlastContigs", {"substep": "generate_taxon_summary"}):

--- a/idseq_dag/steps/generate_accession2taxid.py
+++ b/idseq_dag/steps/generate_accession2taxid.py
@@ -4,7 +4,6 @@ import shelve
 import dbm
 import threading
 from idseq_dag.engine.pipeline_step import PipelineStep
-from idseq_dag.util.command import run_in_subprocess
 import idseq_dag.util.command as command
 import idseq_dag.util.log as log
 import idseq_dag.util.count as count
@@ -61,7 +60,7 @@ class PipelineStepGenerateAccession2Taxid(PipelineStep):
             for p in range(NUM_PARTITIONS):
                 part_file = f"{accession_mapping_file}-{p}"
                 partition_list.append(part_file)
-                thread = threading.Thread(target=self.grab_accession_mapping_list,
+                thread = threading.Thread(target=command.run_in_subprocess(self.grab_accession_mapping_list),
                                           args=[accession_mapping_file, NUM_PARTITIONS, p,
                                                 accessions, part_file])
                 accessions_files.append(accession_file)
@@ -152,7 +151,6 @@ class PipelineStepGenerateAccession2Taxid(PipelineStep):
     def grab_wgs_accessions(self, source_file, dest_file):
         command.execute(f"grep '^>' {source_file} | grep 'complete genome' | cut -f 1 -d' ' > {dest_file}")
 
-    @run_in_subprocess
     def grab_accession_mapping_list(self, source_gz, num_partitions, partition_id,
                                     accessions, output_file):
         num_lines = 0

--- a/idseq_dag/steps/generate_loc_db.py
+++ b/idseq_dag/steps/generate_loc_db.py
@@ -3,7 +3,6 @@ import dbm
 import shelve
 import re
 from idseq_dag.engine.pipeline_step import PipelineStep
-from idseq_dag.util.command import run_in_subprocess
 import idseq_dag.util.command as command
 import idseq_dag.util.log as log
 import idseq_dag.util.count as count
@@ -19,10 +18,10 @@ class PipelineStepGenerateLocDB(PipelineStep):
         db_file = self.input_files_local[0][0]
         loc_db_file = self.output_files_local()[0]
         info_db_file = self.output_files_local()[1]
-        self.generate_loc_db(db_file, loc_db_file, info_db_file)
+        command.run_in_subprocess(PipelineStepGenerateLocDB.generate_loc_db)(db_file, loc_db_file, info_db_file)
 
-    @run_in_subprocess
-    def generate_loc_db(self, db_file, loc_db_file, info_db_file):
+    @staticmethod
+    def generate_loc_db(db_file, loc_db_file, info_db_file):
         loc_db = IdSeqDict(loc_db_file, IdSeqDictValue.VALUE_TYPE_ARRAY, read_only=False)
         info_db = IdSeqDict(info_db_file, IdSeqDictValue.VALUE_TYPE_ARRAY, read_only=False)
         loc_batch_list = []
@@ -72,35 +71,6 @@ class PipelineStepGenerateLocDB(PipelineStep):
                 info_batch_list.append((accession_id, [accession_name, seq_bp_len]))
             loc_db.batch_inserts(loc_batch_list)
             info_db.batch_inserts(info_batch_list)
-
-    @run_in_subprocess
-    def generate_loc_db_old(self, db_file, loc_db_file):
-        # TODO: To be deprecated. Using shelve
-        loc_dict = shelve.Shelf(dbm.ndbm.open(loc_db_file.replace(".db", ""), 'c'))
-        with open(db_file) as dbf:
-            seq_offset = 0
-            seq_len = 0
-            header_len = 0
-            lines = 0
-            accession_id = ""
-            for line in dbf:
-                lines += 1
-                if lines % 100000 == 0:
-                    log.write(f"{lines/1000000.0}M lines")
-                if line[0] == '>':  # header line
-                    if seq_len > 0 and len(accession_id) > 0:
-                        loc_dict[accession_id] = (seq_offset, header_len, seq_len)
-                    seq_offset = seq_offset + header_len + seq_len
-                    header_len = len(line)
-                    seq_len = 0
-                    s = re.match('^>([^ ]*).*', line)
-                    if s:
-                        accession_id = s.group(1)
-                else:
-                    seq_len += len(line)
-            if seq_len > 0 and len(accession_id) > 0:
-                loc_dict[accession_id] = (seq_offset, header_len, seq_len)
-        loc_dict.close()
 
     def count_reads(self):
         ''' Count reads '''

--- a/idseq_dag/steps/nonhost_fastq.py
+++ b/idseq_dag/steps/nonhost_fastq.py
@@ -1,6 +1,5 @@
 import os
 from idseq_dag.engine.pipeline_step import PipelineStep
-from idseq_dag.util.command import run_in_subprocess
 import idseq_dag.util.command as command
 import idseq_dag.util.log as log
 import idseq_dag.util.count as count

--- a/idseq_dag/steps/run_alignment_remotely.py
+++ b/idseq_dag/steps/run_alignment_remotely.py
@@ -49,8 +49,8 @@ class PipelineStepRunAlignmentRemotely(PipelineStep):
         accession2taxid_db = fetch_from_s3(self.additional_files["accession2taxid_db"], self.ref_dir_local, allow_s3mi=True)
         blacklist_s3_file = self.additional_attributes.get('taxon_blacklist', DEFAULT_BLACKLIST_S3)
         taxon_blacklist = fetch_from_s3(blacklist_s3_file, self.ref_dir_local)
-        m8.call_hits_m8(output_m8, lineage_db, accession2taxid_db,
-                        deduped_output_m8, output_hitsummary, taxon_blacklist)
+        command.run_in_subprocess(m8.call_hits_m8)(output_m8, lineage_db, accession2taxid_db,
+                                                   deduped_output_m8, output_hitsummary, taxon_blacklist)
 
         # check deuterostome
         deuterostome_db = None
@@ -59,9 +59,8 @@ class PipelineStepRunAlignmentRemotely(PipelineStep):
         if self.additional_files.get("deuterostome_db"):
             deuterostome_db = fetch_from_s3(self.additional_files["deuterostome_db"],
                                             self.ref_dir_local, allow_s3mi=True)
-        m8.generate_taxon_count_json_from_m8(
-            deduped_output_m8, output_hitsummary, evalue_type, db_type,
-            lineage_db, deuterostome_db, output_counts_json)
+        command.run_in_subprocess(m8.generate_taxon_count_json_from_m8)(deduped_output_m8, output_hitsummary, evalue_type, db_type,
+                                                                        lineage_db, deuterostome_db, output_counts_json)
 
 
     def run_remotely(self, input_fas, output_m8, service):

--- a/idseq_dag/steps/run_lzw.py
+++ b/idseq_dag/steps/run_lzw.py
@@ -3,7 +3,6 @@ from typing import Iterator
 import os
 from idseq_dag.engine.pipeline_step import PipelineStep
 import idseq_dag.util.command as command
-from idseq_dag.util.command import run_in_subprocess
 import idseq_dag.util.log as log
 import idseq_dag.util.count as count
 import idseq_dag.util.fasta as fasta
@@ -84,7 +83,6 @@ class PipelineStepRunLZW(PipelineStep):
         for tfn in temp_file_names:
             assert not os.path.exists(tfn)
 
-        @run_in_subprocess
         def lzw_compute_slice(slice_start):
             """For each read, or read pair, in input_files, such that read_index % slice_step == slice_start,
             output the lzw score for the read, or the min lzw score for the pair."""
@@ -96,7 +94,7 @@ class PipelineStepRunLZW(PipelineStep):
                         slice_output.write(str(lzw_min_score) + "\n")
 
         # slices run in parallel
-        mt_map(lzw_compute_slice, range(slice_step))
+        mt_map(command.run_in_subprocess(lzw_compute_slice), range(slice_step))
 
         slice_outputs = temp_file_names[:-1]
         coalesced_score_file = temp_file_names[-1]

--- a/idseq_dag/util/log.py
+++ b/idseq_dag/util/log.py
@@ -17,14 +17,14 @@ def configure_logger(log_file=None):
 
     if log_file:
         handler = logging.FileHandler(log_file)
-        formatter = logging.Formatter("%(asctime)s: [%(threadName)12s] %(message)s")
+        formatter = logging.Formatter("%(asctime)s: [%(process)d][%(threadName)12s] %(message)s")
         handler.setFormatter(formatter)
         logger.addHandler(handler)
 
     # Echo to stdout so they get to CloudWatch
     handler = logging.StreamHandler(sys.stdout)
     handler.setLevel(logging.INFO)
-    formatter = logging.Formatter("%(asctime)s: [%(threadName)12s] %(message)s")
+    formatter = logging.Formatter("%(asctime)s: [%(process)d][%(threadName)12s] %(message)s")
     handler.setFormatter(formatter)
     logger.addHandler(handler)
 

--- a/idseq_dag/util/m8.py
+++ b/idseq_dag/util/m8.py
@@ -1,11 +1,7 @@
 import os
 import json
 import math
-import time
 import random
-import threading
-import traceback
-import multiprocessing
 from collections import defaultdict
 from collections import Counter
 
@@ -120,7 +116,6 @@ def read_file_into_set(file_name):
         S.discard('')
     return S
 
-@command.run_in_subprocess
 def call_hits_m8(input_m8, lineage_map_path, accession2taxid_dict_path,
                  output_m8, output_summary, taxon_blacklist=None):
     """
@@ -332,7 +327,7 @@ def call_hits_m8(input_m8, lineage_map_path, accession2taxid_dict_path,
                     msg += f"\t{species_taxid}\t{genus_taxid}\t{family_taxid}\n"
                     outf_sum.write(msg)
 
-@command.run_in_subprocess
+
 def generate_taxon_count_json_from_m8(
         m8_file, hit_level_file, e_value_type, count_type, lineage_map_path,
         deuterostome_path, output_json_file):


### PR DESCRIPTION
It seems Python 3.6 has an issue when using multiprocess from Threads (which is the approach we have when using `run_in_supbrocess`).

This code uses `get_context('spawn')`  (new feature in python 3.X) to create subprocesses in a totally separated space, not sharing globals.

Issue has been reproduced locally using this code (you might need to run it a couple times to trigger the issue):
```python3
import threading
import multiprocessing
import sys

def test_run_in_subprocess_1():
    CONCURRENCY = 2
    threads = { threading.Thread(target=run_in_subprocess, args=[t_id]) for t_id in range(CONCURRENCY) }
    for t in threads:
        t.start()
    for t in threads:
        t.join()
    print("=== END ===")

def do_something_in_subprocess(_t_id):
    # some cpu intensive operation
    for i in range(200000):
        pass

def run_in_subprocess(t_id):
    print(f"start {t_id}")
    p = multiprocessing.Process(target=do_something_in_subprocess, args=[id])
    p.start()
    while p.is_alive():
        p.join(5)
        if p.is_alive():
            print(f"stuck {t_id}")
            sys.stdout.flush()
    print(f"end {t_id}")
    if p.exitcode != 0:
        print(f"Failed {t_id} {p.exitcode}")

if __name__ == "__main__":
    test_run_in_subprocess_1()
```