### PR TITLE
Fix an issue with ncbi index regarding oddly annotated descriptions

### DIFF
--- a/idseq_dag/steps/download_accessions.py
+++ b/idseq_dag/steps/download_accessions.py
@@ -92,7 +92,7 @@ class PipelineStepDownloadAccessions(PipelineStep):
             return line
 
         lines = accession_data.split("\n")
-        lines = map(_fix_headers, lines)
+        lines = (_fix_headers(line) for line in lines)
         return "\n".join(lines)
 
     def download_ref_sequences_from_file(self, accession_dict, loc_dict, db_path,

--- a/idseq_dag/steps/download_accessions.py
+++ b/idseq_dag/steps/download_accessions.py
@@ -45,6 +45,9 @@ class PipelineStepDownloadAccessions(PipelineStep):
                     allow_s3mi=ALLOW_S3MI)
                 self.download_ref_sequences_from_file(accession_dict, loc_dict, db_path, output_reference_fasta)
 
+
+    FIX_COMMA_REGEXP = re.compile(r'^(?P<accession_id>[^ ]+) (?P<wrong_pattern>, *)?(?P<description>.*)$')
+
     @staticmethod
     def _fix_ncbi_record(accession_data: str) -> str:
         '''
@@ -82,12 +85,11 @@ class PipelineStepDownloadAccessions(PipelineStep):
             since this is the only case that we found so far affecting the pipeline.
             It may be extended the future to handle more exceptions if it is needed.
         '''
-        FIX_COMMA_REGEXP = re.compile(r'^(?P<accession_id>[^ ]+) (?P<wrong_pattern>, *)?(?P<description>.*)$')
         def _fix_headers(line):
             if len(line) > 0 and line[0] == ">":
                 # support for multiheader line separted by CTRL_A (https://en.wikipedia.org/wiki/FASTA_format#Description_line)
                 header_items = line.lstrip(">").split("\x01")
-                header_items = (FIX_COMMA_REGEXP.sub(r"\g<accession_id> \g<description>", header_item) for header_item in header_items)
+                header_items = (PipelineStepDownloadAccessions.FIX_COMMA_REGEXP.sub(r"\g<accession_id> \g<description>", header_item) for header_item in header_items)
                 return ">" + ("\x01".join(header_items))
             return line
 

--- a/idseq_dag/steps/download_accessions.py
+++ b/idseq_dag/steps/download_accessions.py
@@ -1,6 +1,7 @@
 import os
 import threading
 import time
+import re
 import traceback
 from idseq_dag.engine.pipeline_step import PipelineStep
 import idseq_dag.util.command as command
@@ -44,6 +45,63 @@ class PipelineStepDownloadAccessions(PipelineStep):
                     allow_s3mi=ALLOW_S3MI)
                 self.download_ref_sequences_from_file(accession_dict, loc_dict, db_path, output_reference_fasta)
 
