### PR TITLE
Use sorted mode of bedtools coverage to reduce RAM usage.

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,9 @@ TODO: Move this code over to the idseq-dag repo.
 
 ## Release notes
 
+- 3.9.4
+  - Additional performance improvements in run_srst2 step, so that the step uses less RAM.
+
 - 3.9.3
   - Fix typo in phylo tree generation step.
 

--- a/idseq_dag/__init__.py
+++ b/idseq_dag/__init__.py
@@ -1,2 +1,2 @@
 ''' idseq_dag '''
-__version__ = "3.9.3"
+__version__ = "3.9.4"


### PR DESCRIPTION
This addresses an issue where the `bedtools coverage` command was running out of RAM.

We use the "sorted" mode of `bedtools coverage`, as documented here:
https://bedtools.readthedocs.io/en/latest/content/tools/coverage.html

In order to do this, we need to sort the `bam` file produced by SRST2 before passing it to bedtools. So we convert the bam file to a bed file, and then sort it using the linux `sort` command.

There are a couple of additional details regarding `sort`:
* We need `env LC_ALL=C` so that `sort` will sort the same way across all machines.
* We need to specify the tmp directory (we create one manually in the local output dir and delete it afterward). Otherwise, `sort` will use the `/tmp` folder, which is not where our AWS volumes are mounted in production. This causes `sort` to run out of disk space in production.

Testing:
* We tested on a benchmark sample, a small sample with no AMR output, and a small sample with only one input file.
* In the case where the sample had no AMR output, the code did not reach the bedtool command (there is a guard in the `run` function when SRST outputs nothing which causes it to exit), so we do not have to worry about empty AMR output causing the bedtool command to crash.
* We also tested on samples that had failed the amr step in production due to running out of memory. See samples 27339 (this one had 494 million input reads), 27340, 27345 and others. All of these samples succeeded using this change, although they took hours to complete (we will look into reducing the number of input reads separately)

