### PR TITLE
Bump version

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,8 +227,11 @@ TODO: Move this code over to the idseq-dag repo.
 
 ## Release notes
 
+- 3.12.0
+  - Update NCBI databases to those downloaded on 2019-09-17.
+
 - 3.11.0
-  - Modify the LZW filter to apply a more stringent cutoff at higher read lengths. 
+  - Modify the LZW filter to apply a more stringent cutoff at higher read lengths.
 
 - 3.10.2
   - Better logging for a rare AMR bug.

--- a/idseq_dag/__init__.py
+++ b/idseq_dag/__init__.py
@@ -1,3 +1,3 @@
 ''' idseq_dag '''
-__version__ = "3.11.0"
+__version__ = "3.12.0"
 


### PR DESCRIPTION
This is needed to facilitate re-runs on the new NCBI indexes, because idseq-web is keyed on the pipeline version. 