### PR TITLE
Increment pipeline version for new NCBI indices

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,9 @@ TODO: Move this code over to the idseq-dag repo.
 
 ## Release notes
 
+- 3.11.0
+  - Use new NCBI indices, dated 2019-09-17
+
 - 3.10.1
   - Increase GSNAP threads to 48 for better utilization of r5d.metal instances.
 

--- a/idseq_dag/__init__.py
+++ b/idseq_dag/__init__.py
@@ -1,2 +1,1 @@
-''' idseq_dag '''
-__version__ = "3.10.1"
+__version__ = "3.11.0"


### PR DESCRIPTION
Although there is no code change to the main idseq pipeline, it seems like we should increment the version because the results will be different. 

Are there any more places the version should change? In idseq-web? 