### PR TITLE
IDSEQ-1326 - [Stabilization] Performance optimization for coverage_out

### DIFF
--- a/idseq_dag/steps/generate_coverage_stats.py
+++ b/idseq_dag/steps/generate_coverage_stats.py
@@ -111,7 +111,7 @@ class PipelineStepGenerateCoverageStats(PipelineStep):
 
     @staticmethod
     def calc_contig2coverage(bam_file):
-        CHUNK_SIZE = 100
+        CHUNK_SIZE = 200
         with pysam.AlignmentFile(bam_file, "rb") as f:
             all_references = f.references
             with log.log_context("calc_contig2coverage", {"bam_file": bam_file, "all_references_count": len(all_references)}):

--- a/idseq_dag/steps/generate_coverage_stats.py
+++ b/idseq_dag/steps/generate_coverage_stats.py
@@ -2,6 +2,8 @@
 import json
 import os
 import pysam
+import functools
+from multiprocessing import Pool
 
 from idseq_dag.engine.pipeline_step import PipelineStep
 import idseq_dag.util.command as command
@@ -62,47 +64,71 @@ class PipelineStepGenerateCoverageStats(PipelineStep):
                 output_str = ','.join(str(e) for e in output_row)
                 csc.write(output_str + "\n")
 
+    @staticmethod
+    def _process_contig_names(bam_file, contig_names):
+        contig2coverage = {}
+        if len(contig_names) > 0:
+            with log.log_context(f"calc_contig2coverage_chunk", {"bam_file": bam_file, "from": contig_names[0], "to": contig_names[-1]}):
+                with pysam.AlignmentFile(bam_file, "rb") as f:
+                    for c in contig_names:
+                        coverage = []
+                        for pileup_column in f.pileup(contig=c):
+                            coverage.append(pileup_column.get_num_aligned())
+                        sorted_coverage = sorted(coverage)
+                        contig_len = len(coverage)
+                        if contig_len <= 0:
+                            continue
+
+                        avg = sum(coverage)/contig_len
+                        avg2xcnt = 0
+                        cnt0 = 0
+                        cnt1 = 0
+                        cnt2 = 0
+                        for t in coverage:
+                            if t > 2 * avg:
+                                avg2xcnt += 1
+                            if t == 0:
+                                cnt0 += 1
+                            elif t == 1:
+                                cnt1 += 1
+                            elif t == 2:
+                                cnt2 += 1
+
+                        contig2coverage[c] = {
+                            "coverage": coverage,
+                            "avg": avg,
+                            "p0": sorted_coverage[0],
+                            "p100": sorted_coverage[-1],
+                            "p25": sorted_coverage[int(0.25*contig_len)],
+                            "p50": sorted_coverage[int(0.5*contig_len)],
+                            "p75": sorted_coverage[int(0.75*contig_len)],
+                            "avg2xcnt": avg2xcnt / contig_len,
+                            "cnt0": cnt0 / contig_len,
+                            "cnt1": cnt1 / contig_len,
+                            "cnt2": cnt2 / contig_len
+                        }
+        return contig2coverage
 
     @staticmethod
     def calc_contig2coverage(bam_file):
         CHUNK_SIZE = 100
-        contig2coverage = {}
         with pysam.AlignmentFile(bam_file, "rb") as f:
             all_references = f.references
             with log.log_context("calc_contig2coverage", {"bam_file": bam_file, "all_references_count": len(all_references)}):
                 chunked_references = chunks(f.references, CHUNK_SIZE)
-                for contig_names in chunked_references:
-                    if len(contig_names) == 0:
-                        break
-                    with log.log_context(f"calc_contig2coverage_chunk", {"bam_file": bam_file, "from": contig_names[0], "to": contig_names[-1]}):
-                        for c in contig_names:
-                            coverage = []
-                            for pileup_column in f.pileup(contig=c):
-                                coverage.append(pileup_column.get_num_aligned())
-                            sorted_coverage = sorted(coverage)
-                            contig_len = len(coverage)
-                            if contig_len <= 0:
-                                continue
-
-                            avg = sum(coverage)/contig_len
-                            contig2coverage[c] = {
-                                "coverage": coverage,
-                                "avg": avg,
-                                "p0": sorted_coverage[0],
-                                "p100": sorted_coverage[-1],
-                                "p25": sorted_coverage[int(0.25*contig_len)],
-                                "p50": sorted_coverage[int(0.5*contig_len)],
-                                "p75": sorted_coverage[int(0.75*contig_len)],
-                                "avg2xcnt": len(list(filter(lambda t: t > 2 * avg, coverage)))/contig_len,
-                                "cnt0": len(list(filter(lambda t: t == 0, coverage)))/contig_len,
-                                "cnt1": len(list(filter(lambda t: t == 1, coverage)))/contig_len,
-                                "cnt2": len(list(filter(lambda t: t == 2, coverage)))/contig_len
-                        }
+                fn = functools.partial(PipelineStepGenerateCoverageStats._process_contig_names, bam_file)
+                with Pool() as pool:
+                    chunk_results = pool.map(fn, chunked_references)
+        contig2coverage = {}
+        for chunk_result in chunk_results:
+            # check if there are duplicated keys
+            for key in chunk_result.keys():
+                if key in contig2coverage:
+                    raise Exception(f"Key {key} already present in contig2coverage")
+            contig2coverage.update(chunk_result)
         return contig2coverage
 
 
     def count_reads(self):
         ''' Count reads '''
         pass
-
-


### PR DESCRIPTION
Under special circumstances, step `coverage_out` (Stage 3 - Post-processing) takes too long to execute and the batch gets terminated.

This operation (`coverage_out`) is usually fast, however depending on the data, it can currently take multiple hours to complete.

This PR introduces parallelism to process these chunks, dramatically increasing the performance for these slowest samples.

# Tests

- Compared the output files `contig_coverage.json` and `contig_coverage_summary.csv` by removing these files from a previous run and re-runing it with and without this optimization. The end results were exactly the same.

# Performance gains

Timings from 'coverage_out' step:

Sample 1:
- Without optimization: never completed, job got terminated after 2 hours
- With optimization: ~9 min

Sample 2:
- Without optimization: ~70 minutes
- With optimization: ~6 min

Sample 3 (Benchmark sample):
- Without optimization: ~12 seconds
- With optimization: ~4 seconds