+    @staticmethod
+    def _fix_ncbi_record(accession_data: str) -> str:
+        '''
+            We found a ncbi record that is oddly annotated (title starts with a comma,
+            as you can see here: https://www.ncbi.nlm.nih.gov/protein/XP_002289390.1)
+            That produce wrong results in blastx (blastx understand this accession 
+            as being "XP_002289390.1," instead of "XP_002289390.1")
+
+            This method detects and removes this comma from the title, and
+            it is being invoked before writing it to file assembly/nr.refseq.fasta,
+            which is a subset of the original nr index.
+
+            `accession_data` is a string that looks like this:
+
+                accession_data = (
+                    '>XP_002289390.1 , partial [Thalassiosira pseudonana CCMP1335]\x01EED92927.1 Conserved Hypothetical Protein, partial [Thalassiosira pseudonana CCMP1335]\n'
+                    'GGREKKKLLKSQKDGSAKDRHNPRAFSVANIVRTQRNVQRNLDRAQKKEYVPLSDRRAARVEEGPPSLVAVVGPPGVGKS\n'
+                    'TLIRSLVKLYTNHNLTNPTGPITVCTSQTKRITFLECPNTPTAMLDVAKIADLVLLCVDAKFGFEMETFEFLNMMQTHGF\n'
+                    'PKVMGIFTHLDQFRTQKNLRKTKKLLKHRFWTEIYDGAKMFYFSGCVNGKYLKHEVKQLSLLLSRIKYRPLVWRNTHPYV\n'
+                    # (...more lines with sequence data...)
+                )
+                # note entry above represents a single string and line breaks and ^A character are part of it.
+
+            this method returns same string with title correction:
+
+            result = (
+                '>XP_002289390.1 partial [Thalassiosira pseudonana CCMP1335]\x01EED92927.1 Conserved Hypothetical Protein, partial [Thalassiosira pseudonana CCMP1335]\n'
+                'GGREKKKLLKSQKDGSAKDRHNPRAFSVANIVRTQRNVQRNLDRAQKKEYVPLSDRRAARVEEGPPSLVAVVGPPGVGKS\n'
+                'TLIRSLVKLYTNHNLTNPTGPITVCTSQTKRITFLECPNTPTAMLDVAKIADLVLLCVDAKFGFEMETFEFLNMMQTHGF\n'
+                'PKVMGIFTHLDQFRTQKNLRKTKKLLKHRFWTEIYDGAKMFYFSGCVNGKYLKHEVKQLSLLLSRIKYRPLVWRNTHPYV\n'
+                # (...more lines with sequence data...)
+            )
+
+            Right now this method is only being used to remove the commas (and spaces),
+            since this is the only case that we found so far affecting the pipeline.
+            It may be extended the future to handle more exceptions if it is needed.
+        '''
+        def _fix_headers(line):
+            if len(line) > 0 and line[0] == ">":
+                # support for multiheader line separted by CTRL_A (https://en.wikipedia.org/wiki/FASTA_format#Description_line)
+                header_items = line.lstrip(">").split("\x01")
+                return ">" + "\x01".join(map(_fix_comma, header_items))
+            return line
+
+        def _fix_comma(header_item):
+            sub_items = header_item.split(" ", 1)
+            if len(sub_items) > 1:
+                accession_id, description = sub_items
+                if len(description) > 0 and description[0] == ",":
+                    description = description.lstrip(",").lstrip(" ")
+                    return f"{accession_id} {description}"
+            return header_item
+
+        lines = accession_data.split("\n")
+        lines = map(_fix_headers, lines)
+        return "\n".join(lines)
+
     def download_ref_sequences_from_file(self, accession_dict, loc_dict, db_path,
                                          output_reference_fasta):
         db_file = open(db_path, 'r')
@@ -51,6 +109,7 @@ class PipelineStepDownloadAccessions(PipelineStep):
             for accession, _taxinfo in accession_dict.items():
                 accession_data = self.get_sequence_by_accession_from_file(accession, loc_dict, db_file)
                 if accession_data:
+                    accession_data = self._fix_ncbi_record(accession_data)
                     orf.write(accession_data)
         db_file.close()
 

--- a/idseq_dag/steps/download_accessions.py
+++ b/idseq_dag/steps/download_accessions.py
@@ -50,10 +50,10 @@ class PipelineStepDownloadAccessions(PipelineStep):
         '''
             We found a ncbi record that is oddly annotated (title starts with a comma,
             as you can see here: https://www.ncbi.nlm.nih.gov/protein/XP_002289390.1)
-            That produce wrong results in blastx (blastx understand this accession 
+            That produce wrong results in blastx (blastx understand this accession
             as being "XP_002289390.1," instead of "XP_002289390.1")
 
-            This method detects and removes this comma from the title, and
+            This method detects and removes this trailling comma from the title, and
             it is being invoked before writing it to file assembly/nr.refseq.fasta,
             which is a subset of the original nr index.
 
@@ -78,7 +78,7 @@ class PipelineStepDownloadAccessions(PipelineStep):
                 # (...more lines with sequence data...)
             )
 
-            Right now this method is only being used to remove the commas (and spaces),
+            Right now this method is only being used to remove the trailing comma,
             since this is the only case that we found so far affecting the pipeline.
             It may be extended the future to handle more exceptions if it is needed.
         '''

