### PR TITLE
Generate info DBs in shelve format

### DIFF
--- a/examples/accession2taxid_dag_test.json
+++ b/examples/accession2taxid_dag_test.json
@@ -22,12 +22,14 @@
     "nt_loc_out": [
       "nt_loc.sqlite3",
       "nt_info.sqlite3",
-      "nt_loc.db"
+      "nt_loc.db",
+      "nt_info.db"
     ],
     "nr_loc_out": [
       "nr_loc.sqlite3",
       "nr_info.sqlite3",
-      "nr_loc.db"
+      "nr_loc.db",
+      "nr_info.db"
     ]
   },
   "steps": [

--- a/examples/generate_coverage_viz.json
+++ b/examples/generate_coverage_viz.json
@@ -24,7 +24,7 @@
       "class": "PipelineStepGenerateCoverageViz",
       "module": "idseq_dag.steps.generate_coverage_viz",
       "additional_files": {
-        "info_db": "s3://idseq-database/alignment_data/2018-12-01/nt_info.sqlite3"
+        "info_db": "s3://idseq-database/alignment_data/2018-12-01/nt_info.db"
       },
       "additional_attributes": {}
     }

--- a/idseq_dag/steps/generate_coverage_viz.py
+++ b/idseq_dag/steps/generate_coverage_viz.py
@@ -37,11 +37,6 @@ class PipelineStepGenerateCoverageViz(PipelineStep):  # pylint: disable=abstract
         num_accessions_per_taxon = self.additional_attributes.get("num_accessions_per_taxon", NUM_ACCESSIONS_PER_TAXON)
         min_contig_size = self.additional_attributes.get("min_contig_size", MIN_CONTIG_SIZE)
 
