### PR TITLE
Flexible Host Genome Index Generation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -110,6 +110,7 @@ RUN pip install scipy
 RUN pip install git+https://github.com/chanzuckerberg/srst2
 # TODO: Test both pip installations, consider keeping pip use consistent
 RUN pip3 install pandas
+RUN pip3 install psutil==5.6.3
 # Bedtools for obtaining total reads for each gene and calculating reads per million
 RUN apt-get install -y bedtools
 

--- a/examples/host_genome.json
+++ b/examples/host_genome.json
@@ -15,7 +15,7 @@
           "ercc_fasta": "s3://idseq-database/host_filter/pig/2019-02-06/ERCC.fasta", 
           "ercc_gtf": "s3://idseq-database/host_filter/pig/2019-02-06/ERCC.gtf" 
       },
-      "additional_attributes": {"host_name": "pig"}
+      "additional_attributes": {"host_name": "pig", "max_star_part_size": null}
     }
   ],
   "given_targets": {

--- a/examples/host_genome.json
+++ b/examples/host_genome.json
@@ -1,9 +1,9 @@
 {
   "name": "host_genome",
-  "output_dir_s3": "s3://idseq-database/host_filter/pig/2019-02-06",
+  "output_dir_s3": "s3://idseq-database/host_filter/mosquitos/2019-10-02",
   "targets": {
-    "host_fasta": ["GCA_002844635.1_USMARCv1.0_genomic.fna.gz"],
-    "host_index": ["fasta_with_ercc.fa", "gtf_with_ercc.fa", "pig_STAR_genome.tar", "pig_bowtie2_genome.tar"]
+    "host_fasta": ["mosquito_genomes_20181207.fa.gz"],
+    "host_index": ["fasta_with_ercc.fa", "gtf_with_ercc.fa", "mosquito_STAR_genome.tar", "mosquito_bowtie2_genome.tar"]
   },
   "steps": [
     {
@@ -12,15 +12,15 @@
       "class": "PipelineStepGenerateHostGenome",
       "module": "idseq_dag.steps.generate_host_genome",
       "additional_files": {
-          "ercc_fasta": "s3://idseq-database/host_filter/pig/2019-02-06/ERCC.fasta", 
-          "ercc_gtf": "s3://idseq-database/host_filter/pig/2019-02-06/ERCC.gtf" 
+          "ercc_fasta": "s3://idseq-database/host_filter/mosquitos/2019-10-02/ERCC.fasta", 
+          "ercc_gtf": "s3://idseq-database/host_filter/mosquitos/2019-10-02/ERCC.gtf" 
       },
-      "additional_attributes": {"host_name": "pig", "max_star_part_size": null}
+      "additional_attributes": {"host_name": "mosquito"}
     }
   ],
   "given_targets": {
     "host_fasta": {
-      "s3_dir": "s3://idseq-database/host_filter/pig/2019-02-06"
+      "s3_dir": "s3://idseq-database/host_filter/mosquitos/2019-10-02"
     }  
   }
 }

--- a/examples/host_genome.json
+++ b/examples/host_genome.json
@@ -1,9 +1,9 @@
 {
   "name": "host_genome",
-  "output_dir_s3": "s3://idseq-database/host_filter/mosquitos/2019-10-02",
+  "output_dir_s3": "s3://idseq-database/host_filter/pig/2019-02-06",
   "targets": {
-    "host_fasta": ["mosquito_genomes_20181207.fa.gz"],
-    "host_index": ["fasta_with_ercc.fa", "gtf_with_ercc.fa", "mosquito_STAR_genome.tar", "mosquito_bowtie2_genome.tar"]
+    "host_fasta": ["GCA_002844635.1_USMARCv1.0_genomic.fna.gz"],
+    "host_index": ["fasta_with_ercc.fa", "gtf_with_ercc.fa", "pig_STAR_genome.tar", "pig_bowtie2_genome.tar"]
   },
   "steps": [
     {
@@ -12,15 +12,15 @@
       "class": "PipelineStepGenerateHostGenome",
       "module": "idseq_dag.steps.generate_host_genome",
       "additional_files": {
-          "ercc_fasta": "s3://idseq-database/host_filter/mosquitos/2019-10-02/ERCC.fasta", 
-          "ercc_gtf": "s3://idseq-database/host_filter/mosquitos/2019-10-02/ERCC.gtf" 
+          "ercc_fasta": "s3://idseq-database/host_filter/pig/2019-02-06/ERCC.fasta", 
+          "ercc_gtf": "s3://idseq-database/host_filter/pig/2019-02-06/ERCC.gtf" 
       },
-      "additional_attributes": {"host_name": "mosquito"}
+      "additional_attributes": {"host_name": "pig", "max_star_part_size": null}
     }
   ],
   "given_targets": {
     "host_fasta": {
-      "s3_dir": "s3://idseq-database/host_filter/mosquitos/2019-10-02"
+      "s3_dir": "s3://idseq-database/host_filter/pig/2019-02-06"
     }  
   }
 }

--- a/idseq_dag/steps/generate_host_genome.py
+++ b/idseq_dag/steps/generate_host_genome.py
@@ -142,7 +142,8 @@ class PipelineStepGenerateHostGenome(PipelineStep):
                 '--runThreadN',
                 str(multiprocessing.cpu_count()), '--runMode', 'genomeGenerate',
                 *gtf_command_part, '--genomeDir', star_genome_part_dir,
-                '--genomeFastaFiles', fasta_file_list[i]
+                '--genomeFastaFiles', fasta_file_list[i],
+                '--limitGenomeGenerateRAM', os.path.getsize(fasta_file)
             ]
             command.execute(
                 command_patterns.SingleCommand(

--- a/idseq_dag/steps/generate_host_genome.py
+++ b/idseq_dag/steps/generate_host_genome.py
@@ -1,6 +1,7 @@
 ''' Generate Host Genome given a fasta'''
 import os
 import multiprocessing
+from psutil import virtual_memory
 
 from idseq_dag.engine.pipeline_step import PipelineStep
 import idseq_dag.util.command as command
@@ -143,7 +144,7 @@ class PipelineStepGenerateHostGenome(PipelineStep):
                 str(multiprocessing.cpu_count()), '--runMode', 'genomeGenerate',
                 *gtf_command_part, '--genomeDir', star_genome_part_dir,
                 '--genomeFastaFiles', fasta_file_list[i],
-                '--limitGenomeGenerateRAM', os.path.getsize(fasta_file)
+                '--limitGenomeGenerateRAM', virtual_memory().available
             ]
             command.execute(
                 command_patterns.SingleCommand(


### PR DESCRIPTION
Replace the constant `MAX_STAR_PART_SIZE` with a additional attribute that can optionally be set `max_star_part_size`. Default behaviour is no maximum.

Dynamically set the max RAM for STAR index generation for generating very large indexes with lots of RAM without needing to configure manually. This is a bit riskier than a limit so definitely open to feedback here.