### PR TITLE
minimum updates to SQLite wrapper to ensure stability

### DIFF
--- a/idseq_dag/steps/generate_coverage_viz.py
+++ b/idseq_dag/steps/generate_coverage_viz.py
@@ -40,12 +40,11 @@ class PipelineStepGenerateCoverageViz(PipelineStep):
             self.additional_files["info_db"],
             self.ref_dir_local,
             allow_s3mi=True)
-        info_dict = open_file_db_by_extension(info_db, IdSeqDictValue.VALUE_TYPE_ARRAY)
-
-        # Extract data from input files.
-        (taxon_data, accession_data, contig_data, read_data) = self.prepare_data(
-            self.input_files_local, info_dict, min_contig_size, num_accessions_per_taxon
-        )
+        with open_file_db_by_extension(info_db, IdSeqDictValue.VALUE_TYPE_ARRAY) as info_dict:
+            # Extract data from input files.
+            (taxon_data, accession_data, contig_data, read_data) = self.prepare_data(
+                self.input_files_local, info_dict, min_contig_size, num_accessions_per_taxon
+            )
 
         # Generate the coverage viz data for each accession.
         coverage_viz_data = self.generate_coverage_viz_data(accession_data, contig_data, read_data, max_num_bins_coverage)
@@ -78,7 +77,7 @@ class PipelineStepGenerateCoverageViz(PipelineStep):
         Remove taxons with no contigs in any accession.
         Select the best accessions for each taxon.
         """
-        (reassigned_m8, hit_summary, blast_top_m8) = input_files_local[0]
+        (_reassigned_m8, hit_summary, blast_top_m8) = input_files_local[0]
         (contig_coverage_json, contig_stats_json, contigs_fasta) = input_files_local[1]
         (gsnap_deduped_m8, ) = input_files_local[2]
 
@@ -207,9 +206,9 @@ class PipelineStepGenerateCoverageViz(PipelineStep):
         Also generate a dict that maps taxons to accessions.
         """
         # Use a set for contigs, since multiple lines in the hitsummary can map to the same contig.
-        accession_data = defaultdict(lambda: {'reads': [], 'contigs': set() })
+        accession_data = defaultdict(lambda: {'reads': [], 'contigs': set()})
         # Use a set for accessions, since multiple lines in the hitsummary can map to the same accession.
-        taxon_data = defaultdict(lambda: { 'accessions': set(), 'num_total_accessions': 0 })
+        taxon_data = defaultdict(lambda: {'accessions': set(), 'num_total_accessions': 0})
 
         line_count = 0
         with open(hit_summary, 'r') as hs:
@@ -308,7 +307,7 @@ class PipelineStepGenerateCoverageViz(PipelineStep):
 
         # iterate_m8 automatically removes invalid hits.
         for (hit_id, accession_id, percent_id, alignment_length, num_mismatches, num_gaps,
-            query_start, query_end, subject_start, subject_end, _e_value, _bitscore, line) in m8.iterate_m8(m8_file, full_line=True):
+             query_start, query_end, subject_start, subject_end, _e_value, _bitscore, _line) in m8.iterate_m8(m8_file, full_line=True):
 
             if hit_id in valid_hits:
                 # Map the hit_id to a dict of hit data.
@@ -394,7 +393,7 @@ class PipelineStepGenerateCoverageViz(PipelineStep):
                 contig_data[contig_name]["byterange"] = [seq_offset, seq_len]
 
     @staticmethod
-    def select_best_accessions_per_taxon(taxon_data, accession_data, contig_data, read_data, num_accessions_per_taxon):
+    def select_best_accessions_per_taxon(taxon_data, accession_data, contig_data, _read_data, num_accessions_per_taxon):
         """
         Select the accessions that we will generate coverage viz data for.
         We select all accessions that have a contig.
@@ -843,7 +842,7 @@ def _align_interval(interval):
     return (min(bound_one, bound_two), max(bound_one, bound_two))
 
 def _transform_interval(
-    interval, first_domain_start, first_domain_end, second_domain_start, second_domain_end
+        interval, first_domain_start, first_domain_end, second_domain_start, second_domain_end
 ):
     """
     Transform an interval from one domain to another.

--- a/idseq_dag/steps/generate_lineage_db.py
+++ b/idseq_dag/steps/generate_lineage_db.py
@@ -2,8 +2,7 @@
 import gzip
 from idseq_dag.engine.pipeline_step import PipelineStep
 import idseq_dag.util.log as log
