### PR TITLE
Rename `timestamp` field name.

### DIFF
--- a/idseq_dag/util/log.py
+++ b/idseq_dag/util/log.py
@@ -184,7 +184,7 @@ class JsonFormatter(logging.Formatter):
         return f"<<non-serializable: {type(obj).__qualname__}>>"
 
     def format(self, record):
-        obj = {"timestamp": self.formatTime(record)}
+        obj = {"time": self.formatTime(record)}
         if record.msg is not None:
             obj['msg'] = super().format(record)
         if record.obj_data is not None:

--- a/tests/unit/util/test_log.py
+++ b/tests/unit/util/test_log.py
@@ -86,8 +86,8 @@ class TestLog(unittest.TestCase):
 
         out_str = output.getvalue().rstrip()
 
-        LOG_OUTPUT_REGEX = r'^{"timestamp": "\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}", "msg": "test message", "data": {"abc": 1, "f2": "<<non-serializable: bytes>>"}, "thread": "[^"]+", "pid": \d, "level": "INFO"}'
+        LOG_OUTPUT_REGEX = r'^{"time": "\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}", "msg": "test message", "data": {"abc": 1, "f2": "<<non-serializable: bytes>>"}, "thread": "[^"]+", "pid": \d, "level": "INFO"}'
         # sample expected message
-        self.assertRegex('{"timestamp": "2019-05-28T21:06:46.728", "msg": "test message", "data": {"abc": 1, "f2": "<<non-serializable: bytes>>"}, "thread": "MainThread", "pid": 6, "level": "INFO"}', LOG_OUTPUT_REGEX)
+        self.assertRegex('{"time": "2019-05-28T21:06:46.728", "msg": "test message", "data": {"abc": 1, "f2": "<<non-serializable: bytes>>"}, "thread": "MainThread", "pid": 6, "level": "INFO"}', LOG_OUTPUT_REGEX)
         # actual message
         self.assertRegex(out_str, LOG_OUTPUT_REGEX)


### PR DESCRIPTION
`timestamp` field name is implicitly used during log ingestion for lines that are not json, so we need a different field name because it is conflicting