### PR TITLE
reduce memory use of blast reranking algorithm using generators

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,10 +232,11 @@ Version numbers for this repo take the form X.Y.Z.
 - We increase X for a paradigm shift in how the pipeline is conceived. Example: adding a de-novo assembly step and then reassigning hits based on the assembled contigs.
 Changes to X or Y force recomputation of all results when a sample is rerun using idseq-web. Changes to Z do not force recomputation when the sample is rerun - the pipeline will lazily reuse existing outputs in AWS S3.
 
-- 3.14.1-3
+- 3.14.1-4
   - aws credential caching and other stability improvements
   - fix bug that made reverse-strand alignments appear very short in the coverage viz
   - limit blastn BATCH_SIZE to avoid out-of-memory errors (results are unchanged)
+  - reduce RAM footprint of blast rerank python to avoid out-of-memory errors (results are unchanged)
 
 - 3.14
   - add average insert size computation

--- a/idseq_dag/__init__.py
+++ b/idseq_dag/__init__.py
@@ -1,2 +1,2 @@
 ''' idseq_dag '''
-__version__ = "3.14.3"
+__version__ = "3.14.4"


### PR DESCRIPTION
# Description
Some possibly degenerate inputs were at first causing blast to run out of memory, and when that was addressed, are now causing the python reranking algorithm to run out of memory.   The quite straightforward fix is to structure the exact same algorithm using generators so it wouldn't build up huge data structures in RAM.

This takes advantage of the fact that blast output rows are grouped by query.   That appears true in spot checking some examples, and there is information online that suggests blast is very careful about ordering its result.  In fact the reranking algorithm already assumes that within a query the results are ordered by decreasing score.  In case this assumption is violated, we've placed an assert;   and should that fail, we can sort the blast results outside of python prior to reranking in python.

Note:  This is an exactly-equivalent code transformation, provided the blast results are ordered as assumed.   The only difference should be reduction in RAM use.

# Version
- [x] I have increased the appropriate version number in https://github.com/chanzuckerberg/idseq-dag/blob/master/idseq_dag/__init__.py. Guidelines here: https://github.com/chanzuckerberg/idseq-dag/blob/pr-template/README.md#release-notes
- [x] I have added release notes for my new version to https://github.com/chanzuckerberg/idseq-dag/blob/pr-template/README.md#release-notes

# Tests
- [x] I have verified in IDseq staging that the pipeline still completes successfully:
    - [ ] for single-end inputs
    - [x] for paired-end inputs
    - [ ] for FASTQ inputs
    - [ ] for FASTA inputs.
- [x] I have validated that my change does not introduce any correctness bugs to existing output types.
- [x] I have validated that my change does not introduce significant performance regressions or I have discussed with the team that the benefits of the change are substantial enough that we're comfortable accepting the size of the measured performance penalty.

# Notes
*Optional observations, comments or explanations.*