--- a/idseq_dag/steps/download_accessions.py
+++ b/idseq_dag/steps/download_accessions.py
@@ -81,7 +81,7 @@ class PipelineStepDownloadAccessions(PipelineStep):
                 # (...more lines with sequence data...)
             )
 
-            Right now this method is only being used to remove the trailing comma,
+            Right now this method is only being used to remove the heading comma,
             since this is the only case that we found so far affecting the pipeline.
             It may be extended the future to handle more exceptions if it is needed.
         '''

--- a/idseq_dag/steps/generate_coverage_stats.py
+++ b/idseq_dag/steps/generate_coverage_stats.py
@@ -2,6 +2,8 @@
 import json
 import os
 import pysam
+import functools
+from multiprocessing import Pool
 
 from idseq_dag.engine.pipeline_step import PipelineStep
 import idseq_dag.util.command as command
@@ -62,47 +64,66 @@ class PipelineStepGenerateCoverageStats(PipelineStep):
                 output_str = ','.join(str(e) for e in output_row)
                 csc.write(output_str + "\n")
 
+    @staticmethod
+    def _process_contig_names(bam_file, f, contig_names):
+        contig2coverage = {}
+        if len(contig_names) > 0:
+            with log.log_context(f"calc_contig2coverage_chunk", {"bam_file": bam_file, "from": contig_names[0], "to": contig_names[-1]}):
+                for c in contig_names:
+                    coverage = []
+                    for pileup_column in f.pileup(contig=c):
+                        coverage.append(pileup_column.get_num_aligned())
+                    sorted_coverage = sorted(coverage)
+                    contig_len = len(coverage)
+                    if contig_len <= 0:
+                        continue
+
+                    avg = sum(coverage)/contig_len
+                    avg2xcnt = 0
+                    cnt0 = 0
+                    cnt1 = 0
+                    cnt2 = 0
+                    for t in coverage:
+                        if t > 2 * avg:
+                            avg2xcnt += 1
+                        if t == 0:
+                            cnt0 += 1
+                        elif t == 1:
+                            cnt1 += 1
+                        elif t == 2:
+                            cnt2 += 1
+
+                    contig2coverage[c] = {
+                        "coverage": coverage,
+                        "avg": avg,
+                        "p0": sorted_coverage[0],
+                        "p100": sorted_coverage[-1],
+                        "p25": sorted_coverage[int(0.25*contig_len)],
+                        "p50": sorted_coverage[int(0.5*contig_len)],
+                        "p75": sorted_coverage[int(0.75*contig_len)],
+                        "avg2xcnt": avg2xcnt / contig_len,
+                        "cnt0": cnt0 / contig_len,
+                        "cnt1": cnt1 / contig_len,
+                        "cnt2": cnt2 / contig_len
+                    }
+        return contig2coverage
 
     @staticmethod
     def calc_contig2coverage(bam_file):
         CHUNK_SIZE = 100
-        contig2coverage = {}
         with pysam.AlignmentFile(bam_file, "rb") as f:
             all_references = f.references
             with log.log_context("calc_contig2coverage", {"bam_file": bam_file, "all_references_count": len(all_references)}):
                 chunked_references = chunks(f.references, CHUNK_SIZE)
-                for contig_names in chunked_references:
-                    if len(contig_names) == 0:
-                        break
-                    with log.log_context(f"calc_contig2coverage_chunk", {"bam_file": bam_file, "from": contig_names[0], "to": contig_names[-1]}):
-                        for c in contig_names:
-                            coverage = []
-                            for pileup_column in f.pileup(contig=c):
-                                coverage.append(pileup_column.get_num_aligned())
-                            sorted_coverage = sorted(coverage)
-                            contig_len = len(coverage)
-                            if contig_len <= 0:
-                                continue
-
-                            avg = sum(coverage)/contig_len
-                            contig2coverage[c] = {
-                                "coverage": coverage,
-                                "avg": avg,
-                                "p0": sorted_coverage[0],
-                                "p100": sorted_coverage[-1],
-                                "p25": sorted_coverage[int(0.25*contig_len)],
-                                "p50": sorted_coverage[int(0.5*contig_len)],
-                                "p75": sorted_coverage[int(0.75*contig_len)],
-                                "avg2xcnt": len(list(filter(lambda t: t > 2 * avg, coverage)))/contig_len,
-                                "cnt0": len(list(filter(lambda t: t == 0, coverage)))/contig_len,
-                                "cnt1": len(list(filter(lambda t: t == 1, coverage)))/contig_len,
-                                "cnt2": len(list(filter(lambda t: t == 2, coverage)))/contig_len
-                        }
+                fn = functools.partial(PipelineStepGenerateCoverageStats._process_contig_names, bam_file, f)
+                with Pool() as pool:
+                    results = pool.map(fn, chunked_references)
+        contig2coverage = {}
+        for result in results:
+            contig2coverage.update(result)
         return contig2coverage
 
 
     def count_reads(self):
         ''' Count reads '''
         pass
-
-

--- a/tests/unit/steps/test_download_accessions.py
+++ b/tests/unit/steps/test_download_accessions.py
@@ -1,0 +1,78 @@
+import re
+import unittest
+from multiprocessing import RLock
+
+
+# Class under test
+from idseq_dag.steps.download_accessions import PipelineStepDownloadAccessions
+
+FAKE_SEQUENCE_DATA = (
+    'GGREKKKLLKSQKDGSAKDRHNPRAFSVANIVRTQRNVQRNLDRAQKKEYVPLSDRRAARVEEGPPSLVAVVGPPGVGKS\n'
+    'TLIRSLVKLYTNHNLTNPTGPITVCTSQTKRITFLECPNTPTAMLDVAKIADLVLLCVDAKFGFEMETFEFLNMMQTHGF\n'
+    'KLYAPLSNVGAVSFDKDAVYIDIGRANYTKRENLDLPREEKEEGEGSDDASSLQDVKEGVDQKMQYSSLRLFKGSKAVKA\n'
+)
+class TestDownloadAccessions(unittest.TestCase):
+    def setUp(self):
+        self.step = PipelineStepDownloadAccessions(
+            name="rapsearch2_out",
+            input_files=[
+                [
+                    "rapsearch2.m8",
+                    "rapsearch2.deduped.m8",
+                    "rapsearch2.hitsummary.tab",
+                    "rapsearch2_counts.json"
+                ]
+            ],
+            output_files=["assembly/nr.refseq.fasta"],
+            output_dir_local="/mnt/idseq/results",
+            output_dir_s3="s3://dummy_bucket",
+            ref_dir_local="/mnt/idseq/ref/",
+            additional_files={
+                "lineage_db": "s3://idseq-database/taxonomy/2018-12-01/taxid-lineages.sqlite3",
+                "loc_db": "s3://idseq-database/alignment_data/2018-12-01/nr_loc.sqlite3"
+            },
+            additional_attributes={
+                "db":  "s3://idseq-database/alignment_data/2018-12-01/nr",
+                "db_type": "nr"
+            },
+            step_status_lock=RLock(),
+            step_status_local="./dummy_status.json"
+        )
+
+
+    def test_fix_ncbi_record(self):
+        '''Run command remotely with success'''
+        parameterized_tests = [
+            [
+                'WHEN one or more description from a multi-header start with a comma, THEN return the header with comma and spaces from the beginning of each description removed',
+                '>XP_002289390.1 , partial [Thalassiosira pseudonana CCMP1335]\x01EED92927.1 ,  Conserved Hypothetical Protein, partial [Thalassiosira pseudonana CCMP1335]\n' + FAKE_SEQUENCE_DATA,
+                '>XP_002289390.1 partial [Thalassiosira pseudonana CCMP1335]\x01EED92927.1 Conserved Hypothetical Protein, partial [Thalassiosira pseudonana CCMP1335]\n' + FAKE_SEQUENCE_DATA
+            ],
+            [
+                'WHEN entry is a single-header and the description starts with a comma THEN return the header with the comma and spaces from the beginning of the description removed',
+                '>OGG82825.1 replicative DNA helicase [Candidatus Kaiserbacteria bacterium RIFCSPLOWO2_02_FULL_54_13]\n' + FAKE_SEQUENCE_DATA,
+                '>OGG82825.1 replicative DNA helicase [Candidatus Kaiserbacteria bacterium RIFCSPLOWO2_02_FULL_54_13]\n' + FAKE_SEQUENCE_DATA,
+            ],
+            [
+                "WHEN none of the descriptions from a multi-header start with a comma THEN return the original headers",
+                '>XP_002289390.1 , partial [Thalassiosira pseudonana CCMP1335]\x01EED92927.1 ,  Conserved Hypothetical Protein, partial [Thalassiosira pseudonana CCMP1335]\n' + FAKE_SEQUENCE_DATA,
+                '>XP_002289390.1 partial [Thalassiosira pseudonana CCMP1335]\x01EED92927.1 Conserved Hypothetical Protein, partial [Thalassiosira pseudonana CCMP1335]\n' + FAKE_SEQUENCE_DATA
+            ],
+            [
+                "WHEN entry is a single-header and description doesn't start with a comma THEN return the original header",
+                '>OGG82825.1 replicative DNA helicase [Candidatus Kaiserbacteria bacterium RIFCSPLOWO2_02_FULL_54_13]\n' + FAKE_SEQUENCE_DATA,
+                '>OGG82825.1 replicative DNA helicase [Candidatus Kaiserbacteria bacterium RIFCSPLOWO2_02_FULL_54_13]\n' + FAKE_SEQUENCE_DATA,
+            ],
+            [
+                "WHEN entry is a single-header that has no description THEN return the original header",
+                '>OGG82825.1\n' + FAKE_SEQUENCE_DATA,
+                '>OGG82825.1\n' + FAKE_SEQUENCE_DATA,
+            ],
+        ]
+
+        for test_name, accession_data, expected_result in parameterized_tests:
+            with self.subTest(test_name):
+                result = self.step._fix_ncbi_record(accession_data)
+
+                self.assertEqual(result, expected_result)
+        

--- a/tests/unit/steps/test_download_accessions.py
+++ b/tests/unit/steps/test_download_accessions.py
@@ -50,12 +50,12 @@ class TestDownloadAccessions(unittest.TestCase):
             ],
             [
                 'WHEN entry is a single-header and the description starts with a comma THEN return the header with the comma and spaces from the beginning of the description removed',
-                '>OGG82825.1 replicative DNA helicase [Candidatus Kaiserbacteria bacterium RIFCSPLOWO2_02_FULL_54_13]\n' + FAKE_SEQUENCE_DATA,
+                '>OGG82825.1 , replicative DNA helicase [Candidatus Kaiserbacteria bacterium RIFCSPLOWO2_02_FULL_54_13]\n' + FAKE_SEQUENCE_DATA,
                 '>OGG82825.1 replicative DNA helicase [Candidatus Kaiserbacteria bacterium RIFCSPLOWO2_02_FULL_54_13]\n' + FAKE_SEQUENCE_DATA,
             ],
             [
                 "WHEN none of the descriptions from a multi-header start with a comma THEN return the original headers",
-                '>XP_002289390.1 , partial [Thalassiosira pseudonana CCMP1335]\x01EED92927.1 ,  Conserved Hypothetical Protein, partial [Thalassiosira pseudonana CCMP1335]\n' + FAKE_SEQUENCE_DATA,
+                '>XP_002289390.1 partial [Thalassiosira pseudonana CCMP1335]\x01EED92927.1 Conserved Hypothetical Protein, partial [Thalassiosira pseudonana CCMP1335]\n' + FAKE_SEQUENCE_DATA,
                 '>XP_002289390.1 partial [Thalassiosira pseudonana CCMP1335]\x01EED92927.1 Conserved Hypothetical Protein, partial [Thalassiosira pseudonana CCMP1335]\n' + FAKE_SEQUENCE_DATA
             ],
             [


### PR DESCRIPTION
`blastx` produces results with wrong keys in `rapsearch2.blast.m8` whenever a ncbi reference has a header with a description that starts with a comma, and pipeline breaks on step `refined_rapsearch2_out`.

You can see an example on ncbi website, accession [XP_002289390.1](https://www.ncbi.nlm.nih.gov/protein/XP_002289390.1).

`blastx` results file `rapsearch2.blast.m8`:
```
$ grep -e "XP_002289390.1" rapsearch2.blast.m8
NODE_36674_length_226_cov_0.830409 XP_002289390.1, 36.585 41 24 1 20 136 802 842 6.1 26.9
NODE_48441_length_219_cov_1.006098 XP_002289390.1, 35.897 39 25 0 117 1 213 251 3.0 27.7
NODE_53376_length_217_cov_0.876543 XP_002289390.1, 31.707 41 28 0 73 195 815 855 0.52 29.6
NODE_71319_length_208_cov_0.928105 XP_002289390.1, 29.167 48 32 1 189 46 167 212 1.7 28.1
```
Notice that key has a trailing comma, which leads to `KeyError` results.

The source of this problem is that blastx doesn't correctly process entries like that:
```
$ grep -e "XP_002289390.1" nr.refseq.fasta
>XP_002289390.1 , partial [Thalassiosira pseudonana CCMP1335]EED92927.1 Conserved Hypothetical Protein, partial [Thalassiosira pseudonana CCMP1335]
```
Here is the exception:
```
{"time": "2019-07-30T10:57:41.785", "msg": "An exception was thrown. Stage failed.", "thread": "MainThread", "pid": 581, "level": "INFO"}
Exception in thread Thread-54:
Traceback (most recent call last):
File "/usr/lib/python3.7/threading.py", line 917, in _bootstrap_inner
self.run()
File "/usr/lib/python3.7/threading.py", line 865, in run
self._target(*self._args, **self._kwargs)
File "/mnt/idseq-dag/idseq_dag/engine/pipeline_step.py", line 184, in thread_run
self.run()
File "/mnt/idseq-dag/idseq_dag/steps/blast_contigs.py", line 61, in run
read2contig, blast_top_m8, read_dict, accession_dict)
File "/mnt/idseq-dag/idseq_dag/steps/blast_contigs.py", line 180, in update_read_dict
contig2lineage[contig_id] = accession_dict[accession_id]
KeyError: 'XP_002289390.1,'
Traceback (most recent call last):
File "/mnt/idseq-dag/idseq_dag/engine/pipeline_flow.py", line 238, in start
step.wait_until_all_done()
File "/mnt/idseq-dag/idseq_dag/engine/pipeline_step.py", line 161, in wait_until_all_done
self.wait_until_finished()
File "/mnt/idseq-dag/idseq_dag/engine/pipeline_step.py", line 158, in wait_until_finished
raise RuntimeError("step %s run failed" % self.name)
RuntimeError: step refined_rapsearch2_out run failed
```

Since changing ncbi records or fixing `blastx` are not exactly quick options, in order to unblock such samples, this PR remove the undesired characters during the creation of `nr.refseq.fasta`, which is a subset of `nr` database.