### PR TITLE
Add a 36-nt filter for nucleotide alignments

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,9 @@ TODO: Move this code over to the idseq-dag repo.
 
 ## Release notes
 
+- 3.9.4
+  - Additional performance improvements in run_srst2 step, so that the step uses less RAM.
+
 - 3.9.3
   - Fix typo in phylo tree generation step.
 

--- a/README.md
+++ b/README.md
@@ -227,6 +227,9 @@ TODO: Move this code over to the idseq-dag repo.
 
 ## Release notes
 
+- 3.10
+  - Apply a length filter, requiring all NT alignments (GSNAP and BLAST) be >= 36 nucleotides long.
+
 - 3.9.4
   - Additional performance improvements in run_srst2 step, so that the step uses less RAM.
 

--- a/idseq_dag/__init__.py
+++ b/idseq_dag/__init__.py
@@ -1,2 +1,2 @@
 ''' idseq_dag '''
-__version__ = "3.9.4"
+__version__ = "3.10"

--- a/idseq_dag/__init__.py
+++ b/idseq_dag/__init__.py
@@ -1,2 +1,2 @@
 ''' idseq_dag '''
-__version__ = "3.9.3"
+__version__ = "3.9.4"

--- a/idseq_dag/steps/generate_annotated_fasta.py
+++ b/idseq_dag/steps/generate_annotated_fasta.py
@@ -29,7 +29,7 @@ class PipelineStepGenerateAnnotatedFasta(PipelineStep):
             return dict((read_id, accession_id)
                         for read_id, accession_id, _percent_id,
                         _alignment_length, _e_value, _bitscore, _line in m8.iterate_m8(
-                            m8_file, "annotate_fasta_with_accessions"))
+                            m8_file, 0, "annotate_fasta_with_accessions"))
 
         nt_map = get_map(nt_m8)
         nr_map = get_map(nr_m8)

--- a/idseq_dag/steps/run_alignment_remotely.py
+++ b/idseq_dag/steps/run_alignment_remotely.py
@@ -42,7 +42,7 @@ class PipelineStepRunAlignmentRemotely(PipelineStep):
     -t 36
     --max-mismatches=40
     -D {remote_index_dir}
-    -d nt_k16 
+    -d nt_k16
     {remote_input_files} > {multihit_remote_outfile}
     ```
 
@@ -50,15 +50,15 @@ class PipelineStepRunAlignmentRemotely(PipelineStep):
 
     For Rapsearch:
     ```
-    rapsearch 
-    -d {remote_index_dir}/nr_rapsearch 
-    -e -6 
-    -l 10 
-    -a T 
-    -b 0 
-    -v 50 
-    -z 24 
-    -q {remote_input_files} 
+    rapsearch
+    -d {remote_index_dir}/nr_rapsearch
+    -e -6
+    -l 10
+    -a T
+    -b 0
+    -v 50
+    -z 24
+    -q {remote_input_files}
     -o {multihit_remote_outfile}
     ```
 
@@ -86,6 +86,7 @@ class PipelineStepRunAlignmentRemotely(PipelineStep):
         [output_m8, deduped_output_m8, output_hitsummary, output_counts_json] = self.output_files_local()
         service = self.additional_attributes["service"]
         assert service in ("gsnap", "rapsearch2")
+        min_alignment_length = 36 if service == 'gsnap' else 0 # alignments < 36-NT are false positives
 
         self.run_remotely(input_fas, output_m8, service)
 
@@ -95,7 +96,7 @@ class PipelineStepRunAlignmentRemotely(PipelineStep):
         blacklist_s3_file = self.additional_attributes.get('taxon_blacklist', DEFAULT_BLACKLIST_S3)
         taxon_blacklist = fetch_from_s3(blacklist_s3_file, self.ref_dir_local)
         m8.call_hits_m8(output_m8, lineage_db, accession2taxid_db,
-                        deduped_output_m8, output_hitsummary, taxon_blacklist)
+                        deduped_output_m8, output_hitsummary, min_alignment_length, taxon_blacklist)
 
         # check deuterostome
         deuterostome_db = None
@@ -512,7 +513,7 @@ class PipelineStepRunAlignmentRemotely(PipelineStep):
                 -t 36
                 --max-mismatches=40
                 -D {remote_index_dir}
-                -d nt_k16 
+                -d nt_k16
                 {remote_input_files} > {multihit_remote_outfile}
                 ```
 
@@ -521,17 +522,17 @@ class PipelineStepRunAlignmentRemotely(PipelineStep):
         elif (self.name == "rapsearch2_out"):
             return """
                 Runs rapsearch remotely.
-                
+
                 ```
-                rapsearch 
-                -d {remote_index_dir}/nr_rapsearch 
-                -e -6 
-                -l 10 
-                -a T 
-                -b 0 
+                rapsearch
+                -d {remote_index_dir}/nr_rapsearch
+                -e -6
+                -l 10
+                -a T
+                -b 0
                 -v 50 
-                -z 24 
-                -q {remote_input_files} 
+                -z 24
+                -q {remote_input_files}
                 -o {multihit_remote_outfile}
                 ```
 


### PR DESCRIPTION
### Description
Add a 36-nt filter for nucleotide alignments - this is used to set a minimum alignment length filter for GSNAP alignments and BLAST alignments. The minlength filter is taken care of for rapsearch2 using the -l flag. 

### Notes
The 36-nt filter is a conservative filter intended to remove known false-positive alignments that would never be trusted, regardless of input read length. This threshold removes > 99% of false positives identified from negative control benchmark samples, while maintaining sensitivity to detect known positives in benchmark samples.

### Tests

- Tested on internal benchmarks - observe high correlation in relative abundance for highly abundant microbes and some [expected] discordance in counts of low-abundance taxa that were known to be spurious false-positives. Specifically, for sample 17728 where we expect only 1 taxa, the filter reduced IDseq report page rows from 2501 total rows to 9 rows. 

- Tested on select user samples containing M. tuberculosis - the 36-nt filter removes spurious alignments, therefore bumping up the average alignment length value for true alignments, resulting in detection of M.tb in known positive samples that were previously unable to be detected with the L filter.
