### PR TITLE
[READY] reliability improvements for s3 operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,12 @@ TODO: Move this code over to the idseq-dag repo.
 
 ## Release notes
 
+- 3.14.1
+  - aws credential caching and other stability improvements
+
+- 3.14
+  - add average insert size computation
+
 - 3.13.1 - 3.13.3
   - Make phylo tree and alignment viz steps more robust to missing accessions in index.
   - Ensure reference caching respects version.

--- a/idseq_dag/__init__.py
+++ b/idseq_dag/__init__.py
@@ -1,2 +1,2 @@
 ''' idseq_dag '''
-__version__ = "3.13.3"
+__version__ = "3.14.1"

--- a/idseq_dag/engine/pipeline_flow.py
+++ b/idseq_dag/engine/pipeline_flow.py
@@ -38,7 +38,7 @@ class PipelineFlow(object):
         self.output_dir_local = dag.get("output_dir_local", DEFAULT_OUTPUT_DIR_LOCAL).rstrip('/')
         self.ref_dir_local = dag.get("ref_dir_local", DEFAULT_REF_DIR_LOCAL)
         idseq_dag.util.s3.config["REF_DIR"] = self.ref_dir_local
-        idseq_dag.util.s3.config["REF_FETCH_LOG_DIR"] = os.path.join(self.ref_dir_local, "fetch_log")
+        # idseq_dag.util.s3.config["REF_FETCH_LOG_DIR"] = os.path.join(self.ref_dir_local, "fetch_log")
         self.large_file_list = []
 
         self.step_status_local = f"{self.output_dir_local}/{self.name}_status.json"

--- a/idseq_dag/steps/blast_contigs.py
+++ b/idseq_dag/steps/blast_contigs.py
@@ -183,15 +183,15 @@ class PipelineStepBlastContigs(PipelineStep):  # pylint: disable=abstract-method
                                          refined_hit_summary, refined_m8)
 
         # Generating taxon counts based on updated results
