### PR TITLE
[TESTING] improve rapsearch chunk retry logic

### DIFF
--- a/idseq_dag/steps/run_alignment_remotely.py
+++ b/idseq_dag/steps/run_alignment_remotely.py
@@ -10,7 +10,7 @@ from idseq_dag.engine.pipeline_step import PipelineStep, InputFileErrors
 
 import idseq_dag.util.command as command
 import idseq_dag.util.count as count
-import idseq_dag.util.server as server
+from idseq_dag.util.server import ASGInstance, ChunkStatus, chunk_status_tracker
 import idseq_dag.util.log as log
 import idseq_dag.util.m8 as m8
 from idseq_dag.util.s3 import fetch_from_s3, fetch_reference
@@ -19,10 +19,11 @@ from idseq_dag.util.trace_lock import TraceLock
 MAX_CONCURRENT_CHUNK_UPLOADS = 4
 DEFAULT_BLACKLIST_S3 = 's3://idseq-database/taxonomy/2018-04-01-utc-1522569777-unixtime__2018-04-04-utc-1522862260-unixtime/taxon_blacklist.txt'
 CORRECT_NUMBER_OF_OUTPUT_COLUMNS = 12
-CHUNK_MAX_TRIES = 2
-CHUNK_DONT_RETRY_AFTER_SECONDS = 60 * 30 # 30 minutes
-EXPONENTIAL_BACKOFF_MINIMUM_SECONDS = 3
-EXPONENTIAL_BACKOFF_JITTER_SECONDS = 4
+CHUNK_MAX_TRIES = 3
+
+# Please override this with gsnap_chunk_timeout or rapsearch_chunk_timeout in DAG json.
+# Default 30 minutes is several sigmas beyond the pale and indicates the data has to be QC-ed better.
+DEFAULT_CHUNK_TIMEOUT = 60*60
 
 class PipelineStepRunAlignmentRemotely(PipelineStep):
     '''
@@ -52,7 +53,6 @@ class PipelineStepRunAlignmentRemotely(PipelineStep):
         service = self.additional_attributes["service"]
         assert service in ("gsnap", "rapsearch2")
 
-        # TODO: run the alignment remotely and make lazy_chunk=True, revisit this later
         self.run_remotely(input_fas, output_m8, service)
 
         # get database
@@ -78,19 +78,19 @@ class PipelineStepRunAlignmentRemotely(PipelineStep):
     def run_remotely(self, input_fas, output_m8, service):
         key_path = self.fetch_key(os.environ['KEY_PATH_S3'])
         sample_name = self.output_dir_s3.rstrip('/').replace('s3://', '').replace('/', '-')
-        chunk_size = self.additional_attributes["chunk_size"]
+        chunk_size = int(self.additional_attributes["chunk_size"])
         index_dir_suffix = self.additional_attributes.get("index_dir_suffix")
         remote_username = "ec2-user"
-        remote_home_dir = "/home/%s" % remote_username
+        remote_home_dir = f"/home/{remote_username}"
         if service == "gsnap":
-            remote_index_dir = "%s/share" % remote_home_dir
+            remote_index_dir = f"{remote_home_dir}/share"
         elif service == "rapsearch2":
-            remote_index_dir = "%s/references/nr_rapsearch" % remote_home_dir
+            remote_index_dir = f"{remote_home_dir}/references/nr_rapsearch"
 
         if index_dir_suffix:
             remote_index_dir = os.path.join(remote_index_dir, index_dir_suffix)
 
-        remote_work_dir = "%s/batch-pipeline-workdir/%s" % (remote_home_dir, sample_name)
+        remote_work_dir = f"{remote_home_dir}/batch-pipeline-workdir/{sample_name}"
 
         # Split files into chunks for performance
         part_suffix, input_chunks = self.chunk_input(input_fas, chunk_size)
@@ -103,26 +103,35 @@ class PipelineStepRunAlignmentRemotely(PipelineStep):
         randomized = list(enumerate(input_chunks))
         random.shuffle(randomized)
 
-        for n, chunk_input_files in randomized:
-            self.chunks_in_flight.acquire()
-            self.check_for_errors(mutex, chunk_output_files, input_chunks, service)
-            t = threading.Thread(
-                target=PipelineStepRunAlignmentRemotely.run_chunk_wrapper,
-                args=[
-                    self.chunks_in_flight, chunk_output_files, n, mutex, self.run_chunk,
-                    [
-                        part_suffix, remote_home_dir, remote_index_dir,
-                        remote_work_dir, remote_username, chunk_input_files,
-                        key_path, service, True
-                    ]
-                ])
-            t.start()
-            chunk_threads.append(t)
+        try:
+            for n, chunk_input_files in randomized:
+                self.chunks_in_flight.acquire()
+                self.check_for_errors(mutex, chunk_output_files, input_chunks, service)
+                t = threading.Thread(
+                    target=PipelineStepRunAlignmentRemotely.run_chunk_wrapper,
+                    args=[
+                        self.chunks_in_flight, chunk_output_files, n, mutex, self.run_chunk,
+                        [
+                            part_suffix, remote_home_dir, remote_index_dir,
+                            remote_work_dir, remote_username, chunk_input_files,
+                            key_path, service, True
+                        ]
+                    ])
+                t.start()
+                chunk_threads.append(t)
 
-        # Check chunk completion
-        for ct in chunk_threads:
-            ct.join()
-            self.check_for_errors(mutex, chunk_output_files, input_chunks, service)
+        finally:
+            # Check chunk completion
+            for ct in chunk_threads:
+                ct.join()
+            try:
+                chunk_status_tracker(service).log_stats(len(input_chunks))
+            except:
+                log.write(f"Problem dumping status report for {service}")
+                log.write(traceback.format_exc())
+
+        self.check_for_errors(mutex, chunk_output_files, input_chunks, service)
+
         assert None not in chunk_output_files
         # Concatenate the pieces and upload results
         self.concatenate_files(chunk_output_files, output_m8)
@@ -240,6 +249,38 @@ class PipelineStepRunAlignmentRemotely(PipelineStep):
         return min_column_number
 
 
+    @command.retry
+    def __check_if_output_is_corrupt(self, service, key_path, remote_username, instance_ip, # self unused
+                                     multihit_remote_outfile, chunk_id, try_number):
+        # Check if every row has correct number of columns (12) in the output
+        # file on the remote machine
+        if service == "gsnap":
+            verification_command = "cat %s" % multihit_remote_outfile
+        else:
+            # For rapsearch, first remove header lines starting with '#'
+            verification_command = "grep -v '^#' %s" % multihit_remote_outfile
+        verification_command += " | awk '{print NF}' | sort -nu | head -n 1"
+        min_column_number_string = command.execute_with_output(
+            command.remote(verification_command, key_path, remote_username, instance_ip))
+        min_column_number = PipelineStepRunAlignmentRemotely.__interpret_min_column_number_string(
+            min_column_number_string, CORRECT_NUMBER_OF_OUTPUT_COLUMNS,
+            try_number)
+        error = None
+        if min_column_number != CORRECT_NUMBER_OF_OUTPUT_COLUMNS:
+            msg = "Chunk %s output corrupt; not copying to S3. min_column_number = %d -> expected = %d."
+            msg += " Re-start pipeline to try again."
+            error = msg % (chunk_id, min_column_number, CORRECT_NUMBER_OF_OUTPUT_COLUMNS)
+        return error
+
+    @command.retry
+    def __copy_multihit_remote_outfile(self, key_path, remote_username, instance_ip,  # self unused
+                                       multihit_remote_outfile, multihit_local_outfile):
+        # Copy output from remote machine to local machine.  This needs to happen while we are
+        # holding the machine reservation, i.e., inside the "with ASGInstnace" context.
+        command.execute(
+            command.scp(key_path, remote_username, instance_ip,
+                        multihit_remote_outfile, multihit_local_outfile))
+
     def run_chunk(self, part_suffix, remote_home_dir, remote_index_dir, remote_work_dir,
                   remote_username, input_files, key_path, service, lazy_run):
         """Dispatch a chunk to worker machines for distributed GSNAP or RAPSearch
@@ -279,83 +320,91 @@ class PipelineStepRunAlignmentRemotely(PipelineStep):
             # Strip the .m8 for RAPSearch as it adds that
         )
 
-        if not lazy_run or not fetch_from_s3(multihit_s3_outfile,
-                                             multihit_local_outfile):
-            correct_number_of_output_columns = CORRECT_NUMBER_OF_OUTPUT_COLUMNS
-            min_column_number = 0
-            max_tries = CHUNK_MAX_TRIES
-            try_number = 1
-            instance_ip = ""
-            timer = self._start_timer()
+        if lazy_run and fetch_from_s3(multihit_s3_outfile, multihit_local_outfile):
+            log.write(f"finished alignment for chunk {chunk_id} with {service} by lazily fetching last result")
+        else:
+            chunk_timeout = int(self.additional_attributes.get(f"{service.lower()}_chunk_timeout",
+                                                               DEFAULT_CHUNK_TIMEOUT))
+            for try_number in range(1, CHUNK_MAX_TRIES + 1):
+                log.write(f"waiting for {service} server for chunk {chunk_id}. Try #{try_number}")
+                with ASGInstance(service, key_path, remote_username, environment, chunk_id, try_number,
+                                 self.additional_attributes) as instance_ip:
+                    # Try/Except block needs to be inside the ASGInstance context.
+                    # A failure to acquire an ASGInstnace is and should be unrecoverable.
+                    chunk_status = None
+                    elapsed = 0.0
+                    try:
+                        t_start = time.time()
+                        try:
+                            command.execute(command.remote(commands, key_path, remote_username, instance_ip),
+                                            timeout=chunk_timeout)
+                        except:
+                            chunk_status = ChunkStatus.CRASH
+                            raise
+                        finally:
+                            elapsed = time.time() - t_start
+                            if chunk_status == ChunkStatus.CRASH and elapsed >= chunk_timeout:
+                                chunk_status = ChunkStatus.TIMEOUT
 
-            # Check if every row has correct number of columns (12) in the output
-            # file on the remote machine
-            while min_column_number != correct_number_of_output_columns \
-                    and try_number <= max_tries:
-                log.write("waiting for {} server for chunk {}. Try #{}".format(
-                    service, chunk_id, try_number))
-                max_concurrent = self.additional_attributes["max_concurrent"]
+                        output_corrupt = self.__check_if_output_is_corrupt(
+                            service, key_path, remote_username, instance_ip, multihit_remote_outfile,
+                            chunk_id, try_number)
 
-                try:
-                    with server.ASGInstance(service, key_path,
-                                            remote_username, environment,
-                                            max_concurrent, chunk_id,
-                                            self.additional_attributes.get("max_interval_between_describe_instances") or 900,
-                                            self.additional_attributes.get("job_tag_prefix") or "RunningIDseqBatchJob_",
-                                            self.additional_attributes.get("job_tag_refresh_seconds") or 600,
-                                            self.additional_attributes.get("draining_tag") or "draining") as instance_ip:
-                        command.execute(command.remote(commands, key_path, remote_username, instance_ip))
+                        if output_corrupt:
+                            chunk_status = ChunkStatus.CORRUPT_OUTPUT
+                            assert not output_corrupt, output_corrupt
 
-                        if service == "gsnap":
-                            verification_command = "cat %s" % multihit_remote_outfile
+                        # Yay, chunk succeeded.  Copy from server and break out of retry loop.
+                        try:
+                            self.__copy_multihit_remote_outfile(
+                                key_path, remote_username, instance_ip,
+                                multihit_remote_outfile, multihit_local_outfile)
+                            chunk_status = ChunkStatus.SUCCESS
+                            break
+                        except:
+                            # If we failed to copy from the server, it's as bad as a crash in alignment.
+                            chunk_status = ChunkStatus.CRASH
+                            raise
+
+                    except Exception as e:
+
+                        # 1. No backoff needed here before retrying.  We rate limit chunk dispatch (the ASGInstance
+                        # acquisition above is blocking).  ASGInstance acquisition also tries to ensure that every
+                        # chunk flight gets its first try before any retry is dispatched.
+
+                        # 2. If the reason we failed is timeout on the server, we don't retry.  The operator must decide
+                        # whether to QC the data more, or use smaller chunk size.  In fact, we only retry for CRASH and
+                        # CORRUPT_OUTPUT.
+
+                        # 3. If this is the last attempt, we gotta re-raise the exception.
+
+                        # 4. Elapsed time is only the time spent in alignment.  It excludes the time spent waiting to
+                        # acquire ASGinstance.
+
+                        log.log_event('alignment_remote_error', values={"chunk": chunk_id,
+                                                                        "try_number": try_number,
+                                                                        "CHUNK_MAX_TRIES": CHUNK_MAX_TRIES,
+                                                                        "chunk_status": chunk_status,
+                                                                        "elapsed": elapsed,
+                                                                        "chunk_timeout": chunk_timeout,
+                                                                        "exception": log.parse_exception(e)})
+                        retrying_might_help = chunk_status in (ChunkStatus.CORRUPT_OUTPUT, ChunkStatus.CRASH)
+                        if try_number < CHUNK_MAX_TRIES and retrying_might_help:
+                            # Retry!
+                            continue
                         else:
-                            # For rapsearch, first remove header lines starting with '#'
-                            verification_command = "grep -v '^#' %s" % multihit_remote_outfile
-                        verification_command += " | awk '{print NF}' | sort -nu | head -n 1"
-                        min_column_number_string = command.execute_with_output(
-                            command.remote(verification_command, key_path, remote_username, instance_ip))
-                        min_column_number = self.__interpret_min_column_number_string(
-                            min_column_number_string, correct_number_of_output_columns,
-                            try_number)
+                            # End of the road.
+                            raise
+                    finally:
+                        # None chunk_status indicates code bug above.  An exception has been raised already
+                        # for it, and it says nothing about whether the alignment succeeded or not.
+                        if chunk_status != None:
+                            chunk_status_tracker(service).note_outcome(instance_ip, chunk_id, elapsed, chunk_status, try_number)
 
-                        msg = "Chunk %s output corrupt; not copying to S3. min_column_number = %d -> expected = %d. Re-start pipeline to try again." \
-                                % (chunk_id, min_column_number, correct_number_of_output_columns)
-                        assert min_column_number == correct_number_of_output_columns, msg
-
-                        command.execute(
-                            command.scp(key_path, remote_username, instance_ip,
-                                        multihit_remote_outfile, multihit_local_outfile))
-                except Exception as e:
-                    elapsed = self._elapsed_seconds(timer)
-                    log.log_event('alignment_remote_error', values={"chunk": chunk_id,
-                                                                    "try_number": try_number,
-                                                                    "elapsed": elapsed,
-                                                                    "exception": log.parse_exception(e)})
-                    if try_number >= max_tries or elapsed > CHUNK_DONT_RETRY_AFTER_SECONDS:
-                        raise e
-                    self._exponential_backoff(try_number)
-                    try_number += 1
-                    min_column_number = 0 # reset to force a retry
-
-            # Move output from remote machine to local machine
+            # Upload to s3
             with self.iostream_upload:  # Limit concurrent uploads so as not to stall the pipeline.
-                command.execute("aws s3 cp --only-show-errors %s %s/" %
-                                (multihit_local_outfile,
-                                 self.chunks_result_dir_s3))
-            log.write("finished alignment for chunk %s on %s server %s" % (chunk_id, service, instance_ip))
+                command.execute(f"aws s3 cp --only-show-errors {multihit_local_outfile} {self.chunks_result_dir_s3}/")
+            log.write(f"finished alignment for chunk {chunk_id} on {service} server {instance_ip}")
+
+        # Whether lazy or not lazy, we've now got the chunk result locally here.
         return multihit_local_outfile
-
-
-    @staticmethod
-    def _exponential_backoff(_try_number):
-        time.sleep(EXPONENTIAL_BACKOFF_MINIMUM_SECONDS + random.randint(0, EXPONENTIAL_BACKOFF_JITTER_SECONDS))
-
-
-    @staticmethod
-    def _elapsed_seconds(start_time):
-        return time.monotonic()-start_time
-
-
-    @staticmethod
-    def _start_timer():
-        return time.monotonic()

--- a/idseq_dag/steps/run_alignment_remotely.py
+++ b/idseq_dag/steps/run_alignment_remotely.py
@@ -22,7 +22,7 @@ CORRECT_NUMBER_OF_OUTPUT_COLUMNS = 12
 CHUNK_MAX_TRIES = 3
 
 # Please override this with gsnap_chunk_timeout or rapsearch_chunk_timeout in DAG json.
-# Default 30 minutes is several sigmas beyond the pale and indicates the data has to be QC-ed better.
+# Default 60 minutes is several sigmas beyond the pale and indicates the data has to be QC-ed better.
 DEFAULT_CHUNK_TIMEOUT = 60*60
 
 class PipelineStepRunAlignmentRemotely(PipelineStep):
@@ -227,7 +227,7 @@ class PipelineStepRunAlignmentRemotely(PipelineStep):
             result = target(*args)
         except:
             with mutex:
-                traceback.print_exc()
+                log.write(traceback.format_exc())
         finally:
             with mutex:
                 chunk_output_files[n] = result
@@ -288,7 +288,7 @@ class PipelineStepRunAlignmentRemotely(PipelineStep):
         """
         assert service in ("gsnap", "rapsearch2")
 
-        chunk_id = input_files[0].split(part_suffix)[-1]
+        chunk_id = int(input_files[0].split(part_suffix)[-1])
         multihit_basename = f"multihit-{service}-out{part_suffix}{chunk_id}.m8"
         multihit_local_outfile = os.path.join(self.chunks_result_dir_local, multihit_basename)
         multihit_remote_outfile = os.path.join(remote_work_dir, multihit_basename)

--- a/idseq_dag/util/server.py
+++ b/idseq_dag/util/server.py
@@ -6,8 +6,8 @@ import threading
 import traceback
 import multiprocessing
 
-from idseq_dag.util.trace_lock import TraceLock
 from contextlib import contextmanager
+from collections import defaultdict
 
 from idseq_dag.util.periodic_thread import PeriodicThread
 
@@ -20,31 +20,224 @@ MAX_POLLING_LATENCY = 10  # seconds
 MAX_INSTANCES_TO_POLL = 8
 MAX_DISPATCHES_PER_MINUTE = 10
 
+
+def _duct_tape(service_name):
+     # TODO: remove this duct tape
+    if service_name == 'rapsearch2':
+        return 'rapsearch'
+    return service_name
+
+
+class ServiceUnreliable(RuntimeError):
+    ''' Raised when the probability and cost of failures become too high relative to success. '''
+
+    def __init__(self, service, chunk_id):
+        super().__init__(f"Service {_duct_tape(service)} is unreliable, giving up for {chunk_id}.")
+
+
+class ChunkStatus:
+    SUCCESS = "success"
+    CRASH = "crash"
+    TIMEOUT = "timeout"
+    CORRUPT_OUTPUT = "corrupt_output"
+
+
+class ChunkStatusTracker:
+
+    def __init__(self, service):
+        self.lock = multiprocessing.RLock()
+        self.service = service
+        # tally[status][server_ip] contains the list of (chunk_id, elapsed, try_number) for that server and status.
+        # TODO:  A flatter map or list might be even better here.
+        self.outcome_data = {
+            ChunkStatus.SUCCESS: defaultdict(list),
+            ChunkStatus.CRASH: defaultdict(list),
+            ChunkStatus.TIMEOUT: defaultdict(list),
+            ChunkStatus.CORRUPT_OUTPUT: defaultdict(list)
+        }
+        # chunks_waiting[try_number] is the set of chunk_ids that are waiting for an ASGinstance for this try_number
+        # (initially each chunk is at try_number=1, then 2, etc...)
+        # This helps us ensure that most chunks try at least once before any retries.
+        self.chunks_waiting_lock = multiprocessing.RLock()
+        self.chunks_waiting = defaultdict(set)
+
+    def chunk_has_try_priority(self, _chunk_id, try_number):
+        # Note try_number starts counting from 1.
+        with self.chunks_waiting_lock:
+            for prior_try in range(1, try_number):
+                if self.chunks_waiting[prior_try]:
+                    return False
+        return True
+
+    def register_chunk_waiting(self, chunk_id, try_number):
+        with self.chunks_waiting_lock:
+            self.chunks_waiting[try_number].add(chunk_id)
+
+    def register_chunk_dispatched(self, chunk_id, try_number):
+        with self.chunks_waiting_lock:
+            self.chunks_waiting[try_number].discard(chunk_id)
+            # TODO:  notify if we removed the last element of try_number,
+            # when we remove the busy wait.
+
+    def note_outcome(self, instance_ip, chunk_id, elapsed, status, try_number):
+        with self.lock:
+            self.outcome_data[status][instance_ip].append((chunk_id, elapsed, try_number))
+
+    def tally_costs_by_outcome(self):
+        with self.lock:
+            outcome_counts = defaultdict(int)
+            outcome_elapsed = defaultdict(float)
+            for status, outcomes in self.outcome_data.items():
+                for _instance, instance_outcomes in outcomes.items():
+                    for _chunk_id, chunk_elapsed, _try_number in instance_outcomes:  # list of pairs
+                        outcome_counts[status] += 1
+                        outcome_elapsed[status] += chunk_elapsed
+            return outcome_counts, outcome_elapsed
+
+    def service_unreliable(self):
+        outcome_counts, outcome_elapsed = self.tally_costs_by_outcome()
+        total_count = sum(outcome_counts.values())
+        total_elapsed = sum(outcome_elapsed.values())
+        success_count = outcome_counts[ChunkStatus.SUCCESS]
+        fail_count = total_count - success_count
+        avg_elapsed_fail = (total_elapsed - outcome_elapsed[ChunkStatus.SUCCESS]) / fail_count if fail_count else 0.0
+        avg_elapsed_success = outcome_elapsed[ChunkStatus.SUCCESS] / success_count if success_count else 0.0
+        # If after 12 tries the probability of success is < 1/3, we give up.
+        if total_count >= 12 and success_count < (total_count / 3):
+            return True
+        # If after 18 tries the average time to fail is large compared to the average time to succeed,
+        # and failures are common, then it's too expensive to keep trying, so we give up.
+        if total_count >= 18 and success_count < (total_count * 2 / 3) and avg_elapsed_fail >= 0.5 * avg_elapsed_success:
+            return True
+        # Ok, keep trying.
+        return False
+
+    def servers_with_rep(self, chunk_id):
+        rep = defaultdict(int)
+        terrible = set()
+        with self.lock:
+            for status, status_outcomes in self.outcome_data.items():
+                if status == ChunkStatus.SUCCESS:
+                    # We are only interested in the failures here.
+                    continue
+                for instance_ip, instance_outcomes in status_outcomes.items():
+                    num_successes_for_ip = len(self.outcome_data[ChunkStatus.SUCCESS].get(instance_ip, []))
+                    for failed_chunk_id, _elapsed, _try_number in instance_outcomes:  # this is a list
+                        rep[instance_ip] += 1
+                        # If this instance has had 3 failures and not a single success, we declare it "terrible"
+                        # so it gets avoided.  If failures outnumber successes 4:1, also terrible.
+                        if rep[instance_ip] >= 3 and num_successes_for_ip == 0:
+                            terrible.add(instance_ip)
+                        if rep[instance_ip] >= 4 * num_successes_for_ip and num_successes_for_ip > 0:
+                            terrible.add(instance_ip)
+                        # If chunk_id previously failed on this ip, we declare the ip "terrible" so we don't retry
+                        # the chunk on the same server;  unless the failure was corrupt output, for which we allow
+                        # retries on the same server.
+                        if chunk_id == failed_chunk_id and status != ChunkStatus.CORRUPT_OUTPUT:
+                            terrible.add(instance_ip)
+        slightly_suspect = set(rep.keys()) - terrible
+        # NOTE:  When the failure is a timeout, that doesn't mean that anything is wrong with the instance!
+        # Some samples just need more time in rapsearch, and the appropriate behavior is to time-out their chunks
+        # then rerun with smaller chunks after more stringent QC has removed most reads causing the slowness.
+        # So "terrible" here means terrible FOR THIS SAMPLE's data;  not necessarily terrible for the other samples
+        # that may be running at this time.  On the other hand, it COULD mean terrible for all samples -- if
+        # the machine has become unhealthy -- but we just can't leap to that conclusion.
+        return slightly_suspect, terrible
+
+    def status_report(self, total_chunks):
+        # This is called only after the last call to self.note_outcome(),
+        # so we don't have to bother with self.lock.
+        succeeded_first_try = set()
+        succeeded_retry = set()
+        attempted = set()
+        elapsed_succcess = 0.0
+        elapsed_failure = 0.0
+        server_successes = defaultdict(int)
+        server_failures = defaultdict(int)
+        for status, outcomes in self.outcome_data.items():
+            for instance_ip, instance_outcomes in outcomes.items():
+                for chunk_id, elapsed, try_number in instance_outcomes:
+                    attempted.add(chunk_id)
+                    if status == ChunkStatus.SUCCESS:
+                        elapsed_succcess += elapsed
+                        server_successes[instance_ip] += 1
+                        if try_number == 1:
+                            succeeded_first_try.add(chunk_id)
+                        else:
+                            succeeded_retry.add(chunk_id)
+                    else:
+                        elapsed_failure += elapsed
+                        server_failures[instance_ip] += 1
+        failed = attempted - succeeded_first_try - succeeded_retry
+        elapsed_avg_success = 0.0
+        elapsed_avg_failure = 0.0
+        if succeeded_first_try or succeeded_retry:
+            elapsed_avg_success = elapsed_succcess / (len(succeeded_first_try) + len(succeeded_retry))
+        if failed:
+            elapsed_avg_failure = elapsed_failure / len(failed)
+        server_stats = {}
+        for instance_ip in sorted(set(server_successes.keys()) | set(server_failures.keys())):
+            server_stats[instance_ip] = {
+                'SUCCESSES': server_successes.get(instance_ip, 0),
+                'FAILURES': server_failures.get(instance_ip, 0)  # this way we don't affect len(server_failures)
+            }
+        report = {
+            'TOTAL_CHUNKS': total_chunks,
+            'CHUNKS_ATTEMPTED': len(attempted),
+            'CHUNKS_SUCCEEDED_ON_FIRST_TRY': len(succeeded_first_try),
+            'CHUNKS_SUCCEEDED_ON_RETRY': len(succeeded_retry),
+            'CHUNKS_FAILED': len(failed),
+            'CHUNKS_ELAPSED_AVG_SUCCESS': elapsed_avg_success,
+            'CHUNKS_ELAPSED_AVG_FAILURE': elapsed_avg_failure,
+            'TOTAL_SERVERS': len(server_stats),
+            'SERVERS_WITH_FAILURES': len(server_failures),
+            'SERVER_STATS': server_stats
+        }
+        return report
+
+    def log_stats(self, total_chunks):
+        # This happens after the last call to tracker.note_outcome(), making it
+        # safe to access tracker.outcome_data directly without holding a lock.
+        # But, why not.
+        with self.lock:
+            report = self.status_report(total_chunks)
+            report_text = json.dumps(report, indent=4)
+            outcomes_text = json.dumps(self.outcome_data, indent=4)
+        log.write(f"STATUS REPORT FOR {self.service}: " + report_text)
+        log.write(f"FULL OUTCOME DATA FOR {self.service}: " + outcomes_text)
+
+
+def chunk_status_tracker(service, #pylint: disable=dangerous-default-value
+                         trackers={
+                             "gsnap": ChunkStatusTracker("gsnap"),
+                             "rapsearch": ChunkStatusTracker("rapsearch")
+                         }):
+    return trackers[_duct_tape(service)]
+
+
 @command.retry
 def get_server_ips_work(service_name, environment, draining_tag):
     ''' return a dict of relevant instance IPs to instance IDs '''
-    tag = "service"
     value = "%s-%s" % (service_name, environment)
     describe_json = json.loads(
         command.execute_with_output(
-            "aws ec2 describe-instances --filters 'Name=tag:%s,Values=%s' 'Name=instance-state-name,Values=running'"
-            % (tag, value)))
+            f"aws ec2 describe-instances --filters 'Name=tag:service,Values={value}' 'Name=instance-state-name,Values=running'"))
     server_ips = {
         instance["NetworkInterfaces"][0]["PrivateIpAddress"]: instance["InstanceId"]
-        for reservation in describe_json["Reservations"] 
+        for reservation in describe_json["Reservations"]
         for instance in reservation["Instances"]
         if draining_tag not in [tag["Key"] for tag in instance["Tags"]]
     }
     return server_ips
 
 
-def get_server_ips(service_name,
+def get_server_ips(service_name, #pylint: disable=dangerous-default-value
                    environment,
                    max_interval_between_describe_instances,
                    draining_tag,
                    aggressive=False,
                    cache={},
-                   mutex=TraceLock("get_server_ips", threading.RLock())):  #pylint: disable=dangerous-default-value
+                   mutex=threading.RLock()):
     try:
         with mutex:
             if aggressive:
@@ -65,7 +258,7 @@ def get_server_ips(service_name,
         return []
 
 
-def wait_for_server_ip_work(service_name,
+def wait_for_server_ip_work(service_name, #pylint: disable=dangerous-default-value
                             key_path,
                             remote_username,
                             environment,
@@ -73,20 +266,23 @@ def wait_for_server_ip_work(service_name,
                             chunk_id,
                             max_interval_between_describe_instances,
                             draining_tag,
-                            had_to_wait=[False]):  #pylint: disable=dangerous-default-value
+                            had_to_wait=[False]):
     while True:
-        log.write(
-            "Chunk {chunk_id} of {service_name} is at third gate".format(
-                chunk_id=chunk_id, service_name=service_name))
+        log.write(f"Chunk {chunk_id} of {service_name} is at third gate")
         instance_ip_id_dict = get_server_ips(
             service_name, environment,
-            max_interval_between_describe_instances, draining_tag, 
+            max_interval_between_describe_instances, draining_tag,
             aggressive=had_to_wait[0])
-        instance_ips = random.sample(instance_ip_id_dict.keys(),
+        all_servers = set(instance_ip_id_dict.keys())
+        slightly_suspect, terrible = chunk_status_tracker(service_name).servers_with_rep(chunk_id)
+        slightly_suspect &= all_servers
+        terrible &= all_servers
+        presumed_good = all_servers - terrible
+        instance_ips = random.sample(presumed_good,
                                      min(MAX_INSTANCES_TO_POLL,
-                                         len(instance_ip_id_dict)))
+                                         len(presumed_good)))
         ip_nproc_dict = {}
-        dict_mutex = TraceLock("wait_for_server_ip_work", threading.RLock())
+        dict_mutex = threading.RLock()
         dict_writable = True
 
         def poll_server(ip):
@@ -118,9 +314,7 @@ def wait_for_server_ip_work(service_name,
                 format(
                     len(ip_nproc_dict), len(poller_threads),
                     len([pt for pt in poller_threads if pt.isAlive()])))
-        log.write(
-            "Chunk {chunk_id} of {service_name} is at fourth gate".format(
-                chunk_id=chunk_id, service_name=service_name))
+        log.write(f"Chunk {chunk_id} of {service_name} is at fourth gate")
         if not ip_nproc_dict:
             have_capacity = False
         else:
@@ -134,23 +328,32 @@ def wait_for_server_ip_work(service_name,
             for ip, nproc in ip_nproc_dict.items():
                 free_slots = max_concurrent - nproc
                 if free_slots > 0:
+                    # TODO:  If we are concerned about cost, we could bias this distribution toward the middle,
+                    # so machines that have no jobs running are not preferred so much (this way we can
+                    # reap them in the autoscaler sooner).   The only reason for not doing that yet is
+                    # that we have a race condition (by design) here and that would increase the overload rate.
+                    # TODO:  For reliability, we can factor in the historic success rate and efficiency
+                    # of the machine in addition to its current load.
                     weight = 2**free_slots - 1
+                    if ip in slightly_suspect:
+                        # minimize the probability of choosing a server with a bad reputation
+                        weight = 1
                     urn.extend([ip] * weight)
             min_nproc_ip = random.choice(urn)
             free_slots = max_concurrent - ip_nproc_dict[min_nproc_ip]
-            log.write("%s server %s has capacity %d. Kicking off " %
-                         (service_name, min_nproc_ip, free_slots))
+            log.write(f"{service_name} server {min_nproc_ip} has capacity {free_slots}. Kicking off ")
             return min_nproc_ip, instance_ip_id_dict[min_nproc_ip]
         else:
+            if len(terrible) > len(all_servers) * 2 / 3.0:
+                raise ServiceUnreliable(service_name, chunk_id)
             had_to_wait[0] = True
             wait_seconds = random.randint(
                 max(20, MAX_POLLING_LATENCY), max(60, MAX_POLLING_LATENCY))
-            log.write("%s servers busy. Wait for %d seconds" %
-                         (service_name, wait_seconds))
+            log.write(f"{service_name} servers busy. Wait for {wait_seconds} seconds")
             time.sleep(wait_seconds)
 
 
-def wait_for_server_ip(service_name,
+def wait_for_server_ip(service_name, #pylint: disable=dangerous-default-value
                        key_path,
                        remote_username,
                        environment,
@@ -158,32 +361,29 @@ def wait_for_server_ip(service_name,
                        chunk_id,
                        max_interval_between_describe_instances,
                        draining_tag,
-                       mutex=TraceLock("wait_for_server_ip", threading.RLock()),
+                       mutex=threading.RLock(),
                        mutexes={},
-                       last_checks={}):  #pylint: disable=dangerous-default-value
+                       last_checks={}):
     # We rate limit these to ensure fairness across jobs regardless of job size
-    if service_name == 'rapsearch2':
-        # TODO: remove this duct tape
-        service_name = 'rapsearch'
+    service_name = _duct_tape(service_name)
     with mutex:
         if service_name not in mutexes:
-            mutexes[service_name] = TraceLock(f"wait_for_server_ip: {service_name}", threading.RLock())
+            mutexes[service_name] = threading.RLock()  # TraceLock not required because "gate" prints are sufficient.
             last_checks[service_name] = [None]
         lc = last_checks[service_name]
         mx = mutexes[service_name]
-    log.write("Chunk {chunk_id} of {service_name} is at second gate".format(
-        chunk_id=chunk_id, service_name=service_name))
+    log.write(f"Chunk {chunk_id} of {service_name} is at second gate")
     with mx:
         if lc[0] is not None:
             sleep_time = (60.0 / MAX_DISPATCHES_PER_MINUTE) - (
                 time.time() - lc[0])
+            # At least pi seconds of sleep to keep this chunk from racing with the previous one to the same server.
+            sleep_time = max(sleep_time, 3.141519)
             if sleep_time > 0:
-                log.write(
-                    "Sleeping for {:3.1f} seconds to rate-limit wait_for_server_ip.".
-                    format(sleep_time))
+                log.write(f"Sleeping for {sleep_time:3.1f} seconds to rate-limit wait_for_server_ip.")
                 time.sleep(sleep_time)
+        # if we had to wait above, that counts toward the rate limit delay
         lc[0] = time.time()
-        # if we had to wait here, that counts toward the rate limit delay
         result = wait_for_server_ip_work(service_name, key_path,
                                          remote_username, environment,
                                          max_concurrent, chunk_id,
@@ -212,13 +412,31 @@ def delete_tag_with_retries(instance_iD, tag_key):
 
 
 @contextmanager
-def ASGInstance(service, key_path, remote_username, environment, max_concurrent, chunk_id,
-                max_interval_between_describe_instances,
-                job_tag_prefix,
-                job_tag_refresh_seconds,
-                draining_tag):
-    instance_ip, instance_iD = wait_for_server_ip(service, key_path, remote_username, environment, max_concurrent, chunk_id,
-        max_interval_between_describe_instances, draining_tag)
+def ASGInstance(service, key_path, remote_username, environment, chunk_id, try_number, additional_attributes):
+    max_concurrent = additional_attributes["max_concurrent"]
+    max_interval_between_describe_instances = additional_attributes.get("max_interval_between_describe_instances", 900)
+    job_tag_prefix = additional_attributes.get("job_tag_prefix", "RunningIDseqBatchJob_")
+    job_tag_refresh_seconds = additional_attributes.get("job_tag_refresh_seconds", 600)
+    draining_tag = additional_attributes.get("draining_tag", "draining")
+    tracker = chunk_status_tracker(service)
+    if tracker.service_unreliable():
+        raise ServiceUnreliable(service, chunk_id)
+    tracker.register_chunk_waiting(chunk_id, try_number)
+    try:
+        t_start = time.time()
+        t_print = t_start
+        # This delay helps prioritize chunks that still haven't had their first try.
+        if try_number > 1:
+            time.sleep(5.0)
+        while not tracker.chunk_has_try_priority(chunk_id, try_number):
+            if time.time() - t_print >= 60:
+                t_print = time.time()
+                log.write(f"try {try_number} for chunk {chunk_id} has been waiting for {t_print - t_start} seconds for other chunks' prior tries to complete")
+            time.sleep(15.0)
+        instance_ip, instance_iD = wait_for_server_ip(service, key_path, remote_username, environment, max_concurrent, chunk_id,
+                                                      max_interval_between_describe_instances, draining_tag)
+    finally:
+        tracker.register_chunk_dispatched(chunk_id, try_number)
     log.write(f"starting alignment for chunk {chunk_id} on {service} server {instance_ip}")
     job_tag_key, job_tag_value_func = build_job_tag(job_tag_prefix, chunk_id)
     t = PeriodicThread(target=create_tag, wait_seconds=job_tag_refresh_seconds, stop_latency_seconds=60,
@@ -230,3 +448,46 @@ def ASGInstance(service, key_path, remote_username, environment, max_concurrent,
         t.stop()
         t.join()
         delete_tag_with_retries(instance_iD, job_tag_key)
+
+
+def run_test():
+    print("Hello. Testing idseq_dag.utils.server")
+    chunk_status_tracker("rapsearch2").note_outcome("10.10.11.190", 101, 118.0, ChunkStatus.SUCCESS, 1)
+    chunk_status_tracker("rapsearch2").note_outcome("10.10.11.190", 102, 119.0, ChunkStatus.SUCCESS, 1)
+    chunk_status_tracker("rapsearch2").note_outcome("10.10.11.191", 103, 109.0, ChunkStatus.SUCCESS, 1)
+    chunk_status_tracker("rapsearch2").note_outcome("10.10.11.191", 104, 9.0, ChunkStatus.CRASH, 1)
+    chunk_status_tracker("rapsearch2").note_outcome("10.10.11.192", 104, 140.0, ChunkStatus.CORRUPT_OUTPUT, 2)
+    chunk_status_tracker("rapsearch2").note_outcome("10.10.11.192", 104, 100.0, ChunkStatus.SUCCESS, 3)
+    chunk_status_tracker("rapsearch2").note_outcome("10.10.11.192", 105, 98.0, ChunkStatus.SUCCESS, 1)
+    chunk_status_tracker("rapsearch2").note_outcome("10.10.11.191", 106, 18.0, ChunkStatus.CRASH, 1)
+    chunk_status_tracker("rapsearch2").note_outcome("10.10.11.191", 107, 180.0, ChunkStatus.TIMEOUT, 1)
+    chunk_status_tracker("rapsearch2").register_chunk_waiting(100, 1)
+    chunk_status_tracker("rapsearch2").register_chunk_waiting(100, 1)
+    chunk_status_tracker("rapsearch2").register_chunk_waiting(99, 2)
+    assert True == chunk_status_tracker("rapsearch2").chunk_has_try_priority(100, 1)
+    assert False == chunk_status_tracker("rapsearch2").chunk_has_try_priority(99, 2)
+    chunk_status_tracker("rapsearch2").register_chunk_dispatched(100, 1)
+    assert True == chunk_status_tracker("rapsearch2").chunk_has_try_priority(99, 2)
+    input_chunks = {
+        'rapsearch2': set(range(110)),
+        'gsnap': set(range(30)),
+    }
+    chunk_status_tracker("gsnap").note_outcome("10.10.12.121", 6, 18.0, ChunkStatus.CRASH, 1)
+    chunk_status_tracker("gsnap").note_outcome("10.10.12.120", 7, 180.0, ChunkStatus.TIMEOUT, 1)
+    chunk_status_tracker("gsnap").note_outcome("10.10.12.121", 7, 180.0, ChunkStatus.CRASH, 2)
+    chunk_status_tracker("gsnap").note_outcome("10.10.12.120", 6, 18.0, ChunkStatus.SUCCESS, 2)
+    for chunk_id in range(9, 18):
+        chunk_status_tracker("gsnap").note_outcome("10.10.12.120", chunk_id, 88.8, ChunkStatus.CRASH, 1)
+        assert chunk_status_tracker("gsnap").service_unreliable() == (chunk_id >= 16), chunk_id
+    for service in ("rapsearch2", "gsnap"):
+        tracker = chunk_status_tracker(service)
+        tracker_report = tracker.status_report(len(input_chunks[service]))
+        print(f"STATUS REPORT FOR {service}: " + json.dumps(tracker_report, indent=4))
+        print(f"FULL OUTCOME DATA FOR {service}: " + json.dumps(tracker.outcome_data, indent=4))
+        for chunk_id in [104, 105, 106]:
+            print(f"Servers with rep for {chunk_id}: {tracker.servers_with_rep(chunk_id)}")
+        assert tracker.service_unreliable() == (service == "gsnap")
+
+
+if __name__ == "__main__":
+    run_test()


### PR DESCRIPTION
Enforce chunk timeout 60 min.

Retry crashed or corrupt output chunks (but not timed out chunks).   Ensure (mostly) that all chunks get their first try before any retries proceed.

Make sure that a crashed chunk is not retried on the same server where it first crashed.   If no other servers available, give up.   If the chunk produced corrupt output (without crashing) it may be retried on the same server.

If 3 or more tries (across all chunks) have failed on a given server, and none have succeded, avoid that server.   If more than 2/3 of servers have to be avoided, give up.

If some failure have occurred on a server (but fewer than 3), minimize the probability of choosing that server again -- but choose it if all other servers are fully loaded.

If after 12 tries (across all chunks) the success rate is too low or the failure cost is too high, give up.

Log a status report with success/failure/elapsed time stats per chunk and server, for each service.