### PR TITLE
Log output in JSON format. Change TraceLock log level to DEBUG.

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,13 +226,12 @@ TODO: Move this code over to the idseq-dag repo.
 
 ## Release notes
 
-- 3.7.3
+- 3.7.4
+  - Log output in JSON format. Change TraceLock log level to DEBUG.
+
+- 3.7.0 .. 3.7.3
   - Upgrade to python 3.7.3
-
-- 3.7.2
   - Remove db_hack. Standardize db_open/db_assert_table/db_close log entries.
-
-- 3.7.0 .. 3.7.1
    - Fix division by zero error in coverage viz step.
    - Modify trimmomatic command to reduce MINLEN parameter to 35 and allow reads from fragments with small
      insert sizes (where R1 and R2 are reverse complements of each other) through the QC steps.

--- a/idseq_dag/__init__.py
+++ b/idseq_dag/__init__.py
@@ -1,4 +1,3 @@
 ''' idseq_dag '''
 
-__version__ = "3.7.2"
-
+__version__ = "3.7.4"

--- a/idseq_dag/util/log.py
+++ b/idseq_dag/util/log.py
@@ -6,6 +6,7 @@ import json
 import datetime
 import math
 import functools
+import secrets
 
 from contextlib import contextmanager
 
@@ -17,29 +18,47 @@ def configure_logger(log_file=None):
 
     if log_file:
         handler = logging.FileHandler(log_file)
-        formatter = logging.Formatter("%(asctime)s: [%(threadName)12s] %(message)s")
+        formatter = JsonFormatter()
         handler.setFormatter(formatter)
         logger.addHandler(handler)
 
     # Echo to stdout so they get to CloudWatch
     handler = logging.StreamHandler(sys.stdout)
     handler.setLevel(logging.INFO)
-    formatter = logging.Formatter("%(asctime)s: [%(threadName)12s] %(message)s")
+    formatter = JsonFormatter()
     handler.setFormatter(formatter)
     logger.addHandler(handler)
 
 
-def write(message, warning=False, flush=True):
+def write(message: str = None, warning: bool = False, flush: bool = True,
+          debug: bool = False, obj_data: object = None):
+    '''
+    Write a new log entry.
+
+    Parameters:
+    message (str): String message to log. This field is optional, since you might want to send obj_data instead.
+    obj_data (object): Object that will be serialized as json. dict is the preferred format,
+                       although any json serializable type might work (ex: bool). This field is optional,
+                       since you might want to send obj_data instead.
+    warning(boolean): Optional. Log this event using warning level. This level has precedence over debug.
+    debug(boolean): Optional. Log this event using debug level.
+    flush(boolean): Optional (default true). Flush stdout after logging.
+    '''
     with __print_lock:
         logger = logging.getLogger()
         if warning:
-            logger.warning(message)
+            logger.warning(msg=message, extra={"obj_data": obj_data})
+        elif debug:
+            logger.debug(msg=message, extra={"obj_data": obj_data})
         else:
-            logger.info(message)
+            logger.info(msg=message, extra={"obj_data": obj_data})
         if flush:
             sys.stdout.flush()
 
-def log_event(event_name, values=None, start_time=None, warning=False, flush=True, extra_fields={}):
+
+def log_event(event_name: str, values: object = None, start_time: datetime.datetime = None, 
+              warning: bool = False, debug: bool = False, flush: bool = True,
+              extra_fields: dict = {}):
     '''
     Write a new log event.
 
@@ -47,7 +66,10 @@ def log_event(event_name, values=None, start_time=None, warning=False, flush=Tru
     event_name (str): name of the event
     values(dict): Optional. Values associated to that event. Will be logged in json format.
     start_time(datetime): Optional. If given, it will calc the elapsed time from this datetime to now and write it to the log line.
-    extra_fields(datetime): Optional. If given, they will be merged to the main event hash.
+    extra_fields(dict): Optional. If given, keys will be merged to the main event hash.
+    warning(boolean): Optional. Log this event using warning level. This level has precedence over debug. (see log.write)
+    debug(boolean): Optional. Log this event using debug level. (see log.write)
+    flush(boolean): Optional (default true). Flush stdout after logging. (see log.write)
 
     Returns:
     datetime: Now. It can be used to pass to parameter start_time in a future log_event call.
@@ -57,20 +79,17 @@ def log_event(event_name, values=None, start_time=None, warning=False, flush=Tru
     # ... download your file here ...
     log_event("downloaded_completed", {"file":"abc"}, start_time=start)
     '''
