### PR TITLE
Increase gsnapl threads from 36 to 48 for better utilization of r5d.metal machines

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,10 +227,10 @@ TODO: Move this code over to the idseq-dag repo.
 
 ## Release notes
 
-- 3.11
+- 3.10.1
   - Increase GSNAP threads to 48 for better utilization of r5d.metal instances.
 
-- 3.10
+- 3.10.0
   - Apply a length filter, requiring all NT alignments (GSNAP and BLAST) be >= 36 nucleotides long.
 
 - 3.9.4

--- a/README.md
+++ b/README.md
@@ -227,6 +227,9 @@ TODO: Move this code over to the idseq-dag repo.
 
 ## Release notes
 
+- 3.11
+  - Increase GSNAP threads to 48 for better utilization of r5d.metal instances.
+
 - 3.10
   - Apply a length filter, requiring all NT alignments (GSNAP and BLAST) be >= 36 nucleotides long.
 

--- a/idseq_dag/__init__.py
+++ b/idseq_dag/__init__.py
@@ -1,2 +1,2 @@
 ''' idseq_dag '''
-__version__ = "3.11"
+__version__ = "3.10.1"

--- a/idseq_dag/__init__.py
+++ b/idseq_dag/__init__.py
@@ -1,2 +1,2 @@
 ''' idseq_dag '''
-__version__ = "3.10"
+__version__ = "3.11"

--- a/idseq_dag/steps/run_alignment_remotely.py
+++ b/idseq_dag/steps/run_alignment_remotely.py
@@ -47,6 +47,8 @@ class PipelineStepRunAlignmentRemotely(PipelineStep):
     ```
 
     GSNAP documentation is available [here](http://research-pub.gene.com/gmap/).
+    -t (threads): r5d.metal machines have 96 vCPUs. Use 48 threads and each process will be able to
+    concurrently process 2 chunks.
 
     For Rapsearch:
     ```
@@ -382,6 +384,8 @@ class PipelineStepRunAlignmentRemotely(PipelineStep):
 
         base_str = "mkdir -p {remote_work_dir} ; {download_input_from_s3} ; "
         environment = self.additional_attributes["environment"]
+
+        # See step class docstrings for more parameter details.
         if service == "gsnap":
             commands = base_str + "{remote_home_dir}/bin/gsnapl -A m8 --batch=0 --use-shared-memory=0 --gmap-mode=none --npaths=100 --ordered -t 48 --max-mismatches=40 -D {remote_index_dir} -d nt_k16 {remote_input_files} > {multihit_remote_outfile}"
         else:

--- a/idseq_dag/steps/run_alignment_remotely.py
+++ b/idseq_dag/steps/run_alignment_remotely.py
@@ -48,7 +48,7 @@ class PipelineStepRunAlignmentRemotely(PipelineStep):
 
     GSNAP documentation is available [here](http://research-pub.gene.com/gmap/).
     -t (threads): r5d.metal machines have 96 vCPUs. Use 48 threads and each process will be able to
-    concurrently process 2 chunks.
+    concurrently process 2 chunks (see attribute 'max_concurrent').
 
     For Rapsearch:
     ```

--- a/idseq_dag/steps/run_alignment_remotely.py
+++ b/idseq_dag/steps/run_alignment_remotely.py
@@ -39,7 +39,7 @@ class PipelineStepRunAlignmentRemotely(PipelineStep):
     --gmap-mode=none
     --npaths=100
     --ordered
-    -t 36
+    -t 48
     --max-mismatches=40
     -D {remote_index_dir}
     -d nt_k16
@@ -383,7 +383,7 @@ class PipelineStepRunAlignmentRemotely(PipelineStep):
         base_str = "mkdir -p {remote_work_dir} ; {download_input_from_s3} ; "
         environment = self.additional_attributes["environment"]
         if service == "gsnap":
-            commands = base_str + "{remote_home_dir}/bin/gsnapl -A m8 --batch=0 --use-shared-memory=0 --gmap-mode=none --npaths=100 --ordered -t 36 --max-mismatches=40 -D {remote_index_dir} -d nt_k16 {remote_input_files} > {multihit_remote_outfile}"
+            commands = base_str + "{remote_home_dir}/bin/gsnapl -A m8 --batch=0 --use-shared-memory=0 --gmap-mode=none --npaths=100 --ordered -t 48 --max-mismatches=40 -D {remote_index_dir} -d nt_k16 {remote_input_files} > {multihit_remote_outfile}"
         else:
             commands = base_str + "/usr/local/bin/rapsearch -d {remote_index_dir}/nr_rapsearch -e -6 -l 10 -a T -b 0 -v 50 -z 24 -q {remote_input_files} -o {multihit_remote_outfile}"
 
@@ -510,7 +510,7 @@ class PipelineStepRunAlignmentRemotely(PipelineStep):
                 --gmap-mode=none
                 --npaths=100
                 --ordered
-                -t 36
+                -t 48
                 --max-mismatches=40
                 -D {remote_index_dir}
                 -d nt_k16


### PR DESCRIPTION
### Description
- Increase gsnapl threads from 36 to 48 for better utilization of new r5d.metal machines. r5d.metal machines have 96 vCPUs instead of 72 vCPUs on the i3.metal, so each thread gets 2 vCPUs.

### Tests
- Running test samples here: https://staging.idseq.net/my_data?projectId=301