### PR TITLE
Add back berkeley db file generation after sqlite

### DIFF
--- a/examples/accession2taxid_dag_test.json
+++ b/examples/accession2taxid_dag_test.json
@@ -1,6 +1,6 @@
 {
   "name": "accession2taxid_dag_test",
-  "output_dir_s3": "s3://idseq-samples-development/markazhang/accession_test/2018-12-01",
+  "output_dir_s3": "s3://idseq-samples-development/markazhang/accession_test/2018-12-01/",
   "targets": {
     "accession2taxid_input": [
       "pdb.accession2taxid.gz"
@@ -14,16 +14,20 @@
     "accession2taxid_out": [
       "accession2taxid.gz",
       "accession2taxid_wgs.gz",
+      "accession2taxid.sqlite3",
+      "taxid2wgs_accession.sqlite3",
       "accession2taxid.db",
       "taxid2wgs_accession.db"
     ],
     "nt_loc_out": [
-      "nt_loc.db",
-      "nt_info.db"
+      "nt_loc.sqlite3",
+      "nt_info.sqlite3",
+      "nt_loc.db"
     ],
     "nr_loc_out": [
-      "nr_loc.db",
-      "nr_info.db"
+      "nr_loc.sqlite3",
+      "nr_info.sqlite3",
+      "nr_loc.db"
     ]
   },
   "steps": [

--- a/examples/accession2taxid_dag_test.json
+++ b/examples/accession2taxid_dag_test.json
@@ -1,6 +1,6 @@
 {
   "name": "accession2taxid_dag_test",
-  "output_dir_s3": "s3://idseq-samples-development/markazhang/accession_test/2018-12-01/",
+  "output_dir_s3": "s3://idseq-samples-development/markazhang/accession_test/2018-12-01",
   "targets": {
     "accession2taxid_input": [
       "pdb.accession2taxid.gz"

--- a/idseq_dag/steps/generate_loc_db.py
+++ b/idseq_dag/steps/generate_loc_db.py
@@ -8,8 +8,10 @@ import idseq_dag.util.log as log
 from idseq_dag.util.dict import IdSeqDictForUpdate, IdSeqDictValue
 BATCH_INSERT_SIZE = 300
 
+
 class PipelineStepGenerateLocDB(PipelineStep):
     ''' Generate Loc DB for NT/NR '''
+
     def run(self):
         """
         Generate Loc DB for NT/NR
@@ -17,7 +19,8 @@ class PipelineStepGenerateLocDB(PipelineStep):
         db_file = self.input_files_local[0][0]
         loc_db_file = self.output_files_local()[0]
         info_db_file = self.output_files_local()[1]
-        self.generate_loc_db(db_file, loc_db_file, info_db_file)
+        self.generate_loc_db_for_sqlite(db_file, loc_db_file, info_db_file)
+        self.generate_loc_db_for_shelf(db_file, loc_db_file)
 
     @staticmethod
     def generate_loc_db_work(db_file, loc_db, info_db):
@@ -70,14 +73,13 @@ class PipelineStepGenerateLocDB(PipelineStep):
             info_db.batch_inserts(info_batch_list)
 
     @run_in_subprocess
-    def generate_loc_db(self, db_file, loc_db_file, info_db_file):
+    def generate_loc_db_for_sqlite(self, db_file, loc_db_file, info_db_file):
         with IdSeqDictForUpdate(loc_db_file, IdSeqDictValue.VALUE_TYPE_ARRAY) as loc_db, \
-             IdSeqDictForUpdate(info_db_file, IdSeqDictValue.VALUE_TYPE_ARRAY) as info_db:
+                IdSeqDictForUpdate(info_db_file, IdSeqDictValue.VALUE_TYPE_ARRAY) as info_db:
             PipelineStepGenerateLocDB.generate_loc_db_work(db_file, loc_db, info_db)
 
     @run_in_subprocess
-    def generate_loc_db_old(self, db_file, loc_db_file):
-        # TODO: To be deprecated. Using shelve
+    def generate_loc_db_for_shelf(self, db_file, loc_db_file):
         loc_dict = shelve.Shelf(dbm.ndbm.open(loc_db_file.replace(".db", ""), 'c'))
         with open(db_file) as dbf:
             seq_offset = 0

--- a/idseq_dag/steps/generate_loc_db.py
+++ b/idseq_dag/steps/generate_loc_db.py
@@ -1,10 +1,11 @@
 ''' Generate loc db  '''
 import dbm
-import shelve
+import idseq_dag.util.log as log
 import re
+import shelve
+
 from idseq_dag.engine.pipeline_step import PipelineStep
 from idseq_dag.util.command import run_in_subprocess
-import idseq_dag.util.log as log
 from idseq_dag.util.dict import IdSeqDictForUpdate, IdSeqDictValue
 BATCH_INSERT_SIZE = 300
 
@@ -17,9 +18,14 @@ class PipelineStepGenerateLocDB(PipelineStep):
         Generate Loc DB for NT/NR
         """
         db_file = self.input_files_local[0][0]
-        loc_db_file = self.output_files_local()[0]
-        info_db_file = self.output_files_local()[1]
-        self.generate_loc_db_for_sqlite(db_file, loc_db_file, info_db_file)
+
+        loc_db_file_sqlite = self.output_files_local()[0]
+        info_db_file_sqlite = self.output_files_local()[1]
+        self.generate_loc_db_for_sqlite(db_file, loc_db_file_sqlite, info_db_file_sqlite)
+
+        loc_db_file = self.output_files_local()[2]
+        # TODO: (gdingle): this needs to be added
+        # info_db_file = self.output_files_local()[3]
         self.generate_loc_db_for_shelf(db_file, loc_db_file)
 
     @staticmethod

--- a/idseq_dag/util/dict.py
+++ b/idseq_dag/util/dict.py
@@ -1,7 +1,7 @@
-import sqlite3
-import shelve
-import pathlib
 import multiprocessing
+import pathlib
+import shelve
+import sqlite3
 
 from enum import IntEnum
 

--- a/templates/accession2taxid_dag.json
+++ b/templates/accession2taxid_dag.json
@@ -17,15 +17,19 @@
       "accession2taxid.gz",
       "accession2taxid_wgs.gz",
       "accession2taxid.sqlite3",
-      "taxid2wgs_accession.sqlite3"
+      "taxid2wgs_accession.sqlite3",
+      "accession2taxid.db",
+      "taxid2wgs_accession.db"
     ],
     "nt_loc_out": [
       "nt_loc.sqlite3",
-      "nt_info.sqlite3"
+      "nt_info.sqlite3",
+      "nt_loc.db"
     ],
     "nr_loc_out": [
       "nr_loc.sqlite3",
-      "nr_info.sqlite3"
+      "nr_info.sqlite3",
+      "nr_loc.db"
     ]
   },
   "steps": [


### PR DESCRIPTION
# Description

Berkeley DB file generation was stopped in 
In https://github.com/chanzuckerberg/idseq-dag/pull/126 and https://github.com/chanzuckerberg/idseq-dag/pull/157 . Now that we've reverted back to BDB, this PR adds it back in the index file generation. 

# Notes

There appears to be an addition to the sqlite that was not back ported. It was introduced in https://github.com/chanzuckerberg/idseq-dag/pull/137 . 

# Tests

Run in pipeline dev machine
`python3 -m idseq_dag examples/accession2taxid_dag_test.json --no-lazy-run`

see `all steps done` message