### PR TITLE
Fail gracefully if read pairing is broken

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,11 +226,13 @@ TODO: Move this code over to the idseq-dag repo.
 
 ## Release notes
 
-- 3.7.5
+- 3.7.6
+   - Allow up to 50% of read pairs to be fixed by the pair synchronizer after STAR.
+     Fail if the order of more than 50% of pairs is broken.
+
+- 3.7.0 .. 3.7.5
    - Validate whether input files to a pipeline step contain a sufficient number of reads.
      Output invalid_step_input.json file if validation fails.
-
-- 3.7.0 .. 3.7.4
    - Log output in JSON format. Change TraceLock log level to DEBUG.
    - Upgrade to python 3.7.3
    - Remove db_hack. Standardize db_open/db_assert_table/db_close log entries.

--- a/README.md
+++ b/README.md
@@ -227,9 +227,7 @@ TODO: Move this code over to the idseq-dag repo.
 ## Release notes
 
 - 3.7.6
-   - Allow up to 50% of read pairs to be fixed by the pair synchronizer after STAR.
-     Fail with an informative user error if more than 50% of pairs are broken,
-     since there is clearly something wrong with the input files in that case.
+   - Fail with an informative user error if the input contains broken read pairs.
 
 - 3.7.0 .. 3.7.5
    - Validate whether input files to a pipeline step contain a sufficient number of reads.

--- a/README.md
+++ b/README.md
@@ -228,7 +228,8 @@ TODO: Move this code over to the idseq-dag repo.
 
 - 3.7.6
    - Allow up to 50% of read pairs to be fixed by the pair synchronizer after STAR.
-     Fail if the order of more than 50% of pairs is broken.
+     Fail with an informative user error if more than 50% of pairs are broken,
+     since there is clearly something wrong with the input files in that case.
 
 - 3.7.0 .. 3.7.5
    - Validate whether input files to a pipeline step contain a sufficient number of reads.

--- a/idseq_dag/__init__.py
+++ b/idseq_dag/__init__.py
@@ -1,2 +1,2 @@
 ''' idseq_dag '''
-__version__ = "3.7.5"
+__version__ = "3.7.6"

--- a/idseq_dag/engine/pipeline_step.py
+++ b/idseq_dag/engine/pipeline_step.py
@@ -21,6 +21,7 @@ class StepStatus(IntEnum):
 class InputFileErrors(Enum):
     ''' This error will be used by the front-end to display a user-friendly error message '''
     INSUFFICIENT_READS = "INSUFFICIENT_READS"
+    BROKEN_PAIRS = "BROKEN_PAIRS"
 
 class InvalidInputFileError(Exception):
     def __init__(self, json):

--- a/idseq_dag/steps/run_star.py
+++ b/idseq_dag/steps/run_star.py
@@ -179,13 +179,14 @@ class PipelineStepRunStar(PipelineStep):
         return outstanding_r0, outstanding_r1, max_mem, total
 
     @staticmethod
-    def sync_pairs(fastq_files):
+    def sync_pairs(fastq_files, max_discrepant_fraction=0):
         """The given fastq_files contain the same read IDs but in different order.
-        Output the same data in synchronized order. Omit up to max_discrepancies
-        if necessary. If more must be suppressed, raise assertion.
+        Output the same data in synchronized order. Omit any reads missing their mate
+        up to max_discrepant_fraction if necessary. If more must be suppressed,
+        indicate it in the second value of the returned tuple.
         """
         if len(fastq_files) != 2:
-            return fastq_files
+            return fastq_files, False
 
         output_fnames = [ifn + ".synchronized_pairs.fq" for ifn in fastq_files]
         with open(fastq_files[0], "rb") as if_0, open(fastq_files[1],
@@ -209,7 +210,7 @@ class PipelineStepRunStar(PipelineStep):
                 fqf=fastq_files,
                 example=(outstanding_r0 or outstanding_r1).popitem()[0])
             log.write(msg)
-        too_discrepant = (discrepancies_count > 0.5 * total)
+        too_discrepant = (discrepancies_count > max_discrepant_fraction * total)
         return output_fnames, too_discrepant
 
     @staticmethod

--- a/idseq_dag/steps/run_star.py
+++ b/idseq_dag/steps/run_star.py
@@ -202,7 +202,7 @@ class PipelineStepRunStar(PipelineStep):
                 fqf=fastq_files,
                 example=(outstanding_r0 or outstanding_r1).popitem()[0])
             log.write(msg)
-            assert discrepancies_count <= max_discrepancies, msg
+            # assert discrepancies_count <= max_discrepancies, msg
         return output_fnames
 
     @staticmethod

--- a/idseq_dag/steps/run_star.py
+++ b/idseq_dag/steps/run_star.py
@@ -209,7 +209,7 @@ class PipelineStepRunStar(PipelineStep):
                 fqf=fastq_files,
                 example=(outstanding_r0 or outstanding_r1).popitem()[0])
             log.write(msg)
-        too_discrepant = (discrepancies_count > 0.01 * total)
+        too_discrepant = (discrepancies_count > 0.5 * total)
         return output_fnames, too_discrepant
 
     @staticmethod

--- a/idseq_dag/steps/run_star.py
+++ b/idseq_dag/steps/run_star.py
@@ -209,7 +209,7 @@ class PipelineStepRunStar(PipelineStep):
                 fqf=fastq_files,
                 example=(outstanding_r0 or outstanding_r1).popitem()[0])
             log.write(msg)
-        too_discrepant = (discrepancies_count > 0.5 * total)
+        too_discrepant = (discrepancies_count > 0.01 * total)
         return output_fnames, too_discrepant
 
     @staticmethod

--- a/idseq_dag/steps/run_star.py
+++ b/idseq_dag/steps/run_star.py
@@ -163,7 +163,7 @@ class PipelineStepRunStar(PipelineStep):
             r1, r1id = PipelineStepRunStar.get_read(if1)
             if not r0 and not r1:
                 break
-            total += 1
+            total += 2
             if r0id == r1id:
                 # If the input pairs are already synchronized, we take this
                 # branch on every iteration.


### PR DESCRIPTION
Goes with https://github.com/chanzuckerberg/idseq-web/pull/2432.
Surface an informative error message to idseq-web if there are broken pairs.