-import idseq_dag.util.count as count
-from idseq_dag.util.dict import IdSeqDict, IdSeqDictValue
+from idseq_dag.util.dict import IdSeqDictForUpdate, IdSeqDictValue
 
 BATCH_INSERT_SIZE = 300
 
@@ -20,18 +19,18 @@ class PipelineStepGenerateLineageDB(PipelineStep):
         output_db = self.output_files_local()[0]
         log.write(f"input: {lineage_csv_gz} output: {output_db}")
 
-        lineage_dict = IdSeqDict(output_db, IdSeqDictValue.VALUE_TYPE_ARRAY)
-        batch_list = {}
-        with gzip.open(lineage_csv_gz, "rt") as gzf:
-            for line in gzf:
-                fields = line.rstrip().split(",")
-                taxid = fields[0]
-                species, genus, family = fields[-1:-4:-1]
-                batch_list[taxid] = [species, genus, family]
-                if len(batch_list) >= BATCH_INSERT_SIZE:
-                    lineage_dict.batch_inserts(batch_list.items())
-                    batch_list = {}
-            lineage_dict.batch_inserts(batch_list.items())
+        with IdSeqDictForUpdate(output_db, IdSeqDictValue.VALUE_TYPE_ARRAY) as lineage_dict:
+            batch_list = {}
+            with gzip.open(lineage_csv_gz, "rt") as gzf:
+                for line in gzf:
+                    fields = line.rstrip().split(",")
+                    taxid = fields[0]
+                    species, genus, family = fields[-1:-4:-1]
+                    batch_list[taxid] = [species, genus, family]
+                    if len(batch_list) >= BATCH_INSERT_SIZE:
+                        lineage_dict.batch_inserts(batch_list.items())
+                        batch_list = {}
+                lineage_dict.batch_inserts(batch_list.items())
 
     def count_reads(self):
         ''' Count reads '''

--- a/idseq_dag/steps/generate_phylo_tree.py
+++ b/idseq_dag/steps/generate_phylo_tree.py
@@ -2,7 +2,6 @@
 import os
 import glob
 import json
-import traceback
 import xml.etree.ElementTree as ET
 
 from collections import defaultdict
@@ -12,7 +11,6 @@ from idseq_dag.steps.generate_alignment_viz import PipelineStepGenerateAlignment
 import idseq_dag.util.command as command
 import idseq_dag.util.s3 as s3
 import idseq_dag.util.log as log
-import idseq_dag.util.count as count
 import idseq_dag.util.convert as convert
 
 from idseq_dag.util.dict import IdSeqDictValue, open_file_db_by_extension
@@ -151,7 +149,7 @@ class PipelineStepGeneratePhyloTree(PipelineStep):
             if genomes:
                 genbank_fastas = {}
                 for line in genomes:
-                    assembly_accession, taxid, species_taxid, organism_name, ftp_path = line.split("\t")
+                    assembly_accession, taxid, _species_taxid, _organism_name, ftp_path = line.split("\t")
                     ftp_fasta_gz = f"{ftp_path}/{os.path.basename(ftp_path)}_genomic.fna.gz"
                     tree_node_name = f"genbank_{self.clean_name_for_ksnp3(assembly_accession)}"
                     local_fasta = f"{destination_dir}/{tree_node_name}.fasta"
@@ -164,7 +162,7 @@ class PipelineStepGeneratePhyloTree(PipelineStep):
         return {}
 
     @staticmethod