-    log_line = {"event": event_name, **extra_fields}
-    default = lambda o: f"<<non-serializable: {type(o).__qualname__}>>"
+    obj_data = {"event": event_name, **extra_fields}
     if values is not None:
-        log_line["values"] = values
-    if start_time is None:
-        fmt_message = json.dumps(log_line, default=default)
-    else:
+        obj_data["values"] = values
+    if start_time is not None:
         duration = (datetime.datetime.now()-start_time).total_seconds()
-        log_line["duration_ms"] = math.floor(duration * 1000)
-        fmt_message = "%s (%.1f seconds)" % (json.dumps(log_line, default=default), duration)
-    write(fmt_message, warning=warning, flush=flush)
+        obj_data["duration_ms"] = math.floor(duration * 1000)
+    write(obj_data=obj_data, warning=warning, debug=debug, flush=flush)
     return datetime.datetime.now()
 
-def log_execution(values=None):
+
+def log_execution(values: dict = None):
     '''
     Decorates a function and write to logs fn_start and fn_end events.
 
@@ -108,8 +127,9 @@ def log_execution(values=None):
         return wrapper_fn
     return decorator_fn
 
+
 @contextmanager
-def log_context(context_name, values=None, log_caller_info=True):
+def log_context(context_name: str, values: dict = None, log_caller_info: bool = False):
     '''
     Log context manager to track started and completed events for a block of code
 
