### PR TITLE
Remove deprecated NCBI files from input

### DIFF
--- a/templates/accession2taxid_dag.json
+++ b/templates/accession2taxid_dag.json
@@ -3,9 +3,7 @@
   "targets": {
     "accession2taxid_input": [
       "nucl_wgs.accession2taxid.gz",
-      "nucl_est.accession2taxid.gz",
       "nucl_gb.accession2taxid.gz",
-      "nucl_gss.accession2taxid.gz",
       "pdb.accession2taxid.gz",
       "prot.accession2taxid.gz"
     ],


### PR DESCRIPTION
# Description

The files are no longer present in https://ftp.ncbi.nlm.nih.gov/pub/taxonomy/accession2taxid/ . This is blocking our index generation. 

Following the example of kraken (https://github.com/marbl/Krona/commit/ad6ee3fdb7ce65fe7607a75909ef5913fb826c96), this PR removes the files. 

# Notes

See https://ncbiinsights.ncbi.nlm.nih.gov/2018/07/30/upcoming-changes-est-gss-databases/ for details on the deprecation. 

# Tests

Follow the steps in https://github.com/chanzuckerberg/idseq-web/wiki/%5BDev%5D-Index-Update-Instructions, and see no more error. 