-    def parse_tree(current_dict, results, key = None):
+    def parse_tree(current_dict, results, key=None):
         """
         Produce a dictionary like:
           { "accession 1": { "coverage_summary": ... },
@@ -233,9 +231,9 @@ class PipelineStepGeneratePhyloTree(PipelineStep):
 
         # Make map of accession to sequence file
         accession2info = dict((acc, {}) for acc in accessions)
-        nt_loc_dict = open_file_db_by_extension(nt_loc_db, IdSeqDictValue.VALUE_TYPE_ARRAY)
-        PipelineStepGenerateAlignmentViz.get_sequences_by_accession_list_from_s3(
-            accession2info, nt_loc_dict, nt_db)
+        with open_file_db_by_extension(nt_loc_db, IdSeqDictValue.VALUE_TYPE_ARRAY) as nt_loc_dict:
+            PipelineStepGenerateAlignmentViz.get_sequences_by_accession_list_from_s3(
+                accession2info, nt_loc_dict, nt_db)
 
         # Put 1 fasta file per accession into the destination directory
         accession_fastas = {}

--- a/idseq_dag/util/dict.py
+++ b/idseq_dag/util/dict.py
@@ -1,6 +1,7 @@
 import sqlite3
 import shelve
 import pathlib
+import multiprocessing
 
 from enum import IntEnum
 
@@ -12,72 +13,176 @@ class IdSeqDictValue(IntEnum):
     VALUE_TYPE_ARRAY = 2
 SQLITE_TABLE_NAME = "idseq_dict"
 
-class IdSeqDict(object):
+
+class _IdSeqDictBase(object):
     '''
-        a key -> value permanent dictionary store with sqlite3 as the backend.
-        key has to be a string
-        value could be either array of strings or a string
+        Private superclass of IdSeqDict and IdSeqDictForUpdate.
+        See IdSeqDict for more information.
     '''
-    def __init__(self, db_path, value_type, read_only=True):
+
+    def __init__(self, db_path, value_type):
         self.db_path = db_path
         self.value_type = value_type
-        self.read_only = read_only
-        self.uri_db_path = pathlib.Path(self.db_path).as_uri()
-        if self.read_only:
-            self.uri_db_path += "?mode=ro&immutable=1&nolock=1&cache=private"
-        with log.log_context(f"db_open", {"db_path": self.db_path, "read_only": self.read_only, "uri_db_path": self.uri_db_path}):
-            self.db_conn = sqlite3.connect(self.uri_db_path, check_same_thread=False, uri=True) # make it thread safe
-        self._open = True
-        with log.log_context(f"db_assert_table", {"db_path": self.db_path, "read_only": self.read_only}):
-            cursor = self.db_conn.cursor()
-            if not self.read_only:
-                res = cursor.execute(f"SELECT count(*) FROM sqlite_master WHERE type='table' AND name='{SQLITE_TABLE_NAME}';")
-                v = res.fetchone()
-                if v[0] == 0:
-                    raise Exception(f"table {SQLITE_TABLE_NAME} doesn't exist in db {self.db_path}")
-            else:
-                cursor.execute(f"CREATE TABLE IF NOT EXISTS {SQLITE_TABLE_NAME} (dict_key VARCHAR(255) PRIMARY KEY, dict_value text)")
-                self.db_conn.commit()
-            cursor.close()
+        # Private from the point of view of users.  Accessible to derived classes.
+        self._db_conn = None
+        self._lock = multiprocessing.RLock()
+        self._lock.acquire()
+
+    def _assert_lock_held(self):
+        assert self._lock.acquire(block=False), "Sharing an IdSeqDict object among multiple threads or processes is not supported."
+
+    def _uri_base(self):
+        return pathlib.Path(self.db_path).as_uri()
+
+    def _connect(self):
+        self._assert_lock_held()
+        uri_db_path = self._uri_base()
+        with log.log_context(f"db_open", {"db_path": self.db_path, "uri_db_path": uri_db_path}):
+            return sqlite3.connect(uri_db_path, uri=True)
+
+    def _ensure_table_exists(self, _conn):
+        assert False and self, "Abstract method.  Behavior is different for read-only vs read-write mode."
 
     def __enter__(self):
-        ''' context manager enter '''
+        ''' Open a connection, ensure table exists, and enter connection context (i.e. begin transaction). '''
+        # Connection objects can be used as context managers that automatically commit or rollback transactions.
+        # In the event of an exception, the transaction is rolled back; otherwise, the transaction is committed.
+        # https://docs.python.org/2/library/sqlite3.html#using-the-connection-as-a-context-manager
+        self._assert_lock_held()
+        assert not self._db_conn
+        conn = self._connect()
+        try:
+            # The connection is first entered and exited in ensure_table_exists(), then entered again
+            # to start a new transaction for the context block being managed.
+            self._ensure_table_exists(conn)
+            conn.__enter__()
+        except:
+            # Try not to leak open connections.  If an exception is raised above,
+            # the self.__exit__() method will never run, so we have to close
+            # the connection here.
+            conn.close()
+            raise
+        # Leaving this last ensures we don't __exit__ a conn that hasn't been __enter__'ed.
+        self._db_conn = conn
         return self
 
-    def __exit__(self, type, value, traceback):
-        ''' context manager exit '''
-        self.close()
-        return False
+    def __exit__(self, etype, evalue, etraceback):
+        ''' If an exception has occurred, the connection will auto-rollback;  otherwise it will auto-commit. '''
+        self._assert_lock_held()  # It would be extremely unusual for this to fail.
+        conn = self._db_conn
+        self._db_conn = None
+        try:
+            return conn.__exit__(etype, evalue, etraceback)
+        finally:
+            conn.close()
 
-    def __del__(self):
-        ''' destructor '''
-        self.close()
 
-    def close(self):
-        ''' close db if it is open. If the db is not read-only, it also performs a commit before closing it. '''
-        if self._open:
-            if not self.read_only:
-                with log.log_context("db_commit", {"db_path": self.db_path, "read_only": self.read_only}):
-                    self.db_conn.commit()
-            with log.log_context("db_close", {"db_path": self.db_path, "read_only": self.read_only}):
-                self.db_conn.close()
-            self._open = False
+class IdSeqDict(_IdSeqDictBase):
+    '''
+        A key -> value permanent dictionary store with sqlite3 as the backend.
+
+        The key has to be a string.
+
+        The value could be either an array of strings or a string.
+
+        Use only through a WITH context, like so:
+
+           with IdSeqDict("somefile.sql3") as sf:
+               print(sf.get("somekey"))
+
+        This opens a read-only "connection" to the database file, and looks up
+        the value for "somekey".  The connection is closed when the block exits.
+
+        For write access, use IdSeqDictForUpdate.  That begins a transaction
+        which is either committed or rolled back at block exit depending on
+        whether exceptions have occurred in the block, as per sqlite3 doc.
+
+        To open the same file from multiple threads or processes, each thread or
+        process must execute its own WITH block with an IdSeqDict() constructor
+        exactly as above.
+
+        Accessing the same IdSeqDict instance/connection from multiple threads/
+        processes is a checked runtime error.
+
+        ILLEGAL ACCESSS
+
+        Accessing "sf" outside of the WITH block will raise an assert.
+
+        Accessing "sf" from a child thread or process will raise an assert.
+
+        "Accessing" means calling get(), update(), batch_inserts(), or, trying
+        to enter/exit as a context via "with".
+    '''
+
+    def __init__(self, db_path, value_type):
+        super().__init__(db_path, value_type)
+
+    def _get_uri(self):
+        ''' Private: URI for readonly access '''
+        return self._uri_base() + "?mode=ro&immutable=1&nolock=1&cache=private"
+
+    def _ensure_table_exists(self, conn):
+        ''' Private: Fail if the table does not exist.  Called when self._db_conn is still none. '''
+        self._assert_lock_held()
+        with log.log_context(f"db_assert_table", {"db_path": self.db_path}):
+            with conn:
+                res = conn.execute(f"SELECT count(*) FROM sqlite_master WHERE type='table' AND name='{SQLITE_TABLE_NAME}';")
+                table_exists = res.fetchone()[0] != 0
+            assert table_exists, f"table {SQLITE_TABLE_NAME} doesn't exist in db {self.db_path}"
+
+    @staticmethod
+    def _table_exists(conn, table_name):
+        ''' Private: Return True just when table_name exists. '''
+        with conn:
+            res = conn.execute(f"SELECT count(*) FROM sqlite_master WHERE type='table' AND name='{table_name}';")
+            return res.fetchone()[0] != 0
+
+    def get(self, key, default_value=None):
+        ''' Emulate get as a python dictionary  '''
+        self._assert_lock_held()
+        result = default_value
+        v = self._db_conn.execute(f"SELECT dict_value FROM idseq_dict where dict_key = '{key}'").fetchone()
+        if v:
+            result = v[0]
+            if self.value_type == IdSeqDictValue.VALUE_TYPE_ARRAY:
+                result = result.split(DICT_DELIMITER)
+        return result
+
+
+class IdSeqDictForUpdate(IdSeqDict):
+    '''
+        A version of IdSeqDict that permits updates.  See IdSeqDict for more information.
+    '''
+
+    def __init__(self, db_path, value_type):
+        super().__init__(db_path, value_type)
+
+    def _get_uri(self):
+        ''' URI for read and write access '''
+        return self._uri_base()
+
+    def _ensure_table_exists(self, conn):
+        ''' Create writable table if one doesn't exist. '''
+        self._assert_lock_held()
+        with log.log_context(f"db_assert_table", {"db_path": self.db_path}):
+            with conn:
+                conn.execute(f"CREATE TABLE IF NOT EXISTS {SQLITE_TABLE_NAME} (dict_key VARCHAR(255) PRIMARY KEY, dict_value text)")
 
     def update(self, key, value):
-        ''' Update a particular key value pair '''
-        cursor = self.db_conn.cursor()
+        ''' Update a particular key value pair.  Will commit or roll back at exit of WITH block. '''
+        self._assert_lock_held()
         val = value
         if self.value_type == IdSeqDictValue.VALUE_TYPE_ARRAY:
-            val = DICT_DELIMITER.join([str(v) for v in value])
-        cursor.execute(f"INSERT OR REPLACE INTO {SQLITE_TABLE_NAME} VALUES ('{key}', '{val}')")
-        cursor.close()
+            val = DICT_DELIMITER.join(str(v) for v in value)
+        self._db_conn.execute(f"INSERT OR REPLACE INTO {SQLITE_TABLE_NAME} VALUES ('{key}', '{val}')")
 
     def batch_inserts(self, tuples):
-        ''' Insert multiple records at a time '''
-        if self.read_only:
-            raise Exception(f"db {self.db_path} is open in read-only mode")
+        ''' Insert multiple records at a time.  Will commit or roll back at exit of WITH block. '''
+        self._assert_lock_held()
+
         if len(tuples) == 0:
             return
+
         def tuple_to_sql_str(user_tuple):
             val = user_tuple[1]
             if self.value_type == IdSeqDictValue.VALUE_TYPE_ARRAY:
@@ -92,27 +197,13 @@ class IdSeqDict(object):
 
         parameter_str = ",".join(["(?,?)"] * len(tuples))
 
-        cursor = self.db_conn.cursor()
-        cursor.execute(f"INSERT OR REPLACE INTO {SQLITE_TABLE_NAME} VALUES {parameter_str}", value_arr)
-        self.db_conn.commit()
-        cursor.close()
+        # This adds to the pending transaction.
+        self._db_conn.execute(f"INSERT OR REPLACE INTO {SQLITE_TABLE_NAME} VALUES {parameter_str}", value_arr)
 
-    def get(self, key, default_value=None):
-        ''' Emulate get as a python dictionary  '''
-        cursor = self.db_conn.cursor()
-        res = cursor.execute(f"SELECT dict_value FROM idseq_dict where dict_key = '{key}'")
-        v = res.fetchone()
-        if v is None:
-            return default_value
-        value = v[0]
-        if self.value_type == IdSeqDictValue.VALUE_TYPE_ARRAY:
-            return value.split(DICT_DELIMITER)
-        cursor.close()
-        return value
 
-def open_file_db_by_extension(db_path, value_type=IdSeqDictValue.VALUE_TYPE_SCALAR, read_only=True):
+def open_file_db_by_extension(db_path, value_type=IdSeqDictValue.VALUE_TYPE_SCALAR):
     ''' if extension is .sqlite3 open it as an IdSeqDict, otherwise, open as shelve in read mode '''
     if db_path[-8:] == '.sqlite3': # sqlite3 format
-        return IdSeqDict(db_path, value_type, read_only)
-    # shelve format
+        return IdSeqDict(db_path, value_type)
+    # shelve format;  shelve objects can be used as context managers
     return shelve.open(db_path.replace('.db', ''), 'r')


### PR DESCRIPTION
    minimum updates to SQLite wrapper to ensure stability
    
      (*) spec expressly forbids sharing a connection between threads,
          which we were doing in alignment viz and coverage viz,
          concurrently accessing the location DB from up to 64
          threads while fetching reference sequences from s3
    
          fixes:
    
             -- it's actually efficient to do the location db lookup
                in the parent, as opposed to each child thread
    
             -- add multiprocessing RLock as part of the dict wrapper
                context class to ensure we never accidentally break
                this rule;  acquiring the lock in the context __enter__
                makes it very cheap to re-acquire from get() calls
    
             -- ensure dict wrapper is only used as a context manager
                by removing the deadlocking statement from the __del__
                method and having it fail an assert if __del__ is
                called prior to context exit/cleanup
    
      (*) sqlite spec allows using a connection object as a context,
          python WITH statement; and similar for the shelve spec;
          take advantage of this in our dict wrapper class to
          simplify the code for auto-unrolling/committing
    
      (*) the meaning of read_only was inverted, so it was actually
          doing the create_table_if_not_exists even if opening
          a database for reads;  protect better from this
          bug by creating a separate class for read-only connections



TESTED HERE:

https://staging.idseq.net/samples/12773/

COMPARE TO:

https://staging.idseq.net/samples/12774/