### PR TITLE
use lz4, limit s3mi concurrency, switch from dash to bash

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -133,6 +133,9 @@ RUN sed -i 's:set kSNP=/usr/local/kSNP3:set kSNP=/usr/local/bin:g' /usr/local/bi
 RUN apt install tcsh
 RUN kSNP3
 
+RUN apt-get -y install liblz4-tool
+RUN apt-get -y install lbzip2
+
 # Cleanup
 RUN rm -rf /tmp/*
 

--- a/idseq_dag/engine/pipeline_flow.py
+++ b/idseq_dag/engine/pipeline_flow.py
@@ -42,8 +42,8 @@ class PipelineFlow(object):
     def prefetch_large_files(self):
         with log.log_context("prefetch_large_files", values={"file_list": self.large_file_list}):
             for f in self.large_file_list:
-                with log.log_context("fetch_from_s3", values={"file": f}):
-                    idseq_dag.util.s3.fetch_from_s3(f, self.ref_dir_local, allow_s3mi=True, auto_untar=True)
+                with log.log_context("fetch_reference", values={"file": f}):
+                    idseq_dag.util.s3.fetch_reference(f, self.ref_dir_local, auto_unzip=True, auto_untar=True, allow_s3mi=True)
 
     @staticmethod
     def parse_and_validate_conf(dag_json):

--- a/idseq_dag/steps/blast_contigs.py
+++ b/idseq_dag/steps/blast_contigs.py
@@ -62,12 +62,12 @@ class PipelineStepBlastContigs(PipelineStep):
         lineage_db = s3.fetch_from_s3(
             self.additional_files["lineage_db"],
             self.ref_dir_local,
-            allow_s3mi=True)
+            allow_s3mi=False) # Too small to waste s3mi
         deuterostome_db = None
         evalue_type = 'raw'
         if self.additional_files.get("deuterostome_db"):
             deuterostome_db = s3.fetch_from_s3(self.additional_files["deuterostome_db"],
-                                               self.ref_dir_local, allow_s3mi=True)
+                                               self.ref_dir_local, allow_s3mi=False) # Too small for s3mi
         with log.log_context("PipelineStepBlastContigs", {"substep": "generate_taxon_count_json_from_m8", "db_type": db_type, "refined_counts": refined_counts}):
             m8.generate_taxon_count_json_from_m8(refined_m8, refined_hit_summary,
                                                 evalue_type, db_type.upper(),
@@ -220,12 +220,3 @@ class PipelineStepBlastContigs(PipelineStep):
                     top_line = line
             if top_line is not None:
                 top_m8f.write(top_line)
-
-
-
-
-
-
-
-
-

--- a/idseq_dag/steps/generate_coverage_viz.py
+++ b/idseq_dag/steps/generate_coverage_viz.py
@@ -36,7 +36,7 @@ class PipelineStepGenerateCoverageViz(PipelineStep):
         min_contig_size = self.additional_attributes.get("min_contig_size", MIN_CONTIG_SIZE)
 
         # Info DB contains the name and sequence length of each accession.
-        info_db = s3.fetch_from_s3(
+        info_db = s3.fetch_reference(
             self.additional_files["info_db"],
             self.ref_dir_local,
             allow_s3mi=True)

--- a/idseq_dag/steps/generate_phylo_tree.py
+++ b/idseq_dag/steps/generate_phylo_tree.py
@@ -200,7 +200,7 @@ class PipelineStepGeneratePhyloTree(PipelineStep):
 
         # Retrieve files
         nt_db = self.additional_attributes["nt_db"]
-        nt_loc_db = s3.fetch_from_s3(
+        nt_loc_db = s3.fetch_reference(
             self.additional_files["nt_loc_db"],
             self.ref_dir_local,
             allow_s3mi=True)

--- a/idseq_dag/steps/run_alignment_remotely.py
+++ b/idseq_dag/steps/run_alignment_remotely.py
@@ -13,7 +13,7 @@ import idseq_dag.util.count as count
 import idseq_dag.util.server as server
 import idseq_dag.util.log as log
 import idseq_dag.util.m8 as m8
-from idseq_dag.util.s3 import fetch_from_s3
+from idseq_dag.util.s3 import fetch_from_s3, fetch_reference
 from idseq_dag.util.trace_lock import TraceLock
 
 MAX_CONCURRENT_CHUNK_UPLOADS = 4
@@ -56,8 +56,8 @@ class PipelineStepRunAlignmentRemotely(PipelineStep):
         self.run_remotely(input_fas, output_m8, service)
 
         # get database
-        lineage_db = fetch_from_s3(self.additional_files["lineage_db"], self.ref_dir_local, allow_s3mi=True)
-        accession2taxid_db = fetch_from_s3(self.additional_files["accession2taxid_db"], self.ref_dir_local, allow_s3mi=True)
+        lineage_db = fetch_from_s3(self.additional_files["lineage_db"], self.ref_dir_local)
+        accession2taxid_db = fetch_reference(self.additional_files["accession2taxid_db"], self.ref_dir_local, allow_s3mi=True)
         blacklist_s3_file = self.additional_attributes.get('taxon_blacklist', DEFAULT_BLACKLIST_S3)
         taxon_blacklist = fetch_from_s3(blacklist_s3_file, self.ref_dir_local)
         m8.call_hits_m8(output_m8, lineage_db, accession2taxid_db,
@@ -224,7 +224,7 @@ class PipelineStepRunAlignmentRemotely(PipelineStep):
                 chunk_output_files[n] = result
             chunks_in_flight.release()
 
-    
+
     @staticmethod
     def __interpret_min_column_number_string(min_column_number_string,
                                              correct_number_of_output_columns,

--- a/idseq_dag/steps/run_srst2.py
+++ b/idseq_dag/steps/run_srst2.py
@@ -26,8 +26,8 @@ class PipelineStepRunSRST2(PipelineStep):
         results = os.path.join(self.output_dir_local, OUTPUT_GENES)
         results_dest = self.output_files_local()[1]
         shutil.move(log, log_dest)
-        shutil.move(results, results_dest) 
-        if not os.path.exists(os.path.join(self.output_dir_local, OUTPUT_FULL_GENES)): 
+        shutil.move(results, results_dest)
+        if not os.path.exists(os.path.join(self.output_dir_local, OUTPUT_FULL_GENES)):
             for f in self.output_files_local()[2:5]:
                 PipelineStepRunSRST2.fill_file_path(f)
         else:
@@ -43,15 +43,15 @@ class PipelineStepRunSRST2(PipelineStep):
 
     def execute_srst2(self, isPaired, isFasta, isZipped):
         """Executes srst2 with appropriate parameters based on whether input files are zipped,
-           paired reads and on file type."""        
+           paired reads and on file type."""
         srst2_params = ['srst2']
         srst2_params.extend(self.get_common_params())
-        if isFasta: 
+        if isFasta:
             file_ext = '.fasta.gz' if isZipped else '.fasta'
             srst2_params.extend(['--read_type', 'f'])
-        else: 
+        else:
             file_ext = '.fastq.gz' if isZipped else '.fastq'
-        if isPaired: srst2_params.extend(['--input_pe']) 
+        if isPaired: srst2_params.extend(['--input_pe'])
         else: srst2_params.extend(['--input_se'])
         for i, rd in enumerate(self.input_files_local[0]):
             command.execute(f"ln -sf {rd} _R{i+1}_001"+file_ext)
@@ -62,7 +62,7 @@ class PipelineStepRunSRST2(PipelineStep):
 
     def get_common_params(self):
         """Helper that gets srst2 parameters common to both paired and single rds."""
-        db_file_path = fetch_from_s3(self.additional_files["resist_gene_db"], self.output_dir_local)
+        db_file_path = fetch_from_s3(self.additional_files["resist_gene_db"], self.output_dir_local, allow_s3mi=False) # too small for s3mi
         min_cov = str(self.additional_attributes['min_cov'])
         # srst2 expects this to be a string, in dag could be passed in as a number
         n_threads = str(self.additional_attributes['n_threads'])
@@ -86,7 +86,7 @@ class PipelineStepRunSRST2(PipelineStep):
         fd = os.open(file_path, os.O_RDWR|os.O_CREAT)
         os.write(fd, b"\n")
         os.close(fd)
-             
+
     @staticmethod
     def _get_pre_proc_amr_results(amr_raw_path):
         """ Reads in raw amr results file outputted by srst2, and does initial processing of marking gene family."""
@@ -122,5 +122,3 @@ class PipelineStepRunSRST2(PipelineStep):
             mode='w',
             index=False,
             encoding='utf-8')
-
-

--- a/idseq_dag/util/command.py
+++ b/idseq_dag/util/command.py
@@ -119,7 +119,7 @@ class ProgressFile(object):
         if self.progress_file:
             self.tail_subproc = subprocess.Popen(
                 "touch {pf} ; tail -f {pf}".format(pf=self.progress_file),
-                shell=True)
+                shell=True, executable="/bin/bash")
         return self
 
     def __exit__(self, *args):
@@ -231,6 +231,7 @@ def execute(command,
                 ct.proc = subprocess.Popen(
                     command,
                     shell=True,
+                    executable="/bin/bash",
                     stdin=sys.stdin.fileno(),
                     stdout=subprocess.PIPE,
                     stderr=subprocess.STDOUT
@@ -238,7 +239,7 @@ def execute(command,
                 stdout, _ = ct.proc.communicate()
             else:
                 # Capture nothing. Child inherits parent stdin/out/err.
-                ct.proc = subprocess.Popen(command, shell=True)
+                ct.proc = subprocess.Popen(command, shell=True, executable="/bin/bash")
                 ct.proc.wait()
                 stdout = None
 

--- a/idseq_dag/util/s3.py
+++ b/idseq_dag/util/s3.py
@@ -16,6 +16,10 @@ MAX_CONCURRENT_COPY_OPERATIONS = 8
 IOSTREAM = multiprocessing.Semaphore(MAX_CONCURRENT_COPY_OPERATIONS)
 # Make a second semaphore for uploads to reserve some capacity for downloads.
 MAX_CONCURRENT_UPLOAD_OPERATIONS = 4
+MAX_CONCURRENT_S3MI_DOWNLOADS = 2
+# If a s3mi slot does not free up within MAX_S3MI_WAIT seconds, we use plain old aws s3 cp instead of s3mi.
+MAX_S3MI_WAIT = 15
+S3MI_SEM = multiprocessing.Semaphore(MAX_CONCURRENT_S3MI_DOWNLOADS)
 IOSTREAM_UPLOADS = multiprocessing.Semaphore(MAX_CONCURRENT_UPLOAD_OPERATIONS)
 
 def split_identifiers(s3_path):
@@ -68,31 +72,44 @@ def install_s3mi(installed={}, mutex=TraceLock("install_s3mi", threading.RLock()
             installed['time'] = time.time()
 
 
-def fetch_from_s3(src,
+DEFAULT_AUTO_UNZIP = False
+DEFAULT_AUTO_UNTAR = False
+DEFAULT_ALLOW_S3MI = False
+ZIP_EXTENSIONS = {
+    ".lz4": "lz4 -dc",
+    ".bz2": "lbzip2 -dc",
+    ".gz": "gzip -dc", # please avoid .gz if you can (slow to decompress)
+}
+
+def fetch_from_s3(src,   #pylint: disable=dangerous-default-value
                   dst,
-                  auto_unzip=False,
-                  auto_untar=False,
-                  allow_s3mi=False,
+                  auto_unzip=DEFAULT_AUTO_UNZIP,
+                  auto_untar=DEFAULT_AUTO_UNTAR,
+                  allow_s3mi=DEFAULT_ALLOW_S3MI,
                   mutex=TraceLock("fetch_from_s3", threading.RLock()),
-                  locks={}):  #pylint: disable=dangerous-default-value
-    """Fetch a file from S3 if needed using either s3mi or aws cp."""
+                  locks={}):
+    """Fetch a file from S3 if needed, using either s3mi or aws cp."""
     with mutex:
         if os.path.exists(dst) and os.path.isdir(dst):
             dst = os.path.join(dst, os.path.basename(src))
-        # Right now untar and unzip are mutually exclusive
-        # TODO(boris): we might change this
-        unzip = auto_unzip and dst.endswith(".gz")
-        untar = auto_untar and dst.endswith(".tar")
-        if unzip:
-            dst = dst[:-3]  # Remove .gz
+        unzip = ""
+        if auto_unzip:
+            for zext, zdecomp in ZIP_EXTENSIONS.items():
+                if dst.lower().endswith(zext.lower()):
+                    unzip += f" | {zdecomp}"
+                    dst = dst[:-len(zext)]
+                    break
+        untar = auto_untar and dst.lower().endswith(".tar")
         if untar:
-            dst = dst[:-4] # Remove .tar
+            dst = dst[:-4]  # Remove .tar
         abspath = os.path.abspath(dst)
         if abspath not in locks:
             locks[abspath] = TraceLock(f"fetch_from_s3: {abspath}", threading.RLock())
         destination_lock = locks[abspath]
 
     with destination_lock:
+        # This check is a bit imperfect when untarring... unless you follow the discipline that
+        # all contents of file foo.tar are under directory foo/...
         if os.path.exists(dst):
             # No need to fetch this file from s3, it has been just produced
             # on this instance.
@@ -118,24 +135,33 @@ def fetch_from_s3(src,
                         log.write("s3mi failed to install.")
                         allow_s3mi = False
 
+                if allow_s3mi:
+                    wait_start = time.time()
+                    allow_s3mi = S3MI_SEM.acquire(timeout=MAX_S3MI_WAIT)
+                    wait_duration = time.time() - wait_start
+                    if not allow_s3mi:
+                        log.write(f"Failed to acquire S3MI semaphore after waiting {wait_duration} seconds for {src}.")
+                    elif wait_duration >= 5:
+                        log.write(f"Waited {wait_duration} seconds to acquire S3MI semaphore for {src}.")
+
+                write_dst = f" > {dst}"
                 if untar:
-                    command_params = f" | tar xvf - -C {destdir}"
-                else:
-                    pipe_filter = ""
-                    if unzip:
-                        pipe_filter = "| gzip -dc "
-                    command_params = f"{pipe_filter} > {dst}"
+                    write_dst = f" | tar xvf - -C {destdir}"
+                command_params = f"{unzip} {write_dst}"
                 log.write(f"command_params: {command_params}")
 
                 try:
                     assert allow_s3mi
-                    cmd = f"s3mi cat {src} {command_params}"
+                    cmd = f"set -o pipefail; s3mi cat {src} {command_params}"
                     command.execute(cmd)
                 except:
-                    log.write(
-                        "Failed to download with s3mi. Trying with aws s3 cp..."
-                    )
-                    cmd = f"aws s3 cp --only-show-errors {src} - {command_params}"
+                    if allow_s3mi:
+                        allow_s3mi = False
+                        S3MI_SEM.release()
+                        log.write(
+                            "Failed to download with s3mi. Trying with aws s3 cp..."
+                        )
+                    cmd = f"set -o pipefail; aws s3 cp --only-show-errors {src} - {command_params}"
                     command.execute(cmd)
                 return dst
             except subprocess.CalledProcessError:
@@ -147,6 +173,54 @@ def fetch_from_s3(src,
                 if os.path.isfile(dst) and os.stat(dst).st_size == 0:
                     os.remove(dst)
                 return None
+            finally:
+                if allow_s3mi:
+                    S3MI_SEM.release()
+
+
+
+def fetch_reference(src,
+                    dst,
+                    auto_unzip=True,
+                    auto_untar=True,
+                    allow_s3mi=DEFAULT_ALLOW_S3MI):
+    '''
+        This function behaves like fetch_from_s3 in most cases, with one excetpion:
+
+            *  When auto_unzip=True, src is NOT a compressed file and NOT a tar file, and a compressed
+               version of src exists in s3, this function downloads and uncompresses it.
+
+        This function behaves identically to fetch_from_s3 when:
+
+            * src is a tar file, or
+
+            * auto_unzip=False, or
+
+            * auto_unzip=True and src is a compressed file, or
+
+            * auto_unzip=True, src is NOT a compressed file, and no compressed version of src exists in s3
+
+        We generally try to keep all our references in S3 either lz4-compressed or tar'ed, because this
+        guards against corruption errors that sometimes occur during download.  If we accidentally
+        download a corrupt file, it would fail to unlz4 or to untar, and we would retry the download.
+    '''
+    if auto_unzip and not src.endswith(".tar") and not any(src.endswith(zext) for zext in ZIP_EXTENSIONS):
+        # Try to guess which compressed version of the file exists in S3;  then download and decompress it.
+        for zext in ZIP_EXTENSIONS:
+            try:
+                return fetch_from_s3(src + zext,
+                                     dst,
+                                     auto_unzip=auto_unzip,
+                                     auto_untar=auto_untar,
+                                     allow_s3mi=allow_s3mi)
+            except:
+                # It's okay - if all these fail, we'll try to fetch src directly.
+                pass
+    return fetch_from_s3(src,
+                         dst,
+                         auto_unzip=auto_unzip,
+                         auto_untar=auto_untar,
+                         allow_s3mi=allow_s3mi)
 
 
 def fetch_byterange(first_byte, last_byte, bucket, key, output_file):


### PR DESCRIPTION
use lz4, limit s3mi concurrency, switch from dash to bash
    
Using lz4 catches and retries corrupt downloads so the job doesn't crash.
    
S3mi concurrency > 2 is unreliable;  concurrent attempts 3, 4, etc will wait up to 15 seconds for a s3mi slot to free up then proceed with regular aws cp.
    
Turns out docker's default shell is the exquisitely weird DASH;  switch from that to BASH in order to get easier pipefail semantics for correct error recovery with lz4 etc.   Also generally best to have the docker container shell be the same one that developers are using when testing the code.
    
TODO (in separate PR):  Update index generators to produce lz4.   Having lz4 in the index producers isn't a blocker for deploying this on the index consumer side.
