### PR TITLE
Fix loose read counting bug with coverage viz.

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,9 @@ TODO: Move this code over to the idseq-dag repo.
 
 ## Release notes
 
+- 3.12.1
+  - Fix bug where reads unassigned during alignment that were assembled into contigs were also being counted as loose reads.
+
 - 3.12.0
   - Update NCBI databases to those downloaded on 2019-09-17.
 

--- a/idseq_dag/__init__.py
+++ b/idseq_dag/__init__.py
@@ -1,2 +1,2 @@
 ''' idseq_dag '''
-__version__ = "3.12.0"
+__version__ = "3.12.1"

--- a/idseq_dag/steps/generate_coverage_viz.py
+++ b/idseq_dag/steps/generate_coverage_viz.py
@@ -226,7 +226,10 @@ class PipelineStepGenerateCoverageViz(PipelineStep):
                 values = line.rstrip().split("\t")
 
                 # Only count the contig if the contig is valid, i.e. it is larger than min_contig_size.
-                if len(values) == 12 and values[7] in valid_contigs_with_read_counts:
+                #
+                # For a particular line in hit_summary, if the line only has 7 columns, this means the read wasn't assembled.
+                # If the line has 12 or 13 columns, then the read was assembled into a contig.
+                if len(values) >= 12 and values[7] in valid_contigs_with_read_counts:
                     taxon_data[values[9]]["accessions"].add(values[8])
                     accession_data[values[8]]["contigs"].add(values[7])
                 else:


### PR DESCRIPTION
In the coverage viz code, I assumed that rows in `gsnap.hitsummary2.tab` have 7 columns if the read was not assembled, and 12 columns if the read was assembled into a contig. It turns out a row can also have 13 columns if the read was assembled into a contig, and this read was previously not aligned to anything. (the 13th column just contains the string "from_assembly")

Due to this bug, these unassigned reads were being double counted.

The actual values in the coverage should be correct, but the "Loose Reads" count displayed at the top of the coverage viz can be much larger than expected.

# Tests
* Tested with a sample that was previously double-counting and verified that the double-counting has stopped.