### PR TITLE
Add progress logs to GenerateCoverageStats step

### DIFF
--- a/idseq_dag/steps/generate_coverage_stats.py
+++ b/idseq_dag/steps/generate_coverage_stats.py
@@ -6,7 +6,7 @@ import pysam
 from idseq_dag.engine.pipeline_step import PipelineStep
 import idseq_dag.util.command as command
 import idseq_dag.util.log as log
-import idseq_dag.util.count as count
+from idseq_dag.util.sequence import chunks
 MIN_CONTIG_FILE_SIZE = 50
 
 class PipelineStepGenerateCoverageStats(PipelineStep):
@@ -24,38 +24,13 @@ class PipelineStepGenerateCoverageStats(PipelineStep):
             command.execute("echo 'No Contigs' > " +  coverage_summary_csv)
             return
 
-        contig2coverage = {}
         # generate bam files
         bam_file = read_contig_sam.replace(".sam", ".bam")
         command.execute(f"samtools view -S -b  {read_contig_sam} | samtools sort - -o {bam_file}")
         command.execute(f"samtools index {bam_file}")
 
         # run coverage info
-        with pysam.AlignmentFile(bam_file, "rb") as f:
-            contig_names = f.references
-            for c in contig_names:
-                coverage = []
-                for pileup_column in f.pileup(contig=c):
-                    coverage.append(pileup_column.get_num_aligned())
-                sorted_coverage = sorted(coverage)
-                contig_len = len(coverage)
-                if contig_len <= 0:
-                    continue
-
-                avg = sum(coverage)/contig_len
-                contig2coverage[c] = {
-                    "coverage": coverage,
-                    "avg": avg,
-                    "p0": sorted_coverage[0],
-                    "p100": sorted_coverage[-1],
-                    "p25": sorted_coverage[int(0.25*contig_len)],
-                    "p50": sorted_coverage[int(0.5*contig_len)],
-                    "p75": sorted_coverage[int(0.75*contig_len)],
-                    "avg2xcnt": len(list(filter(lambda t: t > 2*avg, coverage)))/contig_len,
-                    "cnt0": len(list(filter(lambda t: t == 0, coverage)))/contig_len,
-                    "cnt1": len(list(filter(lambda t: t == 1, coverage)))/contig_len,
-                    "cnt2": len(list(filter(lambda t: t == 2, coverage)))/contig_len
-                }
+        contig2coverage = self.calc_contig2coverage(bam_file)
 
         with open(coverage_json, 'w') as csf:
             json.dump(contig2coverage, csf)
@@ -70,6 +45,45 @@ class PipelineStepGenerateCoverageStats(PipelineStep):
                 ]
                 output_str = ','.join(str(e) for e in output_row)
                 csc.write(output_str + "\n")
+
+
+    @staticmethod
+    def calc_contig2coverage(bam_file):
+        CHUNK_SIZE = 100
+        contig2coverage = {}
+        with pysam.AlignmentFile(bam_file, "rb") as f:
+            all_references = f.references
+            with log.log_context("calc_contig2coverage", {"bam_file": bam_file, "all_references_count": len(all_references)}):
+                chunked_references = chunks(f.references, CHUNK_SIZE)
+                for contig_names in chunked_references:
+                    if len(contig_names) == 0:
+                        break
+                    with log.log_context(f"calc_contig2coverage_chunk", {"bam_file": bam_file, "from": contig_names[0], "to": contig_names[-1]}):
+                        for c in contig_names:
+                            coverage = []
+                            for pileup_column in f.pileup(contig=c):
+                                coverage.append(pileup_column.get_num_aligned())
+                            sorted_coverage = sorted(coverage)
+                            contig_len = len(coverage)
+                            if contig_len <= 0:
+                                continue
+
+                            avg = sum(coverage)/contig_len
+                            contig2coverage[c] = {
+                                "coverage": coverage,
+                                "avg": avg,
+                                "p0": sorted_coverage[0],
+                                "p100": sorted_coverage[-1],
+                                "p25": sorted_coverage[int(0.25*contig_len)],
+                                "p50": sorted_coverage[int(0.5*contig_len)],
+                                "p75": sorted_coverage[int(0.75*contig_len)],
+                                "avg2xcnt": len(list(filter(lambda t: t > 2 * avg, coverage)))/contig_len,
+                                "cnt0": len(list(filter(lambda t: t == 0, coverage)))/contig_len,
+                                "cnt1": len(list(filter(lambda t: t == 1, coverage)))/contig_len,
+                                "cnt2": len(list(filter(lambda t: t == 2, coverage)))/contig_len
+                        }
+        return contig2coverage
+
 
     def count_reads(self):
         ''' Count reads '''

--- a/idseq_dag/util/sequence.py
+++ b/idseq_dag/util/sequence.py
@@ -1,0 +1,13 @@
+"""
+  Some convenience methods to manipulate sequence objects (ex: list, range, set, string)
+"""
+def chunks(l, n):
+    """
+    Yield successive n-sized chunks from list l.
+    Example:
+      l = [1,2,3,4,5,6,7,8,9,10]
+      c = list(chunks(l, 3))
+      # c will be equal "[ [1,2,3], [4,5,6], [7,8,9], [10]]
+    """
+    for i in range(0, len(l), n):
+        yield l[i:i + n]

--- a/tests/unit/util/test_sequence.py
+++ b/tests/unit/util/test_sequence.py
@@ -1,0 +1,70 @@
+import unittest
+from unittest.mock import patch, call
+
+# Class under test
+from idseq_dag.util.sequence import chunks
+
+class TestSequence(unittest.TestCase):
+    '''Tests for `util/sequence.py`'''
+
+    def test_chunks_list(self):
+        '''Chunking a list produces a sequence of arrays'''
+        l = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+        chunk_size = 3
+
+        r = list(chunks(l, chunk_size))
+
+        self.assertEqual(
+            r,
+            [
+                [1, 2, 3],
+                [4, 5, 6],
+                [7, 8, 9],
+                [10]
+            ]
+        )
+
+    def test_chunks_str(self):
+        '''Chunking a string produces a sequence of strings'''
+        l = "not really a big string"
+        chunk_size = 5
+
+        r = list(chunks(l, chunk_size))
+
+        self.assertEqual(
+            r,
+            [
+                'not r',
+                'eally',
+                ' a bi',
+                'g str',
+                'ing'
+            ]
+        )
+
+    def test_chunks_empty_list(self):
+        '''Chunking an empty list produces an empty array'''
+        l = []
+        chunk_size = 4
+
+        r = list(chunks(l, chunk_size))
+
+        self.assertEqual(
+            r,
+            []
+        )
+
+    def test_chunks_small_list(self):
+        '''Chunking a list smaller than chunk size produces a sequence containing a single array element'''
+        l = [1, 2, 3]
+        chunk_size = 4
+
+        r = list(chunks(l, chunk_size))
+
+        self.assertEqual(
+            r,
+            [
+                [1, 2, 3]
+            ]
+        )
+


### PR DESCRIPTION
Jira ticket [IDSEQ-991](https://jira.czi.team/browse/IDSEQ-991).

`GenerateCoverageStats` (related to `coverage_out` step of stage 2 - Post Processing) can take many hours to execute, and since it is not generating any progress logs, pipeline watchdog might recognize it as being stuck and terminate the job.

This happened to sample 18337 multiple times. Example: pipeline run 27954.

Fix: add intermediary log steps.