### PR TITLE
Log error on amr allele mismatch.

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,9 @@ TODO: Move this code over to the idseq-dag repo.
 
 ## Release notes
 
+- 3.10.2
+  - Better logging for a rare AMR bug.
+
 - 3.10.1
   - Increase GSNAP threads to 48 for better utilization of r5d.metal instances.
 

--- a/idseq_dag/__init__.py
+++ b/idseq_dag/__init__.py
@@ -1,2 +1,2 @@
 ''' idseq_dag '''
-__version__ = "3.10.1"
+__version__ = "3.10.2"


### PR DESCRIPTION
This logs an error but still lets it fail.
This error was caused by typos in an AMR reference file. We fixed the typos, so this should never happen again, but if it does we should look into it asap.

See explanation of bug and how to debug it here:
https://czi.quip.com/wLYbATDfpUDQ/How-to-handle-AmrAlleleMismatchError