### PR TITLE
STILL TESTING:  fix coverage extent bug seen in coverage viz

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,8 +232,9 @@ Version numbers for this repo take the form X.Y.Z.
 - We increase X for a paradigm shift in how the pipeline is conceived. Example: adding a de-novo assembly step and then reassigning hits based on the assembled contigs.
 Changes to X or Y force recomputation of all results when a sample is rerun using idseq-web. Changes to Z do not force recomputation when the sample is rerun - the pipeline will lazily reuse existing outputs in AWS S3.
 
-- 3.14.1
+- 3.14.1 - 2
   - aws credential caching and other stability improvements
+  - fix bug that made reverse-strand alignments appear very short in the coverage viz
 
 - 3.14
   - add average insert size computation

--- a/idseq_dag/__init__.py
+++ b/idseq_dag/__init__.py
@@ -1,2 +1,2 @@
 ''' idseq_dag '''
-__version__ = "3.14.1"
+__version__ = "3.14.2"

--- a/idseq_dag/steps/blast_contigs.py
+++ b/idseq_dag/steps/blast_contigs.py
@@ -99,10 +99,11 @@ class BlastCandidate:
             r["length"] = 1
         r["pident"] = sum(hsp["pident"] * hsp["length"] for hsp in self.optimal_cover) / r["length"]
         r["bitscore"] = sum(hsp["bitscore"] for hsp in self.optimal_cover)
-        r["qstart"] = min(hsp["qstart"] for hsp in self.optimal_cover)
-        r["qend"] = max(hsp["qend"] for hsp in self.optimal_cover)
-        r["sstart"] = min(hsp["sstart"] for hsp in self.optimal_cover)
-        r["send"] = max(hsp["send"] for hsp in self.optimal_cover)
+        # min(min(... and max(max(... below because, depending on strand, qstart and qend may be reversed
+        r["qstart"] = min(min(hsp["qstart"], hsp["qend"]) for hsp in self.optimal_cover)
+        r["qend"] = max(max(hsp["qstart"], hsp["qend"]) for hsp in self.optimal_cover)
+        r["sstart"] = min(min(hsp["sstart"], hsp["send"]) for hsp in self.optimal_cover)
+        r["send"] = max(max(hsp["sstart"], hsp["send"]) for hsp in self.optimal_cover)
         # add these two
         r["qcov"] = r["length"] / r["qlen"]
         r["hsp_count"] = len(self.optimal_cover)


### PR DESCRIPTION
# Description
3.14.2:  Fixes a bug introduced in PR199 that results in incorrect coverage viz extents when some of the fragments are on the reverse strand (where start > end).

# Version
- [x] I have increased the appropriate version number in https://github.com/chanzuckerberg/idseq-dag/blob/master/idseq_dag/__init__.py. Guidelines here: https://github.com/chanzuckerberg/idseq-dag/blob/pr-template/README.md#release-notes
- [x] I have added release notes for my new version to https://github.com/chanzuckerberg/idseq-dag/blob/pr-template/README.md#release-notes

# Tests
- [x] I have verified in IDseq staging that the pipeline still completes successfully:
    - [ ] for single-end inputs
    - [x] for paired-end inputs
    - [ ] for FASTQ inputs
    - [ ] for FASTA inputs.
- [x] I have validated that my change does not introduce any correctness bugs to existing output types.
- [x] I have validated that my change does not introduce significant performance regressions or I have discussed with the team that the benefits of the change are substantial enough that we're comfortable accepting the size of the measured performance penalty.

# Notes
*Optional observations, comments or explanations.*
