### PR TITLE
Upload step-level updates during pipeline run

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ or `python3 -m unittest tests/<module_file> ` for testing individual modules.
 ## DAG Execution Details
 
 ### Composing an example dag json file
-There are four basic elements of an IdSeq Dag
-
+There are five basic elements of an IdSeq Dag
+ - **name**: the name of the IdSeq Dag.
  - **output_dir_s3**: the s3 directory where the output files will be copied to.
  - **targets**: the outputs that are to be generated through dag execution. Each target consists of a list of files that will be copied to *output_dir_s3*
  - **steps**: the steps that will be executed in order to generate the targets. For each step, the following attributes can be specified:
@@ -71,6 +71,7 @@ The following is an example dag for generating alignment output for idseq. The *
 
 ```
 {
+  "name": "alignment",
   "output_dir_s3": "s3://idseq-samples-prod/samples/12/5815/results_test",
   "targets": {
     "host_filter_out": [

--- a/examples/accession2taxid_dag_test.json
+++ b/examples/accession2taxid_dag_test.json
@@ -1,4 +1,5 @@
 {
+  "name": "",
   "output_dir_s3": "s3://idseq-samples-development/markazhang/accession_test/2018-12-01",
   "targets": {
     "accession2taxid_input": [

--- a/examples/accession2taxid_dag_test.json
+++ b/examples/accession2taxid_dag_test.json
@@ -1,5 +1,5 @@
 {
-  "name": "",
+  "name": "accession2taxid_dag_test",
   "output_dir_s3": "s3://idseq-samples-development/markazhang/accession_test/2018-12-01",
   "targets": {
     "accession2taxid_input": [

--- a/examples/amr_human_sample_paired_rds_dag.json
+++ b/examples/amr_human_sample_paired_rds_dag.json
@@ -1,4 +1,5 @@
 {
+  "name": "",
   "output_dir_s3": "s3://idseq-samples-prod/samples/12/5815/postprocess_test",
   "targets": {
     "srst2_out": ["out.log", "out__genes__ARGannot_r2__results.txt", "out__fullgenes__ARGannot_r2__results.txt", "amr_processed_results.csv", "amr_summary_results.csv"],

--- a/examples/amr_human_sample_paired_rds_dag.json
+++ b/examples/amr_human_sample_paired_rds_dag.json
@@ -1,5 +1,5 @@
 {
-  "name": "",
+  "name": "amr_human_sample_paired_rds_dag",
   "output_dir_s3": "s3://idseq-samples-prod/samples/12/5815/postprocess_test",
   "targets": {
     "srst2_out": ["out.log", "out__genes__ARGannot_r2__results.txt", "out__fullgenes__ARGannot_r2__results.txt", "amr_processed_results.csv", "amr_summary_results.csv"],

--- a/examples/amr_water_sample_single_rd_dag.json
+++ b/examples/amr_water_sample_single_rd_dag.json
@@ -1,5 +1,5 @@
 {
-  "name": "",
+  "name": "amr_water_sample_single_rd_dag",
   "output_dir_s3": "s3://idseq-samples-prod/samples/12/5815/postprocess_test",
   "targets": {
     "srst2_out": ["out.log", "out__genes__ARGannot_r2__results.txt", "out__fullgenes__ARGannot_r2__results.txt", "amr_processed_results.csv", "amr_summary_results.csv"],

--- a/examples/amr_water_sample_single_rd_dag.json
+++ b/examples/amr_water_sample_single_rd_dag.json
@@ -1,4 +1,5 @@
 {
+  "name": "",
   "output_dir_s3": "s3://idseq-samples-prod/samples/12/5815/postprocess_test",
   "targets": {
     "srst2_out": ["out.log", "out__genes__ARGannot_r2__results.txt", "out__fullgenes__ARGannot_r2__results.txt", "amr_processed_results.csv", "amr_summary_results.csv"],

--- a/examples/assemble_blast.json
+++ b/examples/assemble_blast.json
@@ -1,4 +1,5 @@
 {
+  "name": "",
   "output_dir_s3": "s3://idseq-samples-development/yunfang/sample_1793/assembly_blast/",
   "targets": {
     "host_filter_out": [

--- a/examples/assemble_blast.json
+++ b/examples/assemble_blast.json
@@ -1,5 +1,5 @@
 {
-  "name": "",
+  "name": "assemble_blast",
   "output_dir_s3": "s3://idseq-samples-development/yunfang/sample_1793/assembly_blast/",
   "targets": {
     "host_filter_out": [

--- a/examples/assembly_dag.json
+++ b/examples/assembly_dag.json
@@ -1,5 +1,5 @@
 {
-  "name": "",
+  "name": "assembly_dag",
   "output_dir_s3": "s3://idseq-samples-development/yunfang/sample_11285/assembly/",
   "targets": {
     "host_filter_out": [

--- a/examples/assembly_dag.json
+++ b/examples/assembly_dag.json
@@ -1,4 +1,5 @@
 {
+  "name": "",
   "output_dir_s3": "s3://idseq-samples-development/yunfang/sample_11285/assembly/",
   "targets": {
     "host_filter_out": [

--- a/examples/build_custom_blast_index.json
+++ b/examples/build_custom_blast_index.json
@@ -1,5 +1,5 @@
 {
-  "name": "",
+  "name": "build_custom_blast_index",
   "output_dir_s3": "s3://idseq-samples-development/yunfang/rvdb/2018-12-01",
   "targets": {
     "dummy_input": [

--- a/examples/build_custom_blast_index.json
+++ b/examples/build_custom_blast_index.json
@@ -1,4 +1,5 @@
 {
+  "name": "",
   "output_dir_s3": "s3://idseq-samples-development/yunfang/rvdb/2018-12-01",
   "targets": {
     "dummy_input": [

--- a/examples/download_accessions.json
+++ b/examples/download_accessions.json
@@ -1,4 +1,5 @@
 {
+  "name": "",
   "output_dir_s3": "s3://idseq-samples-development/yunfang/samples_4534/download_accessions_test",
   "targets": {
     "gsnap_out": [

--- a/examples/download_accessions.json
+++ b/examples/download_accessions.json
@@ -1,5 +1,5 @@
 {
-  "name": "",
+  "name": "download_accessions",
   "output_dir_s3": "s3://idseq-samples-development/yunfang/samples_4534/download_accessions_test",
   "targets": {
     "gsnap_out": [

--- a/examples/example_dag.json
+++ b/examples/example_dag.json
@@ -1,4 +1,5 @@
 {
+  "name": "host_filtering",
   "output_dir_s3": "s3://idseq-samples-prod/1/10/results",
   "targets": {
     "fastqs": ["fastq1.gz", "fastq2.gz"],

--- a/examples/example_dag.json
+++ b/examples/example_dag.json
@@ -1,5 +1,5 @@
 {
-  "name": "host_filtering",
+  "name": "example_dag",
   "output_dir_s3": "s3://idseq-samples-prod/1/10/results",
   "targets": {
     "fastqs": ["fastq1.gz", "fastq2.gz"],

--- a/examples/generate_coverage_viz.json
+++ b/examples/generate_coverage_viz.json
@@ -1,5 +1,5 @@
 {
-  "name": "",
+  "name": "generate_coverage_viz",
   "output_dir_s3": "s3://idseq-samples-development/markazhang/samples_12452/generate_coverage_viz_test",
   "targets": {
     "refined_gsnap_in": [

--- a/examples/generate_coverage_viz.json
+++ b/examples/generate_coverage_viz.json
@@ -1,4 +1,5 @@
 {
+  "name": "",
   "output_dir_s3": "s3://idseq-samples-development/markazhang/samples_12452/generate_coverage_viz_test",
   "targets": {
     "refined_gsnap_in": [

--- a/examples/generic_test_dag.json
+++ b/examples/generic_test_dag.json
@@ -1,4 +1,5 @@
 {
+  "name": "",
   "output_dir_s3": "",
   "targets": {
     "fastqs": ["1.fastq.gz", "2.fastq.gz"],

--- a/examples/generic_test_dag.json
+++ b/examples/generic_test_dag.json
@@ -1,5 +1,5 @@
 {
-  "name": "",
+  "name": "generic_test_dag",
   "output_dir_s3": "",
   "targets": {
     "fastqs": ["1.fastq.gz", "2.fastq.gz"],

--- a/examples/host_filter_dag.json
+++ b/examples/host_filter_dag.json
@@ -1,4 +1,5 @@
 {
+  "name": "host_filtering",
   "output_dir_s3":
     "s3://idseq-samples-prod/samples/12/5815/results_test",
   "targets": {

--- a/examples/host_filter_dag.json
+++ b/examples/host_filter_dag.json
@@ -1,5 +1,5 @@
 {
-  "name": "host_filtering",
+  "name": "host_filter_dag",
   "output_dir_s3":
     "s3://idseq-samples-prod/samples/12/5815/results_test",
   "targets": {

--- a/examples/host_genome.json
+++ b/examples/host_genome.json
@@ -1,5 +1,5 @@
 {
-  "name": "",
+  "name": "host_genome",
   "output_dir_s3": "s3://idseq-database/host_filter/pig/2019-02-06",
   "targets": {
     "host_fasta": ["GCA_002844635.1_USMARCv1.0_genomic.fna.gz"],

--- a/examples/host_genome.json
+++ b/examples/host_genome.json
@@ -1,4 +1,5 @@
 {
+  "name": "",
   "output_dir_s3": "s3://idseq-database/host_filter/pig/2019-02-06",
   "targets": {
     "host_fasta": ["GCA_002844635.1_USMARCv1.0_genomic.fna.gz"],

--- a/examples/non_host_alignment_dag.json
+++ b/examples/non_host_alignment_dag.json
@@ -1,4 +1,5 @@
 {
+  "name": "alignment",
   "output_dir_s3": "s3://idseq-samples-staging/samples/114/1118/results_test",
   "targets": {
     "host_filter_out": [

--- a/examples/non_host_alignment_dag.json
+++ b/examples/non_host_alignment_dag.json
@@ -1,5 +1,5 @@
 {
-  "name": "alignment",
+  "name": "non_host_alignment_dag",
   "output_dir_s3": "s3://idseq-samples-staging/samples/114/1118/results_test",
   "targets": {
     "host_filter_out": [

--- a/examples/nonhost_fastq.json
+++ b/examples/nonhost_fastq.json
@@ -1,4 +1,5 @@
 {
+  "name": "",
   "output_dir_s3": "s3://idseq-samples-development/markazhang/samples_12216/expt_test",
   "targets": {
     "fastqs": ["RR004_water_2_S23_R1_001.fastq", "RR004_water_2_S23_R2_001.fastq"],

--- a/examples/nonhost_fastq.json
+++ b/examples/nonhost_fastq.json
@@ -1,5 +1,5 @@
 {
-  "name": "",
+  "name": "nonhost_fastq",
   "output_dir_s3": "s3://idseq-samples-development/markazhang/samples_12216/expt_test",
   "targets": {
     "fastqs": ["RR004_water_2_S23_R1_001.fastq", "RR004_water_2_S23_R2_001.fastq"],

--- a/examples/paired_dag.json
+++ b/examples/paired_dag.json
@@ -1,4 +1,5 @@
 {
+  "name": "host_filtering",
   "output_dir_s3": "s3://idseq-samples-prod/test_samples/20180917/results",
   "targets": {
     "fastqs": [

--- a/examples/paired_dag.json
+++ b/examples/paired_dag.json
@@ -1,5 +1,5 @@
 {
-  "name": "host_filtering",
+  "name": "paired_dag",
   "output_dir_s3": "s3://idseq-samples-prod/test_samples/20180917/results",
   "targets": {
     "fastqs": [

--- a/examples/pathogen_description.json
+++ b/examples/pathogen_description.json
@@ -1,4 +1,5 @@
 {
+  "name": "",
   "output_dir_s3": "s3://idseq-database/taxonomy/2018-04-01-utc-1522569777-unixtime__2018-04-04-utc-1522862260-unixtime/",
   "targets": {
     "taxid_list": ["taxid_list.txt"],

--- a/examples/pathogen_description.json
+++ b/examples/pathogen_description.json
@@ -1,5 +1,5 @@
 {
-  "name": "",
+  "name": "pathogen_description",
   "output_dir_s3": "s3://idseq-database/taxonomy/2018-04-01-utc-1522569777-unixtime__2018-04-04-utc-1522862260-unixtime/",
   "targets": {
     "taxid_list": ["taxid_list.txt"],

--- a/examples/phylo_tree_dag.json
+++ b/examples/phylo_tree_dag.json
@@ -1,4 +1,5 @@
 {
+  "name": "phylo_tree",
   "output_dir_s3": "s3://idseq-samples-development/phylo_trees/8/test/",
   "targets": {
     "prepare_taxon_fasta_1019_out": ["1019.fasta"],

--- a/examples/phylo_tree_dag.json
+++ b/examples/phylo_tree_dag.json
@@ -1,5 +1,5 @@
 {
-  "name": "phylo_tree",
+  "name": "phylo_tree_dag",
   "output_dir_s3": "s3://idseq-samples-development/phylo_trees/8/test/",
   "targets": {
     "prepare_taxon_fasta_1019_out": ["1019.fasta"],

--- a/examples/postprocess_dag.json
+++ b/examples/postprocess_dag.json
@@ -1,4 +1,5 @@
 {
+  "name": "post_processing",
   "output_dir_s3": "s3://idseq-samples-prod/samples/12/5815/postprocess_test",
   "targets": {
     "taxid_fasta_in": [

--- a/examples/postprocess_dag.json
+++ b/examples/postprocess_dag.json
@@ -1,5 +1,5 @@
 {
-  "name": "post_processing",
+  "name": "post_process_dag",
   "output_dir_s3": "s3://idseq-samples-prod/samples/12/5815/postprocess_test",
   "targets": {
     "taxid_fasta_in": [

--- a/examples/single_dag.json
+++ b/examples/single_dag.json
@@ -1,4 +1,5 @@
 {
+  "name": "host_filtering",
   "output_dir_s3": "s3://idseq-samples-prod/test_samples/1/results",
   "targets": {
     "fastqs": ["RR004_water_2_S23_R1_001.fastq.gz"],

--- a/examples/single_dag.json
+++ b/examples/single_dag.json
@@ -1,5 +1,5 @@
 {
-  "name": "host_filtering",
+  "name": "single_dag",
   "output_dir_s3": "s3://idseq-samples-prod/test_samples/1/results",
   "targets": {
     "fastqs": ["RR004_water_2_S23_R1_001.fastq.gz"],

--- a/idseq_dag/engine/pipeline_flow.py
+++ b/idseq_dag/engine/pipeline_flow.py
@@ -231,10 +231,8 @@ class PipelineFlow(object):
                 target_info = covered_targets[target]
                 if target_info['s3_downloadable']:
                     threading.Thread(target=self.fetch_target_from_s3, args=(target,)).start()
-
         # TODO(boris): check the following implementation
         threading.Thread(target=self.prefetch_large_files).start()
-
 
         self.create_status_json_file()
         # Start initializing all the steps and start running them and wait until all of them are done

--- a/idseq_dag/engine/pipeline_flow.py
+++ b/idseq_dag/engine/pipeline_flow.py
@@ -221,7 +221,7 @@ class PipelineFlow(object):
 
         with open(local_pipeline_status_file, 'w') as pipeline_status_file:
             json.dump(status_json_framework, pipeline_status_file)
-        idseq_dag.util.s3.upload_with_retries(pipeline_status_file, self.output_dir_s3 + "/")
+        idseq_dag.util.s3.upload_with_retries(local_pipeline_status_file, self.output_dir_s3 + "/")
 
     def start(self):
         # Come up with the plan

--- a/idseq_dag/engine/pipeline_flow.py
+++ b/idseq_dag/engine/pipeline_flow.py
@@ -221,7 +221,7 @@ class PipelineFlow(object):
 
         with open(local_pipeline_status_file, 'w') as pipeline_status_file:
             json.dump(status_json_framework, pipeline_status_file)
-        idseq_dag.util.s3.upload_with_retries(pipeline_status_file, self.output_dir_s3 + "/")
+        idseq_dag.util.s3.upload_with_retries(pipeline_status_file, self.output_dir_s3 + "/" + "pipeline_status.json")
 
     def start(self):
         # Come up with the plan

--- a/idseq_dag/engine/pipeline_flow.py
+++ b/idseq_dag/engine/pipeline_flow.py
@@ -88,7 +88,7 @@ class PipelineFlow(object):
             if target_name not in covered_targets:
                 raise ValueError("%s couldn't be generated from the steps" % target_name)
         # Check that name exists
-        if not name:
+        if name is None:
             raise ValueError("Name does not exist for given dag_json")
 
         return dag

--- a/idseq_dag/engine/pipeline_flow.py
+++ b/idseq_dag/engine/pipeline_flow.py
@@ -221,7 +221,7 @@ class PipelineFlow(object):
 
         with open(local_pipeline_status_file, 'w') as pipeline_status_file:
             json.dump(status_json_framework, pipeline_status_file)
-        idseq_dag.util.s3.upload_with_retries(pipeline_status_file, self.output_dir_s3 + "/" + "pipeline_status.json")
+        idseq_dag.util.s3.upload_with_retries(pipeline_status_file, self.output_dir_s3 + "/")
 
     def start(self):
         # Come up with the plan

--- a/idseq_dag/engine/pipeline_flow.py
+++ b/idseq_dag/engine/pipeline_flow.py
@@ -213,8 +213,8 @@ class PipelineFlow(object):
 
     def create_status_json_file(self):
         ''' Create [stage name]_status.json, which will include step-level job status updates to be used in idseq-web. '''
+        log.write(f"Creating {self.name}_status.json")
         local_status_file = f"{self.output_dir_local}/{self.name}_status.json"
-        log.write(f"Creating {self.name}_status.json: {local_status_file}")
 
         status_json_framework = {} # maps out_target to step info
 

--- a/idseq_dag/engine/pipeline_flow.py
+++ b/idseq_dag/engine/pipeline_flow.py
@@ -213,8 +213,8 @@ class PipelineFlow(object):
 
     def create_status_json_file(self):
         ''' Create [stage name]_status.json, which will include step-level job status updates to be used in idseq-web. '''
-        log.write(f"Creating {self.name}_status.json")
         local_status_file = f"{self.output_dir_local}/{self.name}_status.json"
+        log.write(f"Creating {self.name}_status.json: {local_status_file}")
 
         status_json_framework = {} # maps out_target to step info
 

--- a/idseq_dag/engine/pipeline_flow.py
+++ b/idseq_dag/engine/pipeline_flow.py
@@ -214,8 +214,8 @@ class PipelineFlow(object):
         idseq_dag.util.s3.upload_with_retries(local_input_errors_file, self.output_dir_s3 + "/")
 
     def create_status_json_file(self):
-        ''' Create [stage name]_status.json, which will include step-level job status updates to be used in idseq-web. '''
-        log.write(f"Creating {self.name}_status.json")
+        """Create [stage name]_status.json, which will include step-level job status updates to be used in idseq-web."""
+        log.write(f"Creating {self.step_status_local}")
 
         with open(self.step_status_local, 'w') as status_file:
             json.dump({}, status_file)
@@ -236,7 +236,7 @@ class PipelineFlow(object):
         self.create_status_json_file()
         # Start initializing all the steps and start running them and wait until all of them are done
         step_instances = []
-        step_status_lock = TraceLock(f"Step-level status updates for stage {self.name}",threading.RLock())
+        step_status_lock = TraceLock(f"Step-level status updates for stage {self.name}", threading.RLock())
         for step in step_list:
             log.write("Initializing step %s" % step["out"])
             StepClass = getattr(importlib.import_module(step["module"]), step["class"])

--- a/idseq_dag/engine/pipeline_flow.py
+++ b/idseq_dag/engine/pipeline_flow.py
@@ -12,10 +12,8 @@ import idseq_dag.util.count as count
 from idseq_dag.util.trace_lock import TraceLock
 from idseq_dag.engine.pipeline_step import PipelineStep, InvalidInputFileError
 
-# DEFAULT_OUTPUT_DIR_LOCAL = '/mnt/idseq/results/%d' % os.getpid()
-# DEFAULT_REF_DIR_LOCAL = '/mnt/idseq/ref'
-DEFAULT_OUTPUT_DIR_LOCAL = '~/data/results'
-DEFAULT_REF_DIR_LOCAL = '~/data/ref'
+DEFAULT_OUTPUT_DIR_LOCAL = '/mnt/idseq/results/%d' % os.getpid()
+DEFAULT_REF_DIR_LOCAL = '/mnt/idseq/ref'
 
 class PipelineFlow(object):
     def __init__(self, lazy_run, dag_json, versioned_output):

--- a/idseq_dag/engine/pipeline_step.py
+++ b/idseq_dag/engine/pipeline_step.py
@@ -31,10 +31,10 @@ class PipelineStep(object):
     ''' Each Pipeline Run Step i.e. run_star, run_bowtie2, etc '''
     def __init__(self, name, input_files, output_files,
                  output_dir_local, output_dir_s3, ref_dir_local,
-                 additional_files, additional_attributes, step_status_local, step_status_lock):
+                 additional_files, additional_attributes,
+                 step_status_local, step_status_lock):
         ''' Set up all the input_files and output_files here '''
         self.name = name
-        self.stage_name = stage_name
         self.input_files = input_files # list of list files
         self.output_files = output_files # s3 location
         self.output_dir_local = output_dir_local

--- a/idseq_dag/engine/pipeline_step.py
+++ b/idseq_dag/engine/pipeline_step.py
@@ -97,25 +97,25 @@ class PipelineStep(object):
 
     def update_pipeline_status_json(self):
         return
-        # local_pipeline_status_file = os.path.join(self.output_dir_local, "pipeline_status.json")
-        # with open(local_pipeline_status_file, "w+") as current_pipeline_status_json:
-        #     current_pipeline_status = json.load(current_pipeline_status_json)
+        local_pipeline_status_file = os.path.join(self.output_dir_local, "pipeline_status.json")
+        with open(local_pipeline_status_file, "w+") as current_pipeline_status_json:
+            current_pipeline_status = json.load(current_pipeline_status_json)
         
-        #     # Create step info for current step if it doesn't exist yet.
-        #     if not self.name in current_pipeline_status["all_step_info"]:
-        #         current_pipeline_status["all_step_info"][self.name] = {
-        #             "description": self.step_description()
-        #         }
+            # Create step info for current step if it doesn't exist yet.
+            if not self.name in current_pipeline_status["all_step_info"]:
+                current_pipeline_status["all_step_info"][self.name] = {
+                    "description": self.step_description()
+                }
 
-        #     current_pipeline_status["all_step_info"][self.name]["status"] = self.status
+            current_pipeline_status["all_step_info"][self.name]["status"] = self.status
 
-        #     if self.status == StepStatus.STARTED or self.status == StepStatus.INVALID_INPUT:
-        #         current_pipeline_status["current_step"] = self.name
-        #         current_pipeline_status["current_status"] = self.status
-        #         current_pipeline_status["current_errors"]  = self.input_file_error.name
+            if self.status == StepStatus.STARTED or self.status == StepStatus.INVALID_INPUT:
+                current_pipeline_status["current_step"] = self.name
+                current_pipeline_status["current_status"] = self.status
+                current_pipeline_status["current_errors"]  = self.input_file_error.name
             
-        #     json.dump(current_pipeline_status, current_pipeline_status_json)
-        # idseq_dag.util.s3.upload_with_retries(pipeline_status_file, self.s3_path("pipeline_status.json"))
+            json.dump(current_pipeline_status, current_pipeline_status_json)
+        idseq_dag.util.s3.upload_with_retries(local_pipeline_status_file, self.s3_path("pipeline_status.json"))
 
     def s3_path(self, local_path):
         relative_path = os.path.relpath(local_path, self.output_dir_local)

--- a/idseq_dag/engine/pipeline_step.py
+++ b/idseq_dag/engine/pipeline_step.py
@@ -98,8 +98,8 @@ class PipelineStep(object):
         self.status = StepStatus.UPLOADED
 
     def update_stage_status_json(self):
+        log.write(f"Updating {self.stage_name}_status.json with step {self.name}")
         local_stage_status_file = f"{self.output_dir_local}/{self.stage_name}_status.json"
-        log.write(f"Updating {self.stage_name}_status.json with step {self.name}: {local_stage_status_file}")
         with open(local_stage_status_file, 'r', encoding='utf-8') as current_stage_status_json:
             current_stage_status = json.load(current_stage_status_json)
 
@@ -225,14 +225,14 @@ class PipelineStep(object):
         s3_path = os.path.join(self.output_dir_s3, relative_path)
         return s3_path
 
-    def step_description(self):
+    def step_description(self, require_docstrings=false):
         ''' Retrieves description for the given step.
         By default, it pulls the docstring of the class but
         should be overridden for more dynamic descriptions
         that depends on the inputs. If no docstring is provided,
         it throws an exception.
         '''
-        docstring = self.__doc__.strip()
-        if not docstring:
-            raise TypeError('No docstring for step')
-        return docstring
+        docstring = self.__doc__
+        if not docstring and require_docstrings:
+            raise TypeError(f"No docstring for step {self.name}")
+        return docstring.strip()

--- a/idseq_dag/engine/pipeline_step.py
+++ b/idseq_dag/engine/pipeline_step.py
@@ -98,8 +98,8 @@ class PipelineStep(object):
         self.status = StepStatus.UPLOADED
 
     def update_stage_status_json(self):
-        log.write(f"Updating {self.stage_name}_status.json with step {self.name}")
         local_stage_status_file = f"{self.output_dir_local}/{self.stage_name}_status.json"
+        log.write(f"Updating {self.stage_name}_status.json with step {self.name}: {local_stage_status_file}")
         with open(local_stage_status_file, "w+") as current_stage_status_json:
             current_stage_status = json.load(current_stage_status_json)
         

--- a/idseq_dag/engine/pipeline_step.py
+++ b/idseq_dag/engine/pipeline_step.py
@@ -112,9 +112,8 @@ class PipelineStep(object):
             current_stage_status[self.name]["status"] = self.status
             if self.input_file_error:
                 current_stage_status[self.name]["error"] = self.input_file_error.name
-            
             json.dump(current_stage_status, current_stage_status_json)
-        idseq_dag.util.s3.upload_with_retries(local_stage_status_file, self.s3_path(f"{self.stage_name}_status.json"))
+        idseq_dag.util.s3.upload_with_retries(local_stage_status_file, self.s3_path(local_stage_status_file))
 
     def s3_path(self, local_path):
         relative_path = os.path.relpath(local_path, self.output_dir_local)

--- a/idseq_dag/engine/pipeline_step.py
+++ b/idseq_dag/engine/pipeline_step.py
@@ -236,7 +236,7 @@ class PipelineStep(object):
         that depends on the inputs. If no docstring is provided,
         it throws an exception.
         '''
-        docstring = self.__doc__
+        docstring = self.__doc__ or ""
         if not docstring and require_docstrings:
             raise TypeError(f"No docstring for step {self.name}")
         return docstring.strip()

--- a/idseq_dag/engine/pipeline_step.py
+++ b/idseq_dag/engine/pipeline_step.py
@@ -99,7 +99,7 @@ class PipelineStep(object):
 
     def update_stage_status_json(self):
         log.write(f"Updating {self.stage_name}_status.json with step {self.name}")
-        local_stage_status_file = os.path.join(self.output_dir_local, f"{self.stage_name}_status.json")
+        local_stage_status_file = f"{self.output_dir_local}/{self.stage_name}_status.json"
         with open(local_stage_status_file, "w+") as current_stage_status_json:
             current_stage_status = json.load(current_stage_status_json)
         

--- a/idseq_dag/engine/pipeline_step.py
+++ b/idseq_dag/engine/pipeline_step.py
@@ -200,3 +200,21 @@ class PipelineStep(object):
         relative_path = os.path.relpath(local_path, self.output_dir_local)
         s3_path = os.path.join(self.output_dir_s3, relative_path)
         return s3_path
+
+    def step_description(self):
+        ''' Retrieves description for the given step.
+        By default, it pulls the docstring of the class but
+        should be overridden for more dynamic descriptions
+        that depends on the inputs. If no docstring is provided,
+        it throws an exception.
+        '''
+        docstring = self.__doc__.strip()
+        if not docstring:
+            raise TypeError('No docstring for step')
+        return docstring
+
+    def step_name(self):
+        ''' Retrieves name of step if provided in instance,
+        or name of class if not set.
+        '''
+        return self.name or self.__class__.__name__

--- a/idseq_dag/engine/pipeline_step.py
+++ b/idseq_dag/engine/pipeline_step.py
@@ -100,18 +100,18 @@ class PipelineStep(object):
     def update_stage_status_json(self):
         local_stage_status_file = f"{self.output_dir_local}/{self.stage_name}_status.json"
         log.write(f"Updating {self.stage_name}_status.json with step {self.name}: {local_stage_status_file}")
-        with open(local_stage_status_file, "w+") as current_stage_status_json:
+        with open(local_stage_status_file, 'r', encoding='utf-8') as current_stage_status_json:
             current_stage_status = json.load(current_stage_status_json)
-        
-            # Create step info for current step if it doesn't exist yet.
-            if not self.name in current_stage_status:
-                current_stage_status[self.name] = {
-                    "description": self.step_description(),
-                }
 
-            current_stage_status[self.name]["status"] = self.status
-            if self.input_file_error:
-                current_stage_status[self.name]["error"] = self.input_file_error.name
+        if not self.name in current_stage_status:
+            current_stage_status[self.name] = {
+                "description": self.step_description(),
+            }
+        current_stage_status[self.name]["status"] = self.status
+        if self.input_file_error:
+            current_stage_status[self.name]["error"] = self.input_file_error.name
+
+        with open(local_stage_status_file, "w") as current_stage_status_json:
             json.dump(current_stage_status, current_stage_status_json)
         idseq_dag.util.s3.upload_with_retries(local_stage_status_file, self.s3_path(local_stage_status_file))
 

--- a/idseq_dag/engine/pipeline_step.py
+++ b/idseq_dag/engine/pipeline_step.py
@@ -96,25 +96,26 @@ class PipelineStep(object):
         self.status = StepStatus.UPLOADED
 
     def update_pipeline_status_json(self):
-        local_pipeline_status_file = os.path.join(self.output_dir_local, "pipeline_status.json")
-        with open(local_pipeline_status_file, "w+") as current_pipeline_status_json:
-            current_pipeline_status = json.load(current_pipeline_status_json)
+        return
+        # local_pipeline_status_file = os.path.join(self.output_dir_local, "pipeline_status.json")
+        # with open(local_pipeline_status_file, "w+") as current_pipeline_status_json:
+        #     current_pipeline_status = json.load(current_pipeline_status_json)
         
-            # Create step info for current step if it doesn't exist yet.
-            if not self.name in current_pipeline_status["all_step_info"]:
-                current_pipeline_status["all_step_info"][self.name] = {
-                    "description": self.step_description()
-                }
+        #     # Create step info for current step if it doesn't exist yet.
+        #     if not self.name in current_pipeline_status["all_step_info"]:
+        #         current_pipeline_status["all_step_info"][self.name] = {
+        #             "description": self.step_description()
+        #         }
 
-            current_pipeline_status["all_step_info"][self.name]["status"] = self.status
+        #     current_pipeline_status["all_step_info"][self.name]["status"] = self.status
 
-            if self.status == StepStatus.STARTED or self.status == StepStatus.INVALID_INPUT:
-                current_pipeline_status["current_step"] = self.name
-                current_pipeline_status["current_status"] = self.status
-                current_pipeline_status["current_errors"]  = self.input_file_error.name
+        #     if self.status == StepStatus.STARTED or self.status == StepStatus.INVALID_INPUT:
+        #         current_pipeline_status["current_step"] = self.name
+        #         current_pipeline_status["current_status"] = self.status
+        #         current_pipeline_status["current_errors"]  = self.input_file_error.name
             
-            json.dump(current_pipeline_status, current_pipeline_status_json)
-        idseq_dag.util.s3.upload_with_retries(pipeline_status_file, self.s3_path("pipeline_status.json"))
+        #     json.dump(current_pipeline_status, current_pipeline_status_json)
+        # idseq_dag.util.s3.upload_with_retries(pipeline_status_file, self.s3_path("pipeline_status.json"))
 
     def s3_path(self, local_path):
         relative_path = os.path.relpath(local_path, self.output_dir_local)

--- a/idseq_dag/engine/pipeline_step.py
+++ b/idseq_dag/engine/pipeline_step.py
@@ -225,7 +225,7 @@ class PipelineStep(object):
         s3_path = os.path.join(self.output_dir_s3, relative_path)
         return s3_path
 
-    def step_description(self, require_docstrings=false):
+    def step_description(self, require_docstrings=False):
         ''' Retrieves description for the given step.
         By default, it pulls the docstring of the class but
         should be overridden for more dynamic descriptions

--- a/idseq_dag/engine/pipeline_step.py
+++ b/idseq_dag/engine/pipeline_step.py
@@ -110,12 +110,12 @@ class PipelineStep(object):
         if self.input_file_error:
             self.status_dict["error"] = self.input_file_error.name
 
-        # Then, update file
+        # Then, update file by reading the json, modifying, and overwriting.
         self.step_status_lock.acquire()
-        with open(self.step_status_local, 'r+') as status_file:
+        with open(self.step_status_local, 'r') as status_file:
             status = json.load(status_file)
-            status.update({ self.name: self.status_dict })
-            status_file.seek(0)
+        status.update({ self.name: self.status_dict })
+        with open(self.step_status_local, 'w') as status_file:
             json.dump(status, status_file)
         idseq_dag.util.s3.upload_with_retries(self.step_status_local, self.output_dir_s3 + "/")
         self.step_status_lock.release()

--- a/idseq_dag/engine/pipeline_step.py
+++ b/idseq_dag/engine/pipeline_step.py
@@ -96,7 +96,7 @@ class PipelineStep(object):
         self.status = StepStatus.UPLOADED
 
     def update_pipeline_status_json(self):
-        local_pipeline_status_file = f"{self.output_dir_local}/pipeline_status.json"
+        local_pipeline_status_file = os.path.join(self.output_dir_local, "pipeline_status.json")
         with open(local_pipeline_status_file, "w+") as current_pipeline_status_json:
             current_pipeline_status = json.load(current_pipeline_status_json)
         
@@ -114,7 +114,7 @@ class PipelineStep(object):
                 current_pipeline_status["current_errors"]  = self.input_file_error.name
             
             json.dump(current_pipeline_status, current_pipeline_status_json)
-        idseq_dag.util.s3.upload_with_retries(pipeline_status_file, self.output_dir_s3 + "/")
+        idseq_dag.util.s3.upload_with_retries(pipeline_status_file, self.s3_path("pipeline_status.json"))
 
     def s3_path(self, local_path):
         relative_path = os.path.relpath(local_path, self.output_dir_local)
@@ -237,4 +237,3 @@ class PipelineStep(object):
         if not docstring:
             raise TypeError('No docstring for step')
         return docstring
-        

--- a/idseq_dag/engine/pipeline_step.py
+++ b/idseq_dag/engine/pipeline_step.py
@@ -99,6 +99,10 @@ class PipelineStep(object):
 
     def update_stage_status_json(self):
         log.write(f"Updating {self.stage_name}_status.json with step {self.name}")
+
+        # Fetch file from s3, open, and load as a json
+        s3_stage_status_file = f"{self.output_dir_s3}/{self.stage_name}_status.json"
+        stage_status_file = idseq_dag.util.s3.fetch_from_s3(s3_stage_status_file, self.output_dir_local)
         local_stage_status_file = f"{self.output_dir_local}/{self.stage_name}_status.json"
         with open(local_stage_status_file, 'r', encoding='utf-8') as current_stage_status_json:
             current_stage_status = json.load(current_stage_status_json)
@@ -113,7 +117,7 @@ class PipelineStep(object):
 
         with open(local_stage_status_file, "w") as current_stage_status_json:
             json.dump(current_stage_status, current_stage_status_json)
-        idseq_dag.util.s3.upload_with_retries(local_stage_status_file, self.s3_path(local_stage_status_file))
+        idseq_dag.util.s3.upload_with_retries(local_stage_status_file, s3_stage_status_file)
 
     def s3_path(self, local_path):
         relative_path = os.path.relpath(local_path, self.output_dir_local)


### PR DESCRIPTION
# Description

For each stage, create a `[stage name}_status.json` which gets written to when a step starts running or is finished. Will be used to get step-level updates for the pipeline visualization.

Requires a new `name` field in the `dag_json` to ensure that each stage's status file is unique and will not overwrite a previous stage's status file. (See https://github.com/chanzuckerberg/idseq-web/pull/2440, which must be merged *before* this PR is merged)

# Testing
Ran test sample, which succeeded with files uploading correctly!