-        lineage_db = s3.fetch_from_s3(
+        lineage_db = s3.fetch_reference(
             self.additional_files["lineage_db"],
             self.ref_dir_local,
             allow_s3mi=False)  # Too small to waste s3mi
         deuterostome_db = None
         evalue_type = 'raw'
         if self.additional_files.get("deuterostome_db"):
-            deuterostome_db = s3.fetch_from_s3(self.additional_files["deuterostome_db"],
-                                               self.ref_dir_local, allow_s3mi=False)  # Too small for s3mi
+            deuterostome_db = s3.fetch_reference(self.additional_files["deuterostome_db"],
+                                                 self.ref_dir_local, allow_s3mi=False)  # Too small for s3mi
         with TraceLock("PipelineStepBlastContigs-CYA", PipelineStepBlastContigs.cya_lock, debug=False):
             with log.log_context("PipelineStepBlastContigs", {"substep": "generate_taxon_count_json_from_m8", "db_type": db_type, "refined_counts": refined_counts}):
                 m8.generate_taxon_count_json_from_m8(refined_m8, refined_hit_summary,

--- a/idseq_dag/steps/fetch_tax_info.py
+++ b/idseq_dag/steps/fetch_tax_info.py
@@ -4,13 +4,13 @@ import re
 import time
 import wikipedia
 from Bio import Entrez
-import idseq_dag.util.command as command
 import idseq_dag.util.log as log
 import idseq_dag.util.s3 as s3
 from idseq_dag.engine.pipeline_step import PipelineStep
 from idseq_dag.util.trace_lock import TraceLock
 
 
+# This does not run from the actual pipeline.  It's an index generation step.
 class PipelineStepFetchTaxInfo(PipelineStep):
     '''
         fetch tax info based on a list
@@ -31,12 +31,14 @@ class PipelineStepFetchTaxInfo(PipelineStep):
         namecsv = self.additional_files.get("taxon2name")
         id2namedict = {}
         if namecsv:
+            # This is fetching a reference without fetch_reference;  but ok because does not run from the actual pipeline
             namecsvf = s3.fetch_from_s3(namecsv, "/mnt/idseq/ref")
             with open(namecsvf, 'r') as namef:
                 for line in namef:
                     fields = line.rstrip().split(",")
                     id2namedict[fields[0]] = fields[1]
 
+        # This is fetching a reference without fetch_reference and doing a presence check;  but ok because does not run from the actual pipeline
         if s3.check_s3_presence(self.s3_path(taxid2wiki)):
             # generated
             taxid2wiki = s3.fetch_from_s3(self.s3_path(taxid2wiki), taxid2wiki)

--- a/idseq_dag/steps/generate_alignment_viz.py
+++ b/idseq_dag/steps/generate_alignment_viz.py
@@ -10,7 +10,6 @@ import threading
 from idseq_dag.engine.pipeline_step import PipelineStep
 from idseq_dag.util.lineage import INVALID_CALL_BASE_ID
 import idseq_dag.util.log as log
-from idseq_dag.util.trace_lock import TraceLock
 import idseq_dag.util.command as command
 import idseq_dag.util.s3 as s3
 
@@ -30,8 +29,6 @@ class PipelineStepGenerateAlignmentViz(PipelineStep):
     def run(self):
         # Setup
         nt_db = self.additional_attributes["nt_db"]
-        if nt_db.startswith("s3://") and not s3.check_s3_presence(nt_db):
-            raise RuntimeError(f"nt_db at {nt_db} not found.")
         nt_loc_db = s3.fetch_reference(
             self.additional_files["nt_loc_db"],
             self.ref_dir_local,

--- a/idseq_dag/steps/generate_phylo_tree.py
+++ b/idseq_dag/steps/generate_phylo_tree.py
@@ -298,7 +298,7 @@ class PipelineStepGeneratePhyloTree(PipelineStep):
                 local_basename = s3_file.replace("/", "-").replace(":", "-")
                 local_file = s3.fetch_from_s3(
                     s3_file,
-                    os.path.join(self.ref_dir_local, local_basename))
+                    os.path.join(self.output_dir_local, local_basename))
                 if local_file is None:
                     continue
                 with open(local_file, 'r') as f:

--- a/idseq_dag/steps/generate_taxid_fasta.py
+++ b/idseq_dag/steps/generate_taxid_fasta.py
@@ -22,7 +22,7 @@ class PipelineStepGenerateTaxidFasta(PipelineStep):
             hit_summary_files = {'NT': input_files[1], 'NR': input_files[2]}
 
         # Open lineage db
-        lineage_db = s3.fetch_from_s3(
+        lineage_db = s3.fetch_reference(
             self.additional_files["lineage_db"],
             self.ref_dir_local,
             allow_s3mi=True)

--- a/idseq_dag/steps/run_alignment_remotely.py
+++ b/idseq_dag/steps/run_alignment_remotely.py
@@ -93,10 +93,10 @@ class PipelineStepRunAlignmentRemotely(PipelineStep):
         self.run_remotely(input_fas, output_m8, service)
 
         # get database
-        lineage_db = fetch_from_s3(self.additional_files["lineage_db"], self.ref_dir_local)
+        lineage_db = fetch_reference(self.additional_files["lineage_db"], self.ref_dir_local)
         accession2taxid_db = fetch_reference(self.additional_files["accession2taxid_db"], self.ref_dir_local, allow_s3mi=True)
         blacklist_s3_file = self.additional_attributes.get('taxon_blacklist', DEFAULT_BLACKLIST_S3)
-        taxon_blacklist = fetch_from_s3(blacklist_s3_file, self.ref_dir_local)
+        taxon_blacklist = fetch_reference(blacklist_s3_file, self.ref_dir_local)
         m8.call_hits_m8(output_m8, lineage_db, accession2taxid_db,
                         deduped_output_m8, output_hitsummary, min_alignment_length, taxon_blacklist)
 
@@ -105,8 +105,8 @@ class PipelineStepRunAlignmentRemotely(PipelineStep):
         db_type = 'NT' if service == 'gsnap' else 'NR'
         evalue_type = 'log10' if service == 'rapsearch2' else 'raw'
         if self.additional_files.get("deuterostome_db"):
-            deuterostome_db = fetch_from_s3(self.additional_files["deuterostome_db"],
-                                            self.ref_dir_local, allow_s3mi=True)
+            deuterostome_db = fetch_reference(self.additional_files["deuterostome_db"],
+                                              self.ref_dir_local, allow_s3mi=True)
         m8.generate_taxon_count_json_from_m8(
             deduped_output_m8, output_hitsummary, evalue_type, db_type,
             lineage_db, deuterostome_db, output_counts_json)
@@ -399,7 +399,7 @@ class PipelineStepRunAlignmentRemotely(PipelineStep):
             # Strip the .m8 for RAPSearch as it adds that
         )
 
-        if lazy_run and fetch_from_s3(multihit_s3_outfile, multihit_local_outfile):
+        if lazy_run and fetch_from_s3(multihit_s3_outfile, multihit_local_outfile, okay_if_missing=True, allow_s3mi=False):
             log.write(f"finished alignment for chunk {chunk_id} with {service} by lazily fetching last result")
         else:
             chunk_timeout = int(self.additional_attributes.get(f"{service.lower()}_chunk_timeout",

--- a/idseq_dag/steps/run_bowtie2.py
+++ b/idseq_dag/steps/run_bowtie2.py
@@ -6,7 +6,7 @@ import idseq_dag.util.command_patterns as command_patterns
 import idseq_dag.util.count as count
 import idseq_dag.util.convert as convert
 import idseq_dag.util.log as log
-from idseq_dag.util.s3 import fetch_from_s3
+from idseq_dag.util.s3 import fetch_reference
 
 
 class PipelineStepRunBowtie2(PipelineStep):
@@ -40,7 +40,7 @@ class PipelineStepRunBowtie2(PipelineStep):
     def run(self):
         input_fas = self.input_files_local[0][0:2]
         output_fas = self.output_files_local()
-        genome_dir = fetch_from_s3(
+        genome_dir = fetch_reference(
             self.additional_files["bowtie2_genome"],
             self.ref_dir_local,
             allow_s3mi=True,

--- a/idseq_dag/steps/run_gsnap_filter.py
+++ b/idseq_dag/steps/run_gsnap_filter.py
@@ -5,7 +5,7 @@ import idseq_dag.util.command_patterns as command_patterns
 import idseq_dag.util.convert as convert
 import idseq_dag.util.log as log
 import idseq_dag.util.count as count
-from idseq_dag.util.s3 import fetch_from_s3
+from idseq_dag.util.s3 import fetch_reference
 
 
 class PipelineStepRunGsnapFilter(PipelineStep):
@@ -45,10 +45,10 @@ class PipelineStepRunGsnapFilter(PipelineStep):
                                        self.additional_attributes["output_sam_file"])
         self.additional_files_to_upload.append(output_sam_file)
 
-        genome_dir = fetch_from_s3(self.additional_files["gsnap_genome"],
-                                   self.ref_dir_local,
-                                   allow_s3mi=True,
-                                   auto_untar=True)
+        genome_dir = fetch_reference(self.additional_files["gsnap_genome"],
+                                     self.ref_dir_local,
+                                     allow_s3mi=True,
+                                     auto_untar=True)
         gsnap_base_dir = os.path.dirname(genome_dir)
         gsnap_index_name = os.path.basename(genome_dir)
         # Run Gsnap

--- a/idseq_dag/steps/run_srst2.py
+++ b/idseq_dag/steps/run_srst2.py
@@ -4,7 +4,7 @@ import shutil
 from functools import reduce
 
 from idseq_dag.engine.pipeline_step import PipelineStep
-from idseq_dag.util.s3 import fetch_from_s3
+from idseq_dag.util.s3 import fetch_reference
 import idseq_dag.util.command as command
 import idseq_dag.util.command_patterns as command_patterns
 import idseq_dag.util.log as log
@@ -90,7 +90,8 @@ class PipelineStepRunSRST2(PipelineStep):
 
     def get_common_params(self):
         """Helper that gets srst2 parameters common to both paired and single rds."""
-        db_file_path = fetch_from_s3(self.additional_files["resist_gene_db"], self.output_dir_local, allow_s3mi=False)  # too small for s3mi
+        # TODO:  Why is this not fetch_reference?   So it can be cached.
+        db_file_path = fetch_reference(self.additional_files["resist_gene_db"], self.ref_dir_local, allow_s3mi=False)  # too small for s3mi
         min_cov = str(self.additional_attributes['min_cov'])
         # srst2 expects this to be a string, in dag could be passed in as a number
         n_threads = str(self.additional_attributes['n_threads'])
@@ -118,7 +119,7 @@ class PipelineStepRunSRST2(PipelineStep):
     def generate_mapped_reads_tsv(self):
         """Use bedtools to generate a table of mapped reads for each genome in the ARG ANNOT database.
             If a new resistance gene db is used, the .bed file will need to be updated manually."""
-        bed_file_path = fetch_from_s3(self.additional_files["resist_genome_bed"], self.output_dir_local, allow_s3mi=False)
+        bed_file_path = fetch_reference(self.additional_files["resist_genome_bed"], self.ref_dir_local, allow_s3mi=False)
         sample_bam_file_path = self.output_files_local()[5]
 
         tmp_sort_dir = os.path.join(self.output_dir_local, "tmp_sort")

--- a/idseq_dag/steps/run_star.py
+++ b/idseq_dag/steps/run_star.py
@@ -137,7 +137,7 @@ class PipelineStepRunStar(PipelineStep):
         output_files_local = self.output_files_local()
         output_gene_file = self.additional_attributes.get("output_gene_file")
 
-        genome_dir = s3.fetch_from_s3(
+        genome_dir = s3.fetch_reference(
             self.additional_files["star_genome"],
             self.ref_dir_local,
             allow_s3mi=True,
@@ -385,7 +385,7 @@ class PipelineStepRunStar(PipelineStep):
             if line[0] == 64:  # Equivalent to '@', fastq format
                 rid = PipelineStepRunStar.extract_rid(line.decode('utf-8'))
                 read.append(line)
-                for i in range(3):
+                for _ in range(3):
                     read.append(f.readline())
             elif line[0] == 62:  # Equivalent to '>', fasta format
                 rid = PipelineStepRunStar.extract_rid(line.decode('utf-8'))

--- a/idseq_dag/steps/run_trimmomatic.py
+++ b/idseq_dag/steps/run_trimmomatic.py
@@ -77,7 +77,7 @@ class PipelineStepRunTrimmomatic(PipelineStep):
         input_files = self.input_files_local[0][0:2]
         output_files = self.output_files_local()
         is_paired = (len(input_files) == 2)
-        adapter_fasta = s3.fetch_from_s3(
+        adapter_fasta = s3.fetch_reference(
             self.additional_files["adapter_fasta"],
             self.ref_dir_local)
 

--- a/idseq_dag/util/command_patterns.py
+++ b/idseq_dag/util/command_patterns.py
@@ -57,11 +57,12 @@ class SingleCommand(CommandPattern):
             )
         )
     '''
-    def __init__(self, cmd: str, args: List[Union[int, str]], cd: str = None):
+    def __init__(self, cmd: str, args: List[Union[int, str]], cd: str = None, env: Dict[str, str] = None):
         super().__init__()
         self.cmd = cmd
         self.args = args
         self.cd = cd
+        self.env = env  # do not print or log env
 
     def _command_args(self):
         return iter([self.cmd, *(str(a) for a in self.args)])
@@ -71,6 +72,7 @@ class SingleCommand(CommandPattern):
             self._command_args(),
             shell=False,
             cwd=self.cd,
+            env=os.environ if self.env == None else self.env,
             stdin=stdin,
             stdout=stdout,
             stderr=stderr
@@ -162,7 +164,7 @@ class ShellScriptCommand(CommandPattern):
                 script.sh <...all parameters here...>
 
     """
-    def __init__(self, script: str, args: List[Union[int, str]] = None, named_args: Dict[str, Union[int, str, List[Union[int, str]]]] = None, cd: str = None):
+    def __init__(self, script: str, args: List[Union[int, str]] = None, named_args: Dict[str, Union[int, str, List[Union[int, str]]]] = None, cd: str = None, env: Dict[str, str] = None):
         super().__init__()
         assert (args is None) or (named_args is None), "You need to use either args or named_args"
         self.script = script
@@ -170,6 +172,7 @@ class ShellScriptCommand(CommandPattern):
         self.named_args = named_args
         self.popen_handler = None
         self.cd = cd
+        self.env = env  # do not print or log env
 
     def _script_named_args(self):
         args = []
@@ -213,6 +216,7 @@ class ShellScriptCommand(CommandPattern):
             self._command_args(),
             shell=True,
             cwd=self.cd,
+            env=os.environ if self.env == None else self.env,
             stdin=stdin,
             stdout=stdout,
             stderr=stderr,

--- a/idseq_dag/util/s3.py
+++ b/idseq_dag/util/s3.py
@@ -2,12 +2,9 @@ import time
 import subprocess
 import os
 import multiprocessing
-import logging
 import errno
-import base64
-import hashlib
-import json
 from urllib.parse import urlparse
+import traceback
 import boto3
 import botocore
 from idseq_dag.util.trace_lock import TraceLock
@@ -18,10 +15,10 @@ import idseq_dag.util.log as log
 
 # Peak network and storage perf for a typical small instance is saturated by
 # just a few concurrent streams.
-MAX_CONCURRENT_COPY_OPERATIONS = 8
+MAX_CONCURRENT_COPY_OPERATIONS = 12
 IOSTREAM = multiprocessing.Semaphore(MAX_CONCURRENT_COPY_OPERATIONS)
 # Make a second semaphore for uploads to reserve some capacity for downloads.
-MAX_CONCURRENT_UPLOAD_OPERATIONS = 4
+MAX_CONCURRENT_UPLOAD_OPERATIONS = 8
 MAX_CONCURRENT_S3MI_DOWNLOADS = 2
 # If a s3mi slot does not free up within MAX_S3MI_WAIT seconds, we use plain old aws s3 cp instead of s3mi.
 MAX_S3MI_WAIT = 15
@@ -31,20 +28,37 @@ IOSTREAM_UPLOADS = multiprocessing.Semaphore(MAX_CONCURRENT_UPLOAD_OPERATIONS)
 config = {
     # Configured in idseq_dag.engine.pipeline_flow.PipelineFlow
     "REF_DIR": "ref",
-    "REF_FETCH_LOG_DIR": "fetch_log"
+    # "REF_FETCH_LOG_DIR": "fetch_log"
 }
 
 def split_identifiers(s3_path):
     return s3_path[5:].split("/", 1)
 
-def check_s3_presence(s3_path, allow_zero_byte_files=True):
+
+# Boto's default session is global and shared across threads.   As long as this is the
+# only place that we use boto and we never call functions here from multiple processes
+# (threads okay) and all accesses here are protected by this lock, we should be fine.
+# But still easy to defeat this safety by just importing boto into another file.
+# TODO:  Create our own private boto session protected by this lock.
+botolock = multiprocessing.RLock()  # Please don't trace me, I am very lightweight.
+
+
+def rate_limit_boto(average_delay=0.33, last_call={}):  # pylint: disable=dangerous-default-value
+    '''Sleep to ensure at least average_delay has elapsed since the last call.'''
+    with botolock:
+        t_since_last_call = time.time() - last_call.get("time", 0)
+        if t_since_last_call < average_delay:
+            time.sleep(average_delay - t_since_last_call)
+        last_call["time"] = time.time()
+
+
+def _check_s3_presence(s3_path, allow_zero_byte_files):
     """True if s3_path exists. False otherwise."""
     with log.log_context(context_name="s3.check_s3_presence", values={'s3_path': s3_path}, log_context_mode=log.LogContextMode.EXEC_LOG_EVENT) as lc:
         parsed_url = urlparse(s3_path, allow_fragments=False)
         bucket = parsed_url.netloc
         key = parsed_url.path.lstrip('/')
         try:
-            # TODO:  Don't boto3.resource(s3) objects share the global boto "default" session?   Can that be used from multiple processes/threads?
             o = boto3.resource('s3').Object(
                 bucket,
                 key
@@ -62,36 +76,87 @@ def check_s3_presence(s3_path, allow_zero_byte_files=True):
         return exists
 
 
-def check_s3_presence_for_file_list(s3_dir, file_list):
-    for f in file_list:
-        if not check_s3_presence(os.path.join(s3_dir, f)):
-            return False
+def check_s3_presence(s3_path, allow_zero_byte_files=True):
+    with botolock:
+        rate_limit_boto()
+        return _check_s3_presence(s3_path, allow_zero_byte_files)
+
+
+def check_s3_presence_for_file_list(s3_dir, file_list, allow_zero_byte_files=True):
+    with botolock:
+        for f in file_list:
+            rate_limit_boto()
+            if not _check_s3_presence(os.path.join(s3_dir, f), allow_zero_byte_files):
+                return False
     return True
 
 
-def touch_s3_file(s3_file_path):
+@command.retry
+def _get_credentials():
+    log.write("Refreshing credentials.")
+    session = botocore.session.Session()
+    credentials = session.get_credentials()
+    return {
+        "AWS_ACCESS_KEY_ID": credentials.access_key,
+        "AWS_SECRET_ACCESS_KEY": credentials.secret_key,
+        "AWS_SESSION_TOKEN": credentials.token,
+        "AWS_DEFAULT_REGION": session.create_client("s3").meta.region_name
+    }
+
+
+def refreshed_credentials(credentials_mutex=multiprocessing.RLock(), credentials_cache={}):  # pylint: disable=dangerous-default-value
+    with credentials_mutex:
+        if credentials_cache.get("expiration_time", 0) < time.time() + 5 * 60:
+            try:
+                credentials_cache["vars"] = _get_credentials()
+            except:
+                log.write("ERROR:  Failed to refresh credentials with boto, even after retries.  Subcommands will have to do it themselves.")
+                log.write(traceback.format_exc())
+                return {}
+            credentials_cache["expiration_time"] = time.time() + 15 * 60  # this is the default for most accounts
+    return credentials_cache["vars"]
+
+
+def find_oldest_reference(refdir):
     try:
-        command.execute(
-            command_patterns.SingleCommand(
-                cmd="aws",
-                args=[
-                    "s3",
-                    "cp",
-                    "--metadata",
-                    '{"touched":"now"}',
-                    s3_file_path,
-                    s3_file_path
-                ]
-            )
-        )
-        return True
+        ls = subprocess.run(f"ls -t {refdir} | tail -1", shell=True, executable="/bin/bash", check=True, capture_output=True)
     except:
-        return False
+        # This happens when there are no reference files to delete.
+        return None
+    return ls.stdout.decode('utf-8').strip()
 
 
-def touch_s3_file_list(s3_dir, file_list):
-    for f in file_list:
-        touch_s3_file(os.path.join(s3_dir, f))
+def need_more_space(refdir):
+    try:
+        df = subprocess.run(f"df -m {refdir}" + " | awk '{print $5}' | tail -1 | sed 's=%=='", shell=True, executable="/bin/bash", check=True, capture_output=True)
+        percent_used = int(df.stdout.decode('utf-8').strip())
+        log.write(f"Disk used space: {percent_used} percent.")
+        return percent_used > 60
+    except:
+        log.write("Error:  Failed to determine available space on instance.  Will assume too little space is available, and will try to delete least recently used reference downloads.")
+        traceback.format_exc()
+        return True  # Better safe than sorry.
+
+
+def really_make_space():
+    refdir = config['REF_DIR']
+    while need_more_space(refdir):
+        lru = find_oldest_reference(refdir)
+        if not lru:
+            log.write("WARNING:  Too little available space on instance, and could not find any reference downloads to delete.")
+            break
+        command.remove_rf(os.path.join(refdir, lru))
+
+
+def make_space(done={}, mutex=TraceLock("make_space", multiprocessing.RLock())):  # pylint: disable=dangerous-default-value
+    with mutex:
+        if not done:
+            try:
+                really_make_space()
+            except:
+                log.write("Error making space.  Please attend to this before instance storage fills up.")
+                log.write(traceback.format_exc())
+            done['time'] = time.time()
 
 
 def install_s3mi(installed={}, mutex=TraceLock("install_s3mi", multiprocessing.RLock())):  # pylint: disable=dangerous-default-value
@@ -119,24 +184,56 @@ ZIP_EXTENSIONS = {
     ".gz": "gzip -dc",  # please avoid .gz if you can (slow to decompress)
 }
 
+
+# this should be a subset of ZIP_EXTENSIONS, and a very small one, because
+# there is a high cost to each new entry (one more s3 op per reference)
+REFERENCE_AUTOGUESS_ZIP_EXTENSIONS = {
+    ".lz4": "lz4 -dc",
+}
+
+
 def fetch_from_s3(src,  # pylint: disable=dangerous-default-value
                   dst,
                   auto_unzip=DEFAULT_AUTO_UNZIP,
                   auto_untar=DEFAULT_AUTO_UNTAR,
                   allow_s3mi=DEFAULT_ALLOW_S3MI,
+                  okay_if_missing=False,
+                  is_reference=False,
                   mutex=TraceLock("fetch_from_s3", multiprocessing.RLock()),
-                  locks={},
-                  downloaded_this_session={}):
-    """Fetch a file from S3 if needed, using either s3mi or aws cp."""
-    #
-    # IT IS NOT SAFE TO CALL THIS FUNCTION FROM MULTIPLE PROCESSES.
-    # It is totally fine to call it from multiple threads (it is designed for that).
-    #
+                  locks={}):
+    """Fetch a file from S3 if needed, using either s3mi or aws cp.
+
+    IT IS NOT SAFE TO CALL THIS FUNCTION FROM MULTIPLE PROCESSES.
+    It is totally fine to call it from multiple threads (it is designed for that).
+    """
     # Do not be mislead by the multiprocessing.RLock() above -- that just means it won't deadlock
     # if called from multiple processes but does not mean the behaivior will be correct.  It will
-    # be incorrect, because the locks{} and downloaded_this_session{} dicts cannot be shared.
+    # be incorrect, because the locks dict (cointaining per-file locks) cannot be shared across
+    # processes, the way it can be shared across threads.
+
+    make_space()  # this only does anything the first time
+
     if os.path.exists(dst) and os.path.isdir(dst):
-        dst = os.path.join(dst, os.path.basename(src))
+        dirname, basename = os.path.split(src)
+        if is_reference or os.path.abspath(dst).startswith(config["REF_DIR"]):
+            # Downloads to the reference dir are persisted from job to job, so we must include
+            # version information from the full s3 path.
+            #
+            # The final destination for s3://path/to/source.db will look like /mnt/ref/s3__path__to/source.db
+            # The final destination for s3://path/to/myarchive.tar will look like /mnt/ref/s3__path__to/myarchive/...
+            #
+            # We considered some other alternatives, for example /mnt/ref/s3__path__to__source.db, but unfortunately,
+            # some tools incorporate the base name of their database input into the output filenames, so any approach
+            # that changes the basename causes problems downstream.  An example such tool is srst2.
+            is_reference = True
+            if dirname.startswith("s3://"):
+                dirname = dirname.replace("s3://", "s3__", 1)
+            # If dirname contains slashes, it has to be flattened to single level.
+            dirname = dirname.replace("/", "__")
+            dst = os.path.join(dst, dirname, basename)
+        else:
+            dst = os.path.join(dst, basename)
+
     unzip = ""
     if auto_unzip:
         file_without_ext, ext = os.path.splitext(dst)
@@ -146,57 +243,34 @@ def fetch_from_s3(src,  # pylint: disable=dangerous-default-value
     untar = auto_untar and dst.lower().endswith(".tar")
     if untar:
         dst = dst[:-4]  # Remove .tar
-    abspath = os.path.abspath(dst)
 
+    # Downloads are staged under tmp_destdir.  Only after a download completes successfully it is moved to dst.
+    destdir = os.path.dirname(dst)
+    tmp_destdir = os.path.join(destdir, "tmp_downloads")
+    tmp_dst = os.path.join(tmp_destdir, os.path.basename(dst))
+
+    abspath = os.path.abspath(dst)
     with mutex:
         if abspath not in locks:
             locks[abspath] = TraceLock(f"fetch_from_s3: {abspath}", multiprocessing.RLock())
         destination_lock = locks[abspath]
 
     with destination_lock:
-        abspath_hash = base64.urlsafe_b64encode(hashlib.sha256(abspath.encode()).digest()).decode()
-        parsed_s3_url = urlparse(src, allow_fragments=False)
         # This check is a bit imperfect when untarring... unless you follow the discipline that
-        # all contents of file foo.tar are under directory foo/...
+        # all contents of file foo.tar are under directory foo/... (which we do follow in IDseq)
         if os.path.exists(dst):
-            # Because only reference files are persisted from job to job, if this isn't a reference file,
-            # and it exists, it was downloaded by the current job, which means it's fresh and there is
-            # no need to fetch it again from s3.
-            if not abspath.startswith(config["REF_DIR"]):
-                return dst
-            # If it is in the reference download directory, check the reference fetch log for a record of the source
-            # key and etag, and re-do the download only if they mismatch.  This check is only safe ONCE per run,
-            # because, after the first fetch during a given run, even if the source changed in S3, the local
-            # version may have local users so can't be clobbered.  In future we should remove the possibility of
-            # the same destination getting fetched from different source locations (with different compression
-            # formats, for example) but currently this possibility does exist, and without the downloaded_this_session
-            # cache, it would result in clobbered destinations and crashing.
-            with mutex:
-                if dst in downloaded_this_session:
-                    return dst
+            return dst
+
+        for (kind, ddir) in [("destinaiton", destdir), ("temporary download", tmp_destdir)]:
             try:
-                with open(os.path.join(config["REF_FETCH_LOG_DIR"], abspath_hash)) as fh:
-                    fetch_record = json.load(fh)
-                # TODO:  Don't boto3.resource(s3) objects share the global boto "default" session?   Can that be used from multiple processes/threads?
-                obj = boto3.resource('s3').Bucket(parsed_s3_url.netloc).Object(parsed_s3_url.path.lstrip('/'))
-                assert fetch_record["bucket_name"] == obj.bucket_name
-                assert fetch_record["key"] == obj.key
-                assert fetch_record["e_tag"] == obj.e_tag
-                return dst
-            except:  # pylint: disable=broad-except
-                # Let's fetch the file again.  We don't trust the local version.
-                # In this case we need to remove the local version recursively (as it could be expanded from tar).
-                command.remove_rf(dst)
-        try:
-            destdir = os.path.dirname(dst)
-            if destdir:
-                command.make_dirs(destdir)
-        except OSError as e:
-            # It's okay if the parent directory already exists, but all other
-            # errors are fatal.
-            if e.errno != errno.EEXIST:
-                log.write("Error in creating destination directory.")
-                raise
+                if ddir:
+                    command.make_dirs(ddir)
+            except OSError as e:
+                # It's okay if the parent directory already exists, but all other
+                # errors are fatal.
+                if e.errno != errno.EEXIST:
+                    log.write(f"Error in creating {kind} directory.")
+                    raise
 
         with IOSTREAM:
             try:
@@ -217,53 +291,65 @@ def fetch_from_s3(src,  # pylint: disable=dangerous-default-value
                         log.write(f"Waited {wait_duration} seconds to acquire S3MI semaphore for {src}.")
 
                 if untar:
-                    write_dst = r''' | tar xvf - -C "${destdir}";'''
-                    named_args = {'destdir': destdir}
+                    write_dst = r''' | tar xvf - -C "${tmp_destdir}";'''
+                    named_args = {'tmp_destdir': tmp_destdir}
                 else:
-                    write_dst = r''' > "${dst}";'''
-                    named_args = {'dst': dst}
+                    write_dst = r''' > "${tmp_dst}";'''
+                    named_args = {'tmp_dst': tmp_dst}
                 command_params = f"{unzip} {write_dst}"
 
                 named_args.update({'src': src})
-                try:
-                    assert allow_s3mi
-                    command.execute(
-                        command_patterns.ShellScriptCommand(
-                            script=r'set -o pipefail; s3mi cat "${src}" ' + command_params,
-                            named_args=named_args
+
+                if os.path.exists(tmp_dst):
+                    command.remove_rf(tmp_dst)
+
+                try_cli = not allow_s3mi
+                if allow_s3mi:
+                    try:
+                        command.execute(
+                            command_patterns.ShellScriptCommand(
+                                script=r'set -o pipefail; s3mi cat --quiet "${src}" ' + command_params,
+                                named_args=named_args
+                            )
                         )
-                    )
-                except:
-                    if allow_s3mi:
+                    except:
+                        try_cli = not okay_if_missing
                         allow_s3mi = False
                         S3MI_SEM.release()
-                        log.write(
-                            "Failed to download with s3mi. Trying with aws s3 cp..."
-                        )
+                        if try_cli:
+                            log.write(
+                                "Failed to download with s3mi. Trying with aws s3 cp..."
+                            )
+                if try_cli:
+                    if okay_if_missing:
+                        script = r'aws s3 cp --quiet "${src}" - ' + command_params
+                    else:
+                        script = r'aws s3 cp --only-show-errors "${src}" - ' + command_params
                     command.execute(
                         command_patterns.ShellScriptCommand(
-                            script=r'aws s3 cp --only-show-errors "${src}" - ' + command_params,
-                            named_args=named_args
+                            script=script,
+                            named_args=named_args,
+                            env=dict(os.environ, **refreshed_credentials())
                         )
                     )
-                if abspath.startswith(config["REF_DIR"]):
-                    os.makedirs(config["REF_FETCH_LOG_DIR"], exist_ok=True)
-                    with open(os.path.join(config["REF_FETCH_LOG_DIR"], abspath_hash), "w") as fh:
-                        # TODO:  Don't boto3.resource(s3) objects share the global boto "default" session?   Can that be used from multiple processes/threads?
-                        obj = boto3.resource('s3').Bucket(parsed_s3_url.netloc).Object(parsed_s3_url.path.lstrip('/'))
-                        json.dump(dict(bucket_name=obj.bucket_name, key=obj.key, e_tag=obj.e_tag), fh)
-                with mutex:
-                    # If we've successfully downloaded this file once already in this session, we shouldn't download it again.
-                    downloaded_this_session[dst] = True
+                if tmp_dst != dst:
+                    # Move staged download into final location.
+                    command.move_file(tmp_dst, dst)
                 return dst
             except subprocess.CalledProcessError:
-                # Most likely the file doesn't exist in S3.
-                log.write(
-                    "Failed to fetch file from S3. Most likely does not exist."
-                )
-                # Delete potential empty file remnant
-                if os.path.isfile(dst) and os.stat(dst).st_size == 0:
-                    os.remove(dst)
+                if okay_if_missing:
+                    # We presume.
+                    log.write(
+                        "File most likely does not exist in S3."
+                    )
+                else:
+                    log.write(
+                        "Failed to fetch file from S3."
+                    )
+                if os.path.exists(dst):
+                    command.remove_rf(dst)
+                if os.path.exists(tmp_dst):
+                    command.remove_rf(tmp_dst)
                 return None
             finally:
                 if allow_s3mi:
@@ -273,14 +359,12 @@ def fetch_reference(src,  # pylint: disable=dangerous-default-value
                     dst,
                     auto_unzip=True,
                     auto_untar=True,
-                    allow_s3mi=DEFAULT_ALLOW_S3MI,
-                    mutex=multiprocessing.RLock(),
-                    presence_cache={}):
+                    allow_s3mi=DEFAULT_ALLOW_S3MI):
     '''
         This function behaves like fetch_from_s3 in most cases, with one excetpion:
 
             *  When auto_unzip=True, src is NOT a compressed file and NOT a tar file, and a compressed
-               version of src exists in s3, and allow_as3mi=True, this function downloads and uncompresses it.
+               version of src exists in s3, this function downloads and uncompresses it.
 
         This function behaves identically to fetch_from_s3 when:
 
@@ -292,8 +376,6 @@ def fetch_reference(src,  # pylint: disable=dangerous-default-value
 
             * auto_unzip=True, src is NOT a compressed file, and no compressed version of src exists in s3, or
 
-            * allow_s3mi=False
-
         We generally try to keep all our references in S3 either lz4-compressed or tar'ed, because this
         guards against corruption errors that sometimes occur during download.  If we accidentally
         download a corrupt file, it would fail to unlz4 or to untar, and we would retry the download.
@@ -301,27 +383,26 @@ def fetch_reference(src,  # pylint: disable=dangerous-default-value
         We trust "aws s3 cp" to do its own integrity checking, so we only prefer the lz4 version of a file
         if we are allowed to use s3mi.
     '''
-    if auto_unzip and not src.endswith(".tar") and not any(src.endswith(zext) for zext in ZIP_EXTENSIONS) and allow_s3mi:
+    if auto_unzip and not src.endswith(".tar") and not any(src.endswith(zext) for zext in ZIP_EXTENSIONS):
         # Try to guess which compressed version of the file exists in S3;  then download and decompress it.
-        for zext in ZIP_EXTENSIONS:
-            compressed = src + zext
-            # We reduce presence checks using a cache.  Evidence from logs is that we often repeat a presence check.
-            # It's safe to do so for references, because those are static in S3.
-            with mutex:
-                if compressed not in presence_cache:
-                    presence_cache[compressed] = check_s3_presence(compressed)
-                present = presence_cache[compressed]
-            if present:
-                return fetch_from_s3(compressed,
-                                     dst,
-                                     auto_unzip=auto_unzip,
-                                     auto_untar=auto_untar,
-                                     allow_s3mi=allow_s3mi)
+        for zext in REFERENCE_AUTOGUESS_ZIP_EXTENSIONS:
+            result = fetch_from_s3(src + zext,
+                                   dst,
+                                   auto_unzip=auto_unzip,
+                                   auto_untar=auto_untar,
+                                   allow_s3mi=allow_s3mi,
+                                   okay_if_missing=True,  # It's okay if missing a compressed version.
+                                   is_reference=True)
+            if result:
+                return result
+
     return fetch_from_s3(src,
                          dst,
                          auto_unzip=auto_unzip,
                          auto_untar=auto_untar,
-                         allow_s3mi=allow_s3mi)
+                         allow_s3mi=allow_s3mi,
+                         okay_if_missing=False,  # It's NOT okay if missing on the last attempt.
+                         is_reference=True)
 
 
 def fetch_byterange(first_byte, last_byte, bucket, key, output_file):
@@ -343,61 +424,38 @@ def fetch_byterange(first_byte, last_byte, bucket, key, output_file):
 
 @command.retry
 def upload_with_retries(from_f, to_f):
-    command.execute(
-        command_patterns.SingleCommand(
-            cmd="aws",
-            args=[
-                "s3",
-                "cp",
-                "--only-show-errors",
-                from_f,
-                to_f
-            ]
-        )
-    )
+    with IOSTREAM_UPLOADS:
+        with IOSTREAM:
+            command.execute(
+                command_patterns.SingleCommand(
+                    cmd="aws",
+                    args=[
+                        "s3",
+                        "cp",
+                        "--only-show-errors",
+                        from_f,
+                        to_f
+                    ],
+                    env=dict(os.environ, **refreshed_credentials())
+                )
+            )
+
 
 @command.retry
 def upload_folder_with_retries(from_f, to_f):
-    command.execute(
-        command_patterns.SingleCommand(
-            cmd="aws",
-            args=[
-                "s3",
-                "cp",
-                "--only-show-errors",
-                "--recursive",
-                os.path.join(from_f, ""),
-                os.path.join(to_f, "")
-            ]
-        )
-    )
-
-def upload(from_f, to_f, status, status_lock=TraceLock("upload", multiprocessing.RLock())):
-    try:
-        with IOSTREAM_UPLOADS:  # Limit concurrent uploads so as not to stall the pipeline.
-            with IOSTREAM:  # Still counts toward the general semaphore.
-                upload_with_retries(from_f, to_f)
-            with status_lock:
-                status[from_f] = "success"
-    except:
-        with status_lock:
-            status[from_f] = "error"
-        raise
-
-
-def upload_log_file(sample_s3_output_path, lock=TraceLock("upload_log_file", multiprocessing.RLock())):
-    with lock:
-        logh = logging.getLogger().handlers[0]
-        logh.flush()
-        command.execute(
-            command_patterns.SingleCommand(
-                cmd="aws",
-                args=[
-                    "s3",
-                    "cp",
-                    "--only-show-errors",
-                    logh.baseFilename,
-                    os.path.join(sample_s3_output_path, "")
-                ]
+    with IOSTREAM_UPLOADS:
+        with IOSTREAM:
+            command.execute(
+                command_patterns.SingleCommand(
+                    cmd="aws",
+                    args=[
+                        "s3",
+                        "cp",
+                        "--only-show-errors",
+                        "--recursive",
+                        os.path.join(from_f, ""),
+                        os.path.join(to_f, "")
+                    ],
+                    # env=dict(os.environ, **refreshed_credentials())   For recursive uploads, which could open additional connections many minutes after start, cached credentials may expire before the command is done opening connections for subfolder files.  Do not cache.
+                )
             )
-        )


### PR DESCRIPTION
cache AWS credentials for aws s3 cp subcommands

consolidate fetch_reference code path;  fetch_from_s3 is no longer called directly for references

generate_phylo_tree was fetching NON-reference files into the reference dir, causing them to be persisted across runs, incorrectly

run_srst2 was fetching reference files into the output dir causing them NOT to be persisted across runs, incorrectly

revert PR 187 changes to fetch_reference as they needlessly increase the number of s3 operations and use of default global boto session from multiple threads is questionable;   achieve goal of that PR by adding quiet flag to suppress unwanted error messages if files don't exist

revert PR 218 etag checking for references as it needlessly increases the number of s3 operations and use of default global boto session from multiple threads is questionable

ensure boto calls are serialized and throttled by us

modify local reference path to include version by having it include the entire s3 path, while at the same time maintaining the same basename (which ensures tools like srst2 continue to work without changes to that part of the codebase)

stage downloads to ensure only correctly downloaded references are persisted across job.

While less than 40 percent of space is free, delete references from prior runs.

Silence lazy fetches when the file is missing and needs to be recomputed.

Disallow s3mi for rapsearch/gsnap chunks;  those are fetched in parallel anyway