### PR TITLE
READY:  reduce blastn BATCH_SIZE to lower RAM requirement and fix contig viz for reverse strands

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,9 +232,10 @@ Version numbers for this repo take the form X.Y.Z.
 - We increase X for a paradigm shift in how the pipeline is conceived. Example: adding a de-novo assembly step and then reassigning hits based on the assembled contigs.
 Changes to X or Y force recomputation of all results when a sample is rerun using idseq-web. Changes to Z do not force recomputation when the sample is rerun - the pipeline will lazily reuse existing outputs in AWS S3.
 
-- 3.14.1 - 2
+- 3.14.1-3
   - aws credential caching and other stability improvements
   - fix bug that made reverse-strand alignments appear very short in the coverage viz
+  - limit blastn BATCH_SIZE to avoid out-of-memory errors (results are unchanged)
 
 - 3.14
   - add average insert size computation

--- a/idseq_dag/__init__.py
+++ b/idseq_dag/__init__.py
@@ -1,2 +1,2 @@
 ''' idseq_dag '''
-__version__ = "3.14.2"
+__version__ = "3.14.3"

--- a/idseq_dag/steps/blast_contigs.py
+++ b/idseq_dag/steps/blast_contigs.py
@@ -339,7 +339,7 @@ class PipelineStepBlastContigs(PipelineStep):  # pylint: disable=abstract-method
                     blast_type,
                     "-out",
                     blast_index_path
-                ]
+                ],
             )
         )
         command.execute(
@@ -360,7 +360,13 @@ class PipelineStepBlastContigs(PipelineStep):  # pylint: disable=abstract-method
                     5000,
                     "-num_threads",
                     16
-                ]
+                ],
+                # We can only pass BATCH_SIZE as an env var.  The default is 100,000 for blastn;  10,000 for blastp.
+                # Blast concatenates input queries until they exceed this size, then runs them together, for efficiency.
+                # Unfortunately if too many short and low complexity queries are in the input, this can expand too
+                # much the memory required.  We have found empirically 10,000 to be a better default.  It is also the
+                # value used as default for remote blast.
+                env=dict(os.environ, BATCH_SIZE="10000")
             )
         )
         # further processing of getting the top m8 entry for each contig.


### PR DESCRIPTION
# Description
3.14.3:  fix out-of-memory in blastn

blastn concatenates input queries resulting in greater performance at the expense of requiring more memory;  when the input queries are many and short with low complexity, the additional memory required is extensive and effectively unbounded

restricting BATCH_SIZE to 10,000 appears to result in 50% slower performance for some samples while actually improving the performance of other samples;  at the same time, it has the benefit of containing the required memory sufficiently that even samples that would previously fail on 384GB RAM now run just fine with 30GB

the 10,000 number is already the default for blastp and for remote blast, so it is expected to be fairly robust

see https://jira.czi.team/browse/IDSEQ-1927 for further blast performance improvement opportunities

# Version
- [x] I have increased the appropriate version number in https://github.com/chanzuckerberg/idseq-dag/blob/master/idseq_dag/__init__.py. Guidelines here: https://github.com/chanzuckerberg/idseq-dag/blob/pr-template/README.md#release-notes
- [x] I have added release notes for my new version to https://github.com/chanzuckerberg/idseq-dag/blob/pr-template/README.md#release-notes

# Tests
- [x] I have verified in IDseq staging that the pipeline still completes successfully:
    - [ ] for single-end inputs
    - [x] for paired-end inputs
    - [ ] for FASTQ inputs
    - [ ] for FASTA inputs.
- [x] I have validated that my change does not introduce any correctness bugs to existing output types.
- [x] I have validated that my change does not introduce significant performance regressions or I have discussed with the team that the benefits of the change are substantial enough that we're comfortable accepting the size of the measured performance penalty.

# Notes
*Optional observations, comments or explanations.*
