### PR TITLE
Make phylo tree and alignment viz steps more robust to index errors.

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,9 @@ TODO: Move this code over to the idseq-dag repo.
 
 ## Release notes
 
+- 3.13.1
+  - Make phylo tree and alignment viz steps more robust to missing accessions in index.
+
 - 3.13
   - Rerank NT blast results by taking into account all fragments for a given contig and reference sequence, not just the highest scoring one.
 

--- a/idseq_dag/__init__.py
+++ b/idseq_dag/__init__.py
@@ -1,2 +1,2 @@
 ''' idseq_dag '''
-__version__ = "3.13"
+__version__ = "3.13.1"

--- a/idseq_dag/steps/generate_phylo_tree.py
+++ b/idseq_dag/steps/generate_phylo_tree.py
@@ -290,6 +290,8 @@ class PipelineStepGeneratePhyloTree(PipelineStep):
         # Choose accessions to process.
         s3_hitsummary2_files = self.additional_attributes["hitsummary2_files"].values()
         accessions = defaultdict(lambda: 0)
+        # TODO: Address issue where accessions in nr can be chosen in the following code.
+        # These accessions will not be found in nt_loc and will be subsequently omitted.
         for file_list in s3_hitsummary2_files:
             tally = defaultdict(lambda: 0)
             for s3_file in file_list:
@@ -320,7 +322,7 @@ class PipelineStepGeneratePhyloTree(PipelineStep):
         # Put 1 fasta file per accession into the destination directory
         accession_fastas = {}
         for acc, info in accession2info.items():
-            if info['seq_file'] is None:
+            if 'seq_file' not in info or info['seq_file'] is None:
                 log.write(f"WARNING: No sequence retrieved for {acc}")
                 continue
             clean_accession = self.clean_name_for_ksnp3(acc)


### PR DESCRIPTION
Related to an on-call issue this week.

The issue was resolved separately by https://github.com/chanzuckerberg/idseq-dag/pull/218

However, this change still makes the code more robust to a particular type of failure, where a particular accession cannot be found in the `nt` file. Instead of crashing the pipeline step, the code will attempt to continue with the missing data.

We can add a datadog alert on `ntDbIndexError` so we can be alerted when this error occurs.