### PR TITLE
stability improvements - less is more

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,8 +227,10 @@ TODO: Move this code over to the idseq-dag repo.
 
 ## Release notes
 
-- 3.13.1
+- 3.13.1 - 3.13.3
   - Make phylo tree and alignment viz steps more robust to missing accessions in index.
+  - Ensure reference caching respects version.
+  - Reduce frequency of s3 requests, other stability fixes.
 
 - 3.13
   - Rerank NT blast results by taking into account all fragments for a given contig and reference sequence, not just the highest scoring one.

--- a/idseq_dag/__init__.py
+++ b/idseq_dag/__init__.py
@@ -1,2 +1,2 @@
 ''' idseq_dag '''
-__version__ = "3.13.1"
+__version__ = "3.13.3"

--- a/idseq_dag/util/log.py
+++ b/idseq_dag/util/log.py
@@ -12,7 +12,7 @@ from collections import namedtuple
 
 from contextlib import contextmanager
 
-__print_lock = multiprocessing.RLock()
+print_lock = multiprocessing.RLock()  # print_lock is needed outside this module for voodoo magic in run_in_subprocess
 
 LogContext = namedtuple('LogContext', ['values', 'extra_fields'])
 
@@ -52,7 +52,7 @@ def write(message: str = None, warning: bool = False, flush: bool = True,
     debug(boolean): Optional. Log this event using debug level.
     flush(boolean): Optional (default true). Flush stdout after logging.
     '''
-    with __print_lock:
+    with print_lock:
         logger = logging.getLogger()
         if warning:
             logger.warning(msg=message, extra={"obj_data": obj_data})


### PR DESCRIPTION
* remove code paths that execute frequent concurrent s3 get-range operations to fetch reference sequences a-la-carte
    
    -- with the new approach of reference download caching on each batch instance (thanks Andrey Kislyuk), it's more efficient to fetch the entire 
    
    -- the code paths being removed have been replicated through copy-pasting that has introduced concurrency bugs over time
    
    -- the performance of these code paths has been unsatisfactory, and the frequency of calls a most likely cause of exceeding EC2 metadata server
    
    -- the replacement code path has already been executing in a large number of samples and is therefore well tested
    
* improve retry logic based on experience since it was first introduced
    
    -- properly disperse jitter across subprocesses;  previously, subprocesses would retry in lockstep due to drawing from the same random stream 
    
    -- for longer operations, the delay between retries is now longer
    
    -- this version has received some external testing in http://github.com/czbiohub/iggtools
    
* restore print_lock voodoo to run_in_subprocess decorator
    
    -- this was first introduced in release 2.7.4 pull request 61
    
    -- it offers some protection against known races between file locking in CPython and multiprocessing forks, which can cause deadlock
    
*  replace multithreading locks with multiprocessing locks;  work the same but safer
    
*  cache check_s3_presence in fetch_reference
    
*  in fetch_reference prefer compressed only if allow_s3mi = True;  compresison is used for CRC and only s3mi downloads need extra checking;  this
