### PR TITLE
Add support to a new header pattern

### DIFF
--- a/idseq_dag/steps/run_star.py
+++ b/idseq_dag/steps/run_star.py
@@ -10,7 +10,7 @@ import idseq_dag.util.s3 as s3
 import idseq_dag.util.count as count
 import idseq_dag.util.validate_constants as vc
 
-RE_SPLIT = re.compile('[/\t]')
+RE_SPLIT = re.compile('(/[12])?\t')
 
 class PipelineStepRunStar(PipelineStep):
     """ Implements the step for running STAR.

--- a/idseq_dag/steps/run_star.py
+++ b/idseq_dag/steps/run_star.py
@@ -1,6 +1,7 @@
 import multiprocessing
 import os
 import json
+import re
 
 from idseq_dag.engine.pipeline_step import PipelineStep
 import idseq_dag.util.command as command
@@ -8,6 +9,8 @@ import idseq_dag.util.log as log
 import idseq_dag.util.s3 as s3
 import idseq_dag.util.count as count
 import idseq_dag.util.validate_constants as vc
+
+RE_SPLIT = re.compile('[/\t]')
 
 class PipelineStepRunStar(PipelineStep):
     """ Implements the step for running STAR.
@@ -17,6 +20,7 @@ class PipelineStepRunStar(PipelineStep):
     Note that these attributes cannot be set in the __init__ method because required
     file path information only becomes available once the wait_for_input_files() has run.
     """
+
     def __init__(self, *args):
         super().__init__(*args)
         self.sequence_input_files = None
@@ -202,6 +206,10 @@ class PipelineStepRunStar(PipelineStep):
         return output_fnames
 
     @staticmethod
+    def extract_rid(s):
+        return RE_SPLIT.split(s, 1)[0].strip()
+
+    @staticmethod
     def get_read(f):
         # The FASTQ/FASTA format specifies that each read consists of 4/2 lines,
         # the first of which begins with @/> followed by read ID.
@@ -209,12 +217,12 @@ class PipelineStepRunStar(PipelineStep):
         line = f.readline()
         if line:
             if line[0] == 64:  # Equivalent to '@', fastq format
-                rid = line.decode('utf-8').split('\t', 1)[0].strip()
+                rid = PipelineStepRunStar.extract_rid(line.decode('utf-8'))
                 read.append(line)
                 for i in range(3):
                     read.append(f.readline())
             elif line[0] == 62: # Equivalent to '>', fasta format
-                rid = line.decode('utf-8').split('\t', 1)[0].strip()
+                rid = PipelineStepRunStar.extract_rid(line.decode('utf-8'))
                 read.append(line)
                 read.append(f.readline())
             else:

--- a/tests/unit/steps/test_run_star.py
+++ b/tests/unit/steps/test_run_star.py
@@ -1,0 +1,21 @@
+import unittest
+
+# Class under test
+from idseq_dag.steps.run_star import PipelineStepRunStar
+
+class TestPipelineStepRunStar(unittest.TestCase):
+    '''Tests for `util/run_star.py`'''
+
+    # @patch('idseq_dag.steps.run_alignment_remotely.server.ASGInstance')
+    def test_extract_rid(self):
+        '''Extract rid from header string'''
+        param_list = [
+            ("@K11111:222:XXXXXXXXX:3:4444:5555:00000/2\t00", "@K11111:222:XXXXXXXXX:3:4444:5555:00000"),
+            ("@K11111:222:XXXXXXXXX:3:4444:5555:00000\t00", "@K11111:222:XXXXXXXXX:3:4444:5555:00000"),
+            (">K11111:222:XXXXXXXXX:3:4444:5555:00000\t00", ">K11111:222:XXXXXXXXX:3:4444:5555:00000")
+        ]
+        for line, expected in param_list:
+            with self.subTest(line=line, expected=expected):
+                rid = PipelineStepRunStar.extract_rid(line)
+
+                self.assertEqual(rid, expected)


### PR DESCRIPTION
We received a sample that have `/1` and `/2` in the headers, as in:  

```
# file_R1.fastq
@K11111:222:XXXXXXXXX:3:4444:5555:00000/1    00

# file_R2.fastq
@K11111:222:XXXXXXXXX:3:4444:5555:00000/2    00
```

The old command was splitting the name using `\t`, however this number is before it, so it couldn't find a match.