@@ -131,7 +151,7 @@ def log_context(context_name, values=None, log_caller_info=True):
     {"event": "ctx_start", "context_name": "sub_step", "caller": {"filename": "some_file.py", "method": "some_method"}, "values": {abc": 123}}
     {"event": "ctx_end", "context_name": "sub_step", "caller": {"filename": "some_file.py", "method": "some_method"}, "values": {abc": 123}, "duration_ms": 5006} (5.0 seconds)
     '''
-    extra_fields = {"context_name": context_name}
+    extra_fields = {"context_name": context_name, "uid": secrets.token_hex(6)}
     if log_caller_info:
         frame = sys._getframe(2)
         f_code = frame.f_code
@@ -146,8 +166,28 @@ def log_context(context_name, values=None, log_caller_info=True):
         log_event("ctx_error", values, start_time=start, extra_fields=extra_fields)
         raise e
 
+
 def set_up_stdout():
     # Unbuffer stdout and redirect stderr into stdout. This helps observe logged
     # events in realtime.
     sys.stdout = os.fdopen(sys.stdout.fileno(), 'w', 0)
     os.dup2(sys.stdout.fileno(), sys.stderr.fileno())
+
+
+class JsonFormatter(logging.Formatter):
+    default_time_format = '%Y-%m-%dT%H:%M:%S'
+    default_msec_format = '%s.%03d'
+
+    @staticmethod
+    def _default_json_serializer(obj):
+        '''Default serializer that returns string <<non-sertializable: TYPE_NAME>> for that type'''
+        return f"<<non-serializable: {type(obj).__qualname__}>>"
+
+    def format(self, record):
+        obj = {"timestamp": self.formatTime(record)}
+        if record.msg is not None:
+            obj['msg'] = super().format(record)
+        if record.obj_data is not None:
+            obj['data'] = record.obj_data
+        obj.update({"thread": record.threadName, "pid": record.process, "level": record.levelname})
+        return json.dumps(obj, default=JsonFormatter._default_json_serializer)

--- a/tests/unit/util/test_log.py
+++ b/tests/unit/util/test_log.py
@@ -1,11 +1,48 @@
+import datetime
+import io
+import logging
 import unittest
-from unittest.mock import patch, call
+from unittest.mock import patch, call, Mock
 
 # Module under test
 import idseq_dag.util.log as log
 
 class TestLog(unittest.TestCase):
     '''Tests for `util/log.py`'''
+
+    @patch('logging.getLogger')
+    def test_write_debug_text(self, mock_getLogger):
+        '''Test writing a info text message to the logs'''
+
+        log.write("Text message", debug=True)
+
+        mock_getLogger.assert_has_calls([
+            call().debug(msg='Text message', extra={"obj_data": None})
+        ])
+
+
+    @patch('logging.getLogger')
+    def test_write_info_obj_data(self, mock_getLogger):
+        '''Test writing a info object data to the logs'''
+
+        log.write(obj_data={"name_a": 1, "name_b": "fake_string", "name_c": 3.1415})
+
+        mock_getLogger.assert_has_calls([
+            call().info(msg=None, extra={"obj_data": {"name_a": 1, "name_b": "fake_string", "name_c": 3.1415}})
+        ])
+
+
+    @patch('logging.getLogger')
+    def test_write_info_non_serializable(self, mock_getLogger):
+        '''Test writing log entry with a non serializable field'''
+        non_serializable_byte_field = bytes()
+
+        log.write(obj_data={"name_a": 1, "name_b": non_serializable_byte_field, "name_c": 3.1415})
+
+        mock_getLogger.assert_has_calls([
+            call().info(msg=None, extra={"obj_data": {"name_a": 1, "name_b": non_serializable_byte_field, "name_c": 3.1415}})
+        ])
+
 
     @staticmethod
     @patch('idseq_dag.util.log.write')
@@ -14,17 +51,43 @@ class TestLog(unittest.TestCase):
         log.log_event('fake_event_name', values={"name_a": 1, "name_b": "fake_string", "name_c": 3.1415}, warning=True, flush=False, extra_fields={"extra_field_1": "abc"})
 
         mock_log_write.assert_has_calls([
-            call('{"event": "fake_event_name", "extra_field_1": "abc", "values": {"name_a": 1, "name_b": "fake_string", "name_c": 3.1415}}', warning=True, flush=False)
+            call(obj_data={"event": "fake_event_name", "extra_field_1": "abc", "values": {"name_a": 1, "name_b": "fake_string", "name_c": 3.1415}}, warning=True, debug=False, flush=False)
         ])
+
 
     @staticmethod
     @patch('idseq_dag.util.log.write')
-    def test_log_event_2(mock_log_write):
-        '''Test log event with a non serializable field'''
-        invalid_field = bytes()
+    def test_log_event_3(mock_log_write):
+        '''Test a successful log event with duration'''
+        start_time = datetime.datetime(2019, 5, 27, 16, 0, 0)
+        now = start_time + datetime.timedelta(minutes=1, seconds=18)
+        mock_datetime = Mock(datetime.datetime)
+        mock_datetime.now.return_value = now
 
-        log.log_event('fake_event_name', values={"name_a": invalid_field, "name_b": "fake_string", "name_c": 3.1415})
+        with patch.object(datetime, 'datetime', mock_datetime):
+            log.log_event('fake_event_name', values={"name_a": 1}, warning=False, flush=False, start_time=start_time)
 
         mock_log_write.assert_has_calls([
-            call('{"event": "fake_event_name", "values": {"name_a": "<<non-serializable: bytes>>", "name_b": "fake_string", "name_c": 3.1415}}', warning=False, flush=True)
+            call(obj_data={"event": "fake_event_name", "values": {"name_a": 1}, "duration_ms": 78000}, warning=False, debug=False, flush=False)
         ])
+
+
+    def test_json_formatter(self):
+        '''Test if logger is formatting to json output'''
+        output = io.StringIO()
+        handler = logging.StreamHandler(output)
+        formatter = log.JsonFormatter()
+        handler.setFormatter(formatter)
+        logger = logging.Logger("my_test_logger")
+        logger.addHandler(handler)
+
+        with patch('logging.getLogger', return_value=logger):
+            log.write(message='test message', obj_data={"abc": 1, "f2": bytes()})
+
+        out_str = output.getvalue().rstrip()
+
+        LOG_OUTPUT_REGEX = r'^{"timestamp": "\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}", "msg": "test message", "data": {"abc": 1, "f2": "<<non-serializable: bytes>>"}, "thread": "[^"]+", "pid": \d, "level": "INFO"}'
+        # sample expected message
+        self.assertRegex('{"timestamp": "2019-05-28T21:06:46.728", "msg": "test message", "data": {"abc": 1, "f2": "<<non-serializable: bytes>>"}, "thread": "MainThread", "pid": 6, "level": "INFO"}', LOG_OUTPUT_REGEX)
+        # actual message
+        self.assertRegex(out_str, LOG_OUTPUT_REGEX)

--- a/tests/unit/util/test_trace_lock.py
+++ b/tests/unit/util/test_trace_lock.py
@@ -21,8 +21,8 @@ class TestTraceLock(unittest.TestCase):
             pass
 
         mock_log_event.assert_has_calls([
-            call('trace_lock', values={'state': 'acquired', 'lock_name': 'lock1', 'thread_name': 'MainThread'}),
-            call('trace_lock', values={'state': 'released', 'lock_name': 'lock1', 'thread_name': 'MainThread'})
+            call('trace_lock', values={'state': 'acquired', 'lock_name': 'lock1', 'thread_name': 'MainThread'}, debug=True),
+            call('trace_lock', values={'state': 'released', 'lock_name': 'lock1', 'thread_name': 'MainThread'}, debug=True)
         ])
 
     @staticmethod
@@ -45,9 +45,9 @@ class TestTraceLock(unittest.TestCase):
             pass
 
         mock_log_event.assert_has_calls([
-            call('trace_lock', values={'lock_name': 'lock2', 'thread_name': 'Thread-1', 'state': 'acquired'}),
-            call('trace_lock', values={'lock_name': 'lock2', 'thread_name': 'MainThread', 'state': 'waiting'}),
-            call('trace_lock', values={'lock_name': 'lock2', 'thread_name': 'Thread-1', 'state': 'released'}),
-            call('trace_lock', values={'lock_name': 'lock2', 'thread_name': 'MainThread', 'state': 'acquired_after_wait'}),
-            call('trace_lock', values={'lock_name': 'lock2', 'thread_name': 'MainThread', 'state': 'released'})
+            call('trace_lock', values={'lock_name': 'lock2', 'thread_name': 'Thread-1', 'state': 'acquired'}, debug=True),
+            call('trace_lock', values={'lock_name': 'lock2', 'thread_name': 'MainThread', 'state': 'waiting'}, debug=True),
+            call('trace_lock', values={'lock_name': 'lock2', 'thread_name': 'Thread-1', 'state': 'released'}, debug=True),
+            call('trace_lock', values={'lock_name': 'lock2', 'thread_name': 'MainThread', 'state': 'acquired_after_wait'}, debug=True),
+            call('trace_lock', values={'lock_name': 'lock2', 'thread_name': 'MainThread', 'state': 'released'}, debug=True)
         ])


### PR DESCRIPTION
This PR changes the output format of our logs to JSON, because it makes it easier to ingest on data analyzing tools (ex: Datadog).

Log entries now look like this:
```JSON
{"timestamp": "2019-05-29T02:52:05.749", "msg": "Command 28 completed. Return code 0", "thread": "Thread-27", "pid": 3286, "level": "INFO"}
{"timestamp": "2019-05-29T02:52:05.749", "data": {"event": "ctx_end", "context_name": "substep_validate", "uid": "d0744d32ab26", "values": {"step": "banana3_out"}, "duration_ms": 5}, "thread": "Thread-27", "pid": 3286, "level": "INFO"}
```

I'm also changing `TraceLock` logs to DEBUG level, because they are generating a huge amount of entries that are not really needed (except when you need to debug some weird deadlock issue).


**Test plan**
- Unit tested
- Tested running custom local pipeline