-        # Info DB contains the name and sequence length of each accession.
-        # IMPORTANT NOTE: This info_db file is currently nt_info.sqlite3.
-        # SQLite is known to fail intermittently in our pipeline when it is
-        # run inside of multiprocessing. So don't do that here, or else switch
-        # to berkeley DB, as detailed in https://jira.czi.team/browse/IDSEQ-1536.
         info_db = s3.fetch_reference(
             self.additional_files["info_db"],
             self.ref_dir_local,

--- a/idseq_dag/steps/generate_loc_db.py
+++ b/idseq_dag/steps/generate_loc_db.py
@@ -24,8 +24,7 @@ class PipelineStepGenerateLocDB(PipelineStep):
         self.generate_loc_db_for_sqlite(db_file, loc_db_file_sqlite, info_db_file_sqlite)
 
         loc_db_file = self.output_files_local()[2]
-        # TODO: (gdingle): this needs to be added
-        # info_db_file = self.output_files_local()[3]
+        self.info_db_file = self.output_files_local()[3]
         self.generate_loc_db_for_shelf(db_file, loc_db_file)
 
     @staticmethod
@@ -85,32 +84,48 @@ class PipelineStepGenerateLocDB(PipelineStep):
             PipelineStepGenerateLocDB.generate_loc_db_work(db_file, loc_db, info_db)
 
     @run_in_subprocess
-    def generate_loc_db_for_shelf(self, db_file, loc_db_file):
+    def generate_loc_db_for_shelf(self, db_file, loc_db_file, info_db_file):
         loc_dict = shelve.Shelf(dbm.ndbm.open(loc_db_file.replace(".db", ""), 'c'))
+        info_dict = shelve.Shelf(dbm.ndbm.open(info_db_file.replace(".db", ""), 'c'))
         with open(db_file) as dbf:
             seq_offset = 0
             seq_len = 0
+            seq_bp_len = 0
             header_len = 0
             lines = 0
             accession_id = ""
+            accession_name = ""
             for line in dbf:
                 lines += 1
                 if lines % 100000 == 0:
                     log.write(f"{lines/1000000.0}M lines")
                 if line[0] == '>':  # header line
                     if seq_len > 0 and len(accession_id) > 0:
-                        loc_dict[accession_id] = (seq_offset, header_len, seq_len)
+                        loc_dict[accession_id] = [seq_offset, header_len, seq_len]
+                    if seq_bp_len > 0 and len(accession_name) > 0:
+                        info_dict[accession_id] = [accession_name, seq_bp_len]
+
                     seq_offset = seq_offset + header_len + seq_len
                     header_len = len(line)
                     seq_len = 0
-                    s = re.match('^>([^ ]*).*', line)
+                    seq_bp_len = 0
+                    accession_name = ""
+                    # Sometimes multiple accessions will be mapped to a single sequence.
+                    # In this case, they will be separated by the \x01 char.
+                    # To get the accession name, just match until the first \x01.
+                    s = re.match('^>([^ ]*) ([^\x01]*).*', line)
                     if s:
                         accession_id = s.group(1)
+                        accession_name = s.group(2)
                 else:
                     seq_len += len(line)
+                    seq_bp_len += len(line.strip())
             if seq_len > 0 and len(accession_id) > 0:
-                loc_dict[accession_id] = (seq_offset, header_len, seq_len)
+                loc_dict[accession_id] = [seq_offset, header_len, seq_len]
+            if seq_bp_len > 0 and len(accession_name) > 0:
+                info_dict[accession_id] = [accession_name, seq_bp_len]
         loc_dict.close()
+        info_dict.close()
 
     def count_reads(self):
         ''' Count reads '''

--- a/idseq_dag/steps/generate_loc_db.py
+++ b/idseq_dag/steps/generate_loc_db.py
@@ -85,6 +85,8 @@ class PipelineStepGenerateLocDB(PipelineStep):
 
     @run_in_subprocess
     def generate_loc_db_for_shelf(self, db_file, loc_db_file, info_db_file):
+        # Logic copied from generate_loc_db_work
+        #   slightly changed for writing to shelve format
         loc_dict = shelve.Shelf(dbm.ndbm.open(loc_db_file.replace(".db", ""), 'c'))
         info_dict = shelve.Shelf(dbm.ndbm.open(info_db_file.replace(".db", ""), 'c'))
         with open(db_file) as dbf:

--- a/idseq_dag/steps/generate_loc_db.py
+++ b/idseq_dag/steps/generate_loc_db.py
@@ -24,8 +24,8 @@ class PipelineStepGenerateLocDB(PipelineStep):
         self.generate_loc_db_for_sqlite(db_file, loc_db_file_sqlite, info_db_file_sqlite)
 
         loc_db_file = self.output_files_local()[2]
-        self.info_db_file = self.output_files_local()[3]
-        self.generate_loc_db_for_shelf(db_file, loc_db_file)
+        info_db_file = self.output_files_local()[3]
+        self.generate_loc_db_for_shelf(db_file, loc_db_file, info_db_file)
 
     @staticmethod
     def generate_loc_db_work(db_file, loc_db, info_db):

--- a/templates/accession2taxid_dag.json
+++ b/templates/accession2taxid_dag.json
@@ -24,12 +24,14 @@
     "nt_loc_out": [
       "nt_loc.sqlite3",
       "nt_info.sqlite3",
-      "nt_loc.db"
+      "nt_loc.db",
+      "nt_info.db"
     ],
     "nr_loc_out": [
       "nr_loc.sqlite3",
       "nr_info.sqlite3",
-      "nr_loc.db"
+      "nr_loc.db",
+      "nr_info.db"
     ],
     "lz4_out": [
       "accession2taxid.sqlite3.lz4",
@@ -39,9 +41,11 @@
       "nt_loc.sqlite3.lz4",
       "nt_info.sqlite3.lz4",
       "nt_loc.db.lz4",
+      "nt_loc.db.lz4",
       "nr_loc.sqlite3.lz4",
       "nr_info.sqlite3.lz4",
-      "nr_loc.db.lz4"
+      "nr_loc.db.lz4",
+      "nr_info.db.lz4"
     ]
   },
   "steps": [

--- a/templates/accession2taxid_dag.json
+++ b/templates/accession2taxid_dag.json
@@ -41,7 +41,7 @@
       "nt_loc.sqlite3.lz4",
       "nt_info.sqlite3.lz4",
       "nt_loc.db.lz4",
-      "nt_loc.db.lz4",
+      "nt_info.db.lz4",
       "nr_loc.sqlite3.lz4",
       "nr_info.sqlite3.lz4",
       "nr_loc.db.lz4",


### PR DESCRIPTION
Generate a shelve file for the info db as well.

## Test plan

I will run this on the 10-01 configs then do some custom pipeline runs with that config and manually setting the path. In theory it should work with no changes to the dag code itself.