### PR TITLE
Add explicit output file to lz4

### DIFF
--- a/idseq_dag/steps/generate_lz4.py
+++ b/idseq_dag/steps/generate_lz4.py
@@ -20,13 +20,15 @@ class PipelineStepGenerateLZ4(PipelineStep):
                     command.execute(self.get_command(input_file))
 
     def get_command(self, input_file):
-        log.write(f"input: {input_file} output: {input_file}.lz4")
+        output_file = input_file + '.lz4';
+        log.write(f"input: {input_file} output: {output_file}")
         return command_patterns.SingleCommand(
             cmd="lz4",
             args=[
                 "-9", # max compression
                 "-f", # force overwrite output file
-                input_file
+                input_file,
+                output_file,
             ]
         )
 

--- a/tests/unit/steps/test_generate_lz4.py
+++ b/tests/unit/steps/test_generate_lz4.py
@@ -28,6 +28,6 @@ class TestPipelineStepGenerateLZ4(unittest.TestCase):
         command = self.step.get_command(INPUT_FILE)
         self.assertEqual('lz4', command.cmd)
         self.assertSequenceEqual(
-            ['-9', '-f', INPUT_FILE],
+            ['-9', '-f', INPUT_FILE, INPUT_FILE + '.lz4'],
             command.args
         )


### PR DESCRIPTION
# Description

This was causing an issue with newer versions of lz4, which output to stdout by default. 

# Tests

`python -m unittest tests/unit/steps/test_generate_lz4.py`
see test pass

`python -m idseq_dag examples/lz4_test.json`
see "all steps done"