### PR TITLE
Reapply "Upload step-level updates during pipeline run"

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ or `python3 -m unittest tests/<module_file> ` for testing individual modules.
 ## DAG Execution Details
 
 ### Composing an example dag json file
-There are four basic elements of an IdSeq Dag
-
+There are five basic elements of an IdSeq Dag
+ - **name**: the name of the IdSeq Dag.
  - **output_dir_s3**: the s3 directory where the output files will be copied to.
  - **targets**: the outputs that are to be generated through dag execution. Each target consists of a list of files that will be copied to *output_dir_s3*
  - **steps**: the steps that will be executed in order to generate the targets. For each step, the following attributes can be specified:
@@ -71,6 +71,7 @@ The following is an example dag for generating alignment output for idseq. The *
 
 ```
 {
+  "name": "alignment",
   "output_dir_s3": "s3://idseq-samples-prod/samples/12/5815/results_test",
   "targets": {
     "host_filter_out": [

--- a/README.md
+++ b/README.md
@@ -227,6 +227,10 @@ TODO: Move this code over to the idseq-dag repo.
 
 ## Release notes
 
+- 3.8.0
+   - Creates a [status name]_status.json file for each dag_json received, which each step updates with information
+     about itself and its status.
+
 - 3.7.6
    - Fail with an informative user error if the input contains broken read pairs.
 

--- a/README.md
+++ b/README.md
@@ -230,7 +230,6 @@ TODO: Move this code over to the idseq-dag repo.
 - 3.8.0
    - Creates a [status name]_status.json file for each dag_json received, which each step updates with information
      about itself and its status.
-   - Add number of reads, reads per million, and depth per million to the output of PipelineStepRunSRST2.
 
 - 3.7.6
    - Fail with an informative user error if the input contains broken read pairs.

--- a/examples/accession2taxid_dag_test.json
+++ b/examples/accession2taxid_dag_test.json
@@ -1,4 +1,5 @@
 {
+  "name": "accession2taxid_dag_test",
   "output_dir_s3": "s3://idseq-samples-development/markazhang/accession_test/2018-12-01",
   "targets": {
     "accession2taxid_input": [

--- a/examples/amr_human_sample_paired_rds_dag.json
+++ b/examples/amr_human_sample_paired_rds_dag.json
@@ -1,4 +1,5 @@
 {
+  "name": "amr_human_sample_paired_rds_dag",
   "output_dir_s3": "s3://idseq-samples-prod/samples/12/5815/postprocess_test",
   "targets": {
     "srst2_out": ["out.log", "out__genes__ARGannot_r2__results.txt", "out__fullgenes__ARGannot_r2__results.txt", "amr_processed_results.csv", "amr_summary_results.csv"],

--- a/examples/amr_water_sample_single_rd_dag.json
+++ b/examples/amr_water_sample_single_rd_dag.json
@@ -1,4 +1,5 @@
 {
+  "name": "amr_water_sample_single_rd_dag",
   "output_dir_s3": "s3://idseq-samples-prod/samples/12/5815/postprocess_test",
   "targets": {
     "srst2_out": ["out.log", "out__genes__ARGannot_r2__results.txt", "out__fullgenes__ARGannot_r2__results.txt", "amr_processed_results.csv", "amr_summary_results.csv"],

--- a/examples/assemble_blast.json
+++ b/examples/assemble_blast.json
@@ -1,4 +1,5 @@
 {
+  "name": "assemble_blast",
   "output_dir_s3": "s3://idseq-samples-development/yunfang/sample_1793/assembly_blast/",
   "targets": {
     "host_filter_out": [

--- a/examples/assembly_dag.json
+++ b/examples/assembly_dag.json
@@ -1,4 +1,5 @@
 {
+  "name": "assembly_dag",
   "output_dir_s3": "s3://idseq-samples-development/yunfang/sample_11285/assembly/",
   "targets": {
     "host_filter_out": [

--- a/examples/build_custom_blast_index.json
+++ b/examples/build_custom_blast_index.json
@@ -1,4 +1,5 @@
 {
+  "name": "build_custom_blast_index",
   "output_dir_s3": "s3://idseq-samples-development/yunfang/rvdb/2018-12-01",
   "targets": {
     "dummy_input": [

--- a/examples/download_accessions.json
+++ b/examples/download_accessions.json
@@ -1,4 +1,5 @@
 {
+  "name": "download_accessions",
   "output_dir_s3": "s3://idseq-samples-development/yunfang/samples_4534/download_accessions_test",
   "targets": {
     "gsnap_out": [

--- a/examples/example_dag.json
+++ b/examples/example_dag.json
@@ -1,4 +1,5 @@
 {
+  "name": "example_dag",
   "output_dir_s3": "s3://idseq-samples-prod/1/10/results",
   "targets": {
     "fastqs": ["fastq1.gz", "fastq2.gz"],

--- a/examples/generate_coverage_viz.json
+++ b/examples/generate_coverage_viz.json
@@ -1,4 +1,5 @@
 {
+  "name": "generate_coverage_viz",
   "output_dir_s3": "s3://idseq-samples-development/markazhang/samples_12452/generate_coverage_viz_test",
   "targets": {
     "refined_gsnap_in": [

--- a/examples/generic_test_dag.json
+++ b/examples/generic_test_dag.json
@@ -1,4 +1,5 @@
 {
+  "name": "generic_test_dag",
   "output_dir_s3": "",
   "targets": {
     "fastqs": ["1.fastq.gz", "2.fastq.gz"],

--- a/examples/host_filter_dag.json
+++ b/examples/host_filter_dag.json
@@ -1,4 +1,5 @@
 {
+  "name": "host_filter_dag",
   "output_dir_s3":
     "s3://idseq-samples-prod/samples/12/5815/results_test",
   "targets": {

--- a/examples/host_genome.json
+++ b/examples/host_genome.json
@@ -1,4 +1,5 @@
 {
+  "name": "host_genome",
   "output_dir_s3": "s3://idseq-database/host_filter/pig/2019-02-06",
   "targets": {
     "host_fasta": ["GCA_002844635.1_USMARCv1.0_genomic.fna.gz"],

--- a/examples/non_host_alignment_dag.json
+++ b/examples/non_host_alignment_dag.json
@@ -1,4 +1,5 @@
 {
+  "name": "non_host_alignment_dag",
   "output_dir_s3": "s3://idseq-samples-staging/samples/114/1118/results_test",
   "targets": {
     "host_filter_out": [

--- a/examples/nonhost_fastq.json
+++ b/examples/nonhost_fastq.json
@@ -1,4 +1,5 @@
 {
+  "name": "nonhost_fastq",
   "output_dir_s3": "s3://idseq-samples-development/markazhang/samples_12216/expt_test",
   "targets": {
     "fastqs": ["RR004_water_2_S23_R1_001.fastq", "RR004_water_2_S23_R2_001.fastq"],

--- a/examples/paired_dag.json
+++ b/examples/paired_dag.json
@@ -1,4 +1,5 @@
 {
+  "name": "paired_dag",
   "output_dir_s3": "s3://idseq-samples-prod/test_samples/20180917/results",
   "targets": {
     "fastqs": [

--- a/examples/pathogen_description.json
+++ b/examples/pathogen_description.json
@@ -1,4 +1,5 @@
 {
+  "name": "pathogen_description",
   "output_dir_s3": "s3://idseq-database/taxonomy/2018-04-01-utc-1522569777-unixtime__2018-04-04-utc-1522862260-unixtime/",
   "targets": {
     "taxid_list": ["taxid_list.txt"],

--- a/examples/phylo_tree_dag.json
+++ b/examples/phylo_tree_dag.json
@@ -1,4 +1,5 @@
 {
+  "name": "phylo_tree_dag",
   "output_dir_s3": "s3://idseq-samples-development/phylo_trees/8/test/",
   "targets": {
     "prepare_taxon_fasta_1019_out": ["1019.fasta"],

--- a/examples/postprocess_dag.json
+++ b/examples/postprocess_dag.json
@@ -1,4 +1,5 @@
 {
+  "name": "post_process_dag",
   "output_dir_s3": "s3://idseq-samples-prod/samples/12/5815/postprocess_test",
   "targets": {
     "taxid_fasta_in": [

--- a/examples/single_dag.json
+++ b/examples/single_dag.json
@@ -1,4 +1,5 @@
 {
+  "name": "single_dag",
   "output_dir_s3": "s3://idseq-samples-prod/test_samples/1/results",
   "targets": {
     "fastqs": ["RR004_water_2_S23_R1_001.fastq.gz"],

--- a/idseq_dag/__init__.py
+++ b/idseq_dag/__init__.py
@@ -1,2 +1,2 @@
 ''' idseq_dag '''
-__version__ = "3.7.6"
+__version__ = "3.7.7"

--- a/idseq_dag/__init__.py
+++ b/idseq_dag/__init__.py
@@ -1,2 +1,2 @@
 ''' idseq_dag '''
-__version__ = "3.7.7"
+__version__ = "3.8.0"

--- a/idseq_dag/engine/pipeline_step.py
+++ b/idseq_dag/engine/pipeline_step.py
@@ -31,7 +31,8 @@ class PipelineStep(object):
     ''' Each Pipeline Run Step i.e. run_star, run_bowtie2, etc '''
     def __init__(self, name, input_files, output_files,
                  output_dir_local, output_dir_s3, ref_dir_local,
-                 additional_files, additional_attributes):
+                 additional_files, additional_attributes,
+                 step_status_local, step_status_lock):
         ''' Set up all the input_files and output_files here '''
         self.name = name
         self.input_files = input_files # list of list files
@@ -40,6 +41,10 @@ class PipelineStep(object):
         self.output_dir_s3 = output_dir_s3.rstrip('/')
         self.ref_dir_local = ref_dir_local
         self.create_local_dirs()
+
+        self.status_dict = {}
+        self.step_status_local = step_status_local
+        self.step_status_lock = step_status_lock
 
         self.additional_files = additional_files
         self.additional_attributes = additional_attributes
@@ -95,6 +100,24 @@ class PipelineStep(object):
         for f in self.additional_folders_to_upload:
             idseq_dag.util.s3.upload_folder_with_retries(f, self.s3_path(f))
         self.status = StepStatus.UPLOADED
+
+    def update_status_json_file(self):
+        log.write(f"Updating status file for step {self.name}")
+        #  First, update own status dictionary
+        if not "description" in self.status_dict:
+            self.status_dict["description"] = self.step_description()
+        self.status_dict["status"] = self.status
+        if self.input_file_error:
+            self.status_dict["error"] = self.input_file_error.name
+
+        # Then, update file by reading the json, modifying, and overwriting.
+        with self.step_status_lock:
+            with open(self.step_status_local, 'r') as status_file:
+                status = json.load(status_file)
+            status.update({ self.name: self.status_dict })
+            with open(self.step_status_local, 'w') as status_file:
+                json.dump(status, status_file)
+            idseq_dag.util.s3.upload_with_retries(self.step_status_local, self.output_dir_s3 + "/")
 
     def s3_path(self, local_path):
         relative_path = os.path.relpath(local_path, self.output_dir_local)
@@ -167,6 +190,8 @@ class PipelineStep(object):
     def thread_run(self):
         ''' Actually running the step '''
         self.status = StepStatus.STARTED
+        self.update_status_json_file()
+
         v = {"step": self.name}
         with log.log_context("dag_step", v):
             with log.log_context("substep_wait_for_input_files", v):
@@ -178,6 +203,7 @@ class PipelineStep(object):
             if self.input_file_error:
                 log.write("Invalid input detected for step %s" % self.name)
                 self.status = StepStatus.INVALID_INPUT
+                self.update_stage_status_json()
                 return
 
             with log.log_context("substep_run", v):
@@ -191,6 +217,7 @@ class PipelineStep(object):
         self.upload_thread = threading.Thread(target=self.uploading_results)
         self.upload_thread.start()
         self.status = StepStatus.FINISHED
+        self.update_status_json_file()
 
     def start(self):
         ''' function to be called after instantiation to start running the step '''
@@ -201,3 +228,15 @@ class PipelineStep(object):
         relative_path = os.path.relpath(local_path, self.output_dir_local)
         s3_path = os.path.join(self.output_dir_s3, relative_path)
         return s3_path
+
+    def step_description(self, require_docstrings=False):
+        ''' Retrieves description for the given step.
+        By default, it pulls the docstring of the class but
+        should be overridden for more dynamic descriptions
+        that depends on the inputs. If no docstring is provided,
+        it throws an exception.
+        '''
+        docstring = self.__doc__ or ""
+        if not docstring and require_docstrings:
+            raise TypeError(f"No docstring for step {self.name}")
+        return docstring.strip()

--- a/idseq_dag/engine/pipeline_step.py
+++ b/idseq_dag/engine/pipeline_step.py
@@ -256,3 +256,13 @@ class PipelineStep(object):
         if not docstring and require_docstrings:
             raise TypeError(f"No docstring for step {self.name}")
         return docstring.strip()
+
+    def step_resources(self):
+        ''' Returns a dictionary of resources in the form of display name => url.
+
+        These will be used on the sidebar of the pipeline visualization on the idseq-web app.
+        By default, show link to idseq-dag documentation.
+        '''
+        return { "IDseq Docs": "https://github.com/chanzuckerberg/idseq-dag/wiki" }
+
+

--- a/idseq_dag/engine/pipeline_step.py
+++ b/idseq_dag/engine/pipeline_step.py
@@ -208,11 +208,8 @@ class PipelineStep(object):
                 return
 
             with log.log_context("substep_run", v):
-                try:
-                    self.update_status_json_file("running")
-                    self.run()
-                finally:
-                    self.update_status_json_file("finished_running")
+                self.update_status_json_file("running")
+                self.run()
             with log.log_context("substep_validate", v):
                 self.validate()
             with log.log_context("substep_save_progress", v):
@@ -222,6 +219,7 @@ class PipelineStep(object):
         self.upload_thread = threading.Thread(target=self.uploading_results)
         self.upload_thread.start()
         self.status = StepStatus.FINISHED
+        self.update_status_json_file("finished_running")
 
     def start(self):
         ''' function to be called after instantiation to start running the step '''

--- a/idseq_dag/engine/pipeline_step.py
+++ b/idseq_dag/engine/pipeline_step.py
@@ -100,13 +100,14 @@ class PipelineStep(object):
         for f in self.additional_folders_to_upload:
             idseq_dag.util.s3.upload_folder_with_retries(f, self.s3_path(f))
         self.status = StepStatus.UPLOADED
+        self.update_status_json_file("uploaded")
 
-    def update_status_json_file(self):
-        log.write(f"Updating status file for step {self.name}")
+    def update_status_json_file(self, status):
+        log.write(f"Updating status file for step {self.name} with status {status}")
         #  First, update own status dictionary
         if not "description" in self.status_dict:
             self.status_dict["description"] = self.step_description()
-        self.status_dict["status"] = self.status
+        self.status_dict["status"] = status
         if self.input_file_error:
             self.status_dict["error"] = self.input_file_error.name
 
@@ -190,7 +191,7 @@ class PipelineStep(object):
     def thread_run(self):
         ''' Actually running the step '''
         self.status = StepStatus.STARTED
-        self.update_status_json_file()
+        self.update_status_json_file("instantiated")
 
         v = {"step": self.name}
         with log.log_context("dag_step", v):
@@ -203,10 +204,11 @@ class PipelineStep(object):
             if self.input_file_error:
                 log.write("Invalid input detected for step %s" % self.name)
                 self.status = StepStatus.INVALID_INPUT
-                self.update_stage_status_json()
+                self.update_status_json_file("errored")
                 return
 
             with log.log_context("substep_run", v):
+                self.update_status_json_file("running")
                 self.run()
             with log.log_context("substep_validate", v):
                 self.validate()
@@ -217,7 +219,7 @@ class PipelineStep(object):
         self.upload_thread = threading.Thread(target=self.uploading_results)
         self.upload_thread.start()
         self.status = StepStatus.FINISHED
-        self.update_status_json_file()
+        self.update_status_json_file("finished")
 
     def start(self):
         ''' function to be called after instantiation to start running the step '''

--- a/idseq_dag/engine/pipeline_step.py
+++ b/idseq_dag/engine/pipeline_step.py
@@ -3,6 +3,7 @@ import sys
 import os
 import threading
 import time
+import datetime
 import idseq_dag.util.command as command
 import idseq_dag.util.log as log
 from abc import abstractmethod
@@ -104,9 +105,12 @@ class PipelineStep(object):
 
     def update_status_json_file(self, status):
         log.write(f"Updating status file for step {self.name} with status {status}")
-        #  First, update own status dictionary
+        # First, update own status dictionary
+        if not "start_time" in self.status_dict:
+            self.status_dict["start_time"] = time.time() # seconds since epoch
         if not "description" in self.status_dict:
             self.status_dict["description"] = self.step_description()
+
         self.status_dict["status"] = status
         if self.input_file_error:
             self.status_dict["error"] = self.input_file_error.name

--- a/idseq_dag/engine/pipeline_step.py
+++ b/idseq_dag/engine/pipeline_step.py
@@ -109,6 +109,8 @@ class PipelineStep(object):
             self.status_dict["start_time"] = time.time() # seconds since epoch
         if not "description" in self.status_dict:
             self.status_dict["description"] = self.step_description()
+        if not "resources" in self.status_dict:
+            self.status_dict["resources"] = self.step_resources()
 
         self.status_dict["status"] = status
         if self.input_file_error:

--- a/idseq_dag/engine/pipeline_step.py
+++ b/idseq_dag/engine/pipeline_step.py
@@ -187,9 +187,14 @@ class PipelineStep(object):
             raise RuntimeError("step %s run failed" % self.name)
 
     def wait_until_all_done(self):
-        self.wait_until_finished()
-        # run finished
-        self.upload_thread.join()
+        try:
+            self.wait_until_finished()
+            # run finished
+            self.upload_thread.join()
+        except Exception as e:
+            self.update_status_json_file("errored")
+            raise e # Raise again to be caught in PipelineFlow and stop other steps
+
         if self.status < StepStatus.UPLOADED:
             self.update_status_json_file("errored")
             raise RuntimeError("step %s uploading failed" % self.name)

--- a/idseq_dag/engine/pipeline_step.py
+++ b/idseq_dag/engine/pipeline_step.py
@@ -208,8 +208,11 @@ class PipelineStep(object):
                 return
 
             with log.log_context("substep_run", v):
-                self.update_status_json_file("running")
-                self.run()
+                try:
+                    self.update_status_json_file("running")
+                    self.run()
+                finally:
+                    self.update_status_json_file("finished_running")
             with log.log_context("substep_validate", v):
                 self.validate()
             with log.log_context("substep_save_progress", v):
@@ -219,7 +222,6 @@ class PipelineStep(object):
         self.upload_thread = threading.Thread(target=self.uploading_results)
         self.upload_thread.start()
         self.status = StepStatus.FINISHED
-        self.update_status_json_file("finished")
 
     def start(self):
         ''' function to be called after instantiation to start running the step '''

--- a/idseq_dag/engine/pipeline_step.py
+++ b/idseq_dag/engine/pipeline_step.py
@@ -113,6 +113,8 @@ class PipelineStep(object):
         self.status_dict["status"] = status
         if self.input_file_error:
             self.status_dict["error"] = self.input_file_error.name
+        if status == "uploaded":
+            self.status_dict["end_time"] = time.time()
 
         # Then, update file by reading the json, modifying, and overwriting.
         with self.step_status_lock:

--- a/idseq_dag/engine/pipeline_step.py
+++ b/idseq_dag/engine/pipeline_step.py
@@ -173,12 +173,14 @@ class PipelineStep(object):
     def wait_until_finished(self):
         self.exec_thread.join()
         if self.status == StepStatus.INVALID_INPUT:
+            self.update_status_json_file("errored")
             raise InvalidInputFileError({
                 "error": self.input_file_error.name,
                 "step": self.name
             })
 
         if self.status < StepStatus.FINISHED:
+            self.update_status_json_file("errored")
             raise RuntimeError("step %s run failed" % self.name)
 
     def wait_until_all_done(self):
@@ -186,6 +188,7 @@ class PipelineStep(object):
         # run finished
         self.upload_thread.join()
         if self.status < StepStatus.UPLOADED:
+            self.update_status_json_file("errored")
             raise RuntimeError("step %s uploading failed" % self.name)
 
     def thread_run(self):

--- a/idseq_dag/engine/pipeline_step.py
+++ b/idseq_dag/engine/pipeline_step.py
@@ -3,7 +3,6 @@ import sys
 import os
 import threading
 import time
-import datetime
 import idseq_dag.util.command as command
 import idseq_dag.util.log as log
 from abc import abstractmethod


### PR DESCRIPTION
Creating this pull request for now, but will wait for https://github.com/chanzuckerberg/idseq-web/pull/2440 to reach prod before merging (otherwise dag validation will break)

See discussion at #173 

Changes beyond original pull request:
* Added more error logging
* Change location of initial update
* Differentiate between a user (input) error and pipeline error in step-level status logging
* Write `start_time` and `end_time` fields
* Add `step_resources` method, which returns a dictionary mapping resource name => url