### PR TITLE
RNA insert metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,9 @@ Version numbers for this repo take the form X.Y.Z.
 - We increase X for a paradigm shift in how the pipeline is conceived. Example: adding a de-novo assembly step and then reassigning hits based on the assembled contigs.
 Changes to X or Y force recomputation of all results when a sample is rerun using idseq-web. Changes to Z do not force recomputation when the sample is rerun - the pipeline will lazily reuse existing outputs in AWS S3.
 
+- 3.15.5
+  - Compute insert size metrics for all hosts for paired end DNA reads
+  - Compute insert size metrics for hosts with gtf files for paired end RNA reads
 - 3.14.1-4
   - aws credential caching and other stability improvements
   - fix bug that made reverse-strand alignments appear very short in the coverage viz

--- a/examples/generic_test_dag.json
+++ b/examples/generic_test_dag.json
@@ -72,7 +72,6 @@
       "additional_attributes": {
         "truncate_fragments_to": 75000000,
         "output_gene_file": "reads_per_gene.tab",
-        "host_genome": "human",
         "nucleotide_type": "DNA",
         "output_metrics_file": "picard_insert_metrics.txt",
         "output_histogram_file": "insert_size_histogram.pdf"

--- a/examples/host_filter_dag.json
+++ b/examples/host_filter_dag.json
@@ -38,7 +38,6 @@
       "additional_attributes": {
         "truncate_fragments_to": 75000000,
         "output_gene_file": "reads_per_gene.star.tab",
-        "host_genome": "human",
         "nucleotide_type": "DNA",
         "output_metrics_file": "picard_insert_metrics.txt",
         "output_histogram_file": "insert_size_histogram.pdf"

--- a/examples/paired_dag.json
+++ b/examples/paired_dag.json
@@ -100,7 +100,6 @@
       "additional_attributes": {
         "truncate_fragments_to": 75000000,
         "output_gene_file": "reads_per_gene.tab",
-        "host_genome": "human",
         "nucleotide_type": "DNA",
         "output_metrics_file": "picard_insert_metrics.txt",
         "output_histogram_file": "insert_size_histogram.pdf"

--- a/idseq_dag/__init__.py
+++ b/idseq_dag/__init__.py
@@ -1,2 +1,2 @@
 ''' idseq_dag '''
-__version__ = "3.14.5"
+__version__ = "3.15.5"

--- a/idseq_dag/__init__.py
+++ b/idseq_dag/__init__.py
@@ -1,2 +1,2 @@
 ''' idseq_dag '''
-__version__ = "3.15.5"
+__version__ = "3.15.0"

--- a/idseq_dag/steps/run_star.py
+++ b/idseq_dag/steps/run_star.py
@@ -277,20 +277,21 @@ class PipelineStepRunStar(PipelineStep):
             '--readFilesIn', *input_files
         ]
 
-        if self.collect_insert_size_metrics_for == "dna":
-            params += ['--outSAMtype', 'BAM', 'Unsorted', '--outSAMmode', 'NoQS', ]
-        elif self.collect_insert_size_metrics_for == "rna":
+        if self.collect_insert_size_metrics_for == "rna":
             params += [
                 '--outSAMtype', 'BAM', 'Unsorted',
                 '--outSAMmode', 'NoQS',
-                '--quantMode', 'TranscriptomeSAM',
+                '--quantMode', 'TranscriptomeSAM', 'GeneCounts',
             ]
         else:
-            params += ['--outSAMmode', 'None']
-
-        count_file = f"{genome_dir}/sjdbList.fromGTF.out.tab"
-        if count_genes and os.path.isfile(count_file):
-            params += ['--quantMode', 'GeneCounts']
+            if self.collect_insert_size_metrics_for == "dna":
+                params += ['--outSAMtype', 'BAM', 'Unsorted', '--outSAMmode', 'NoQS', ]
+            else:
+                params += ['--outSAMmode', 'None']
+            
+            count_file = f"{genome_dir}/sjdbList.fromGTF.out.tab"
+            if count_genes and os.path.isfile(count_file):
+                params += ['--quantMode', 'GeneCounts']
 
         if use_starlong:
             params += [

--- a/idseq_dag/steps/run_star.py
+++ b/idseq_dag/steps/run_star.py
@@ -118,7 +118,7 @@ class PipelineStepRunStar(PipelineStep):
 
         self.collect_insert_size_metrics_for = None
         if paired and requested_insert_size_metrics_output:
-            self.collect_insert_size_metrics_for = collect_insert_size_metrics_for.nucleotide_type
+            self.collect_insert_size_metrics_for = nucleotide_type
 
     def run(self):
         """Run STAR to filter out host reads."""

--- a/idseq_dag/steps/run_star.py
+++ b/idseq_dag/steps/run_star.py
@@ -105,27 +105,20 @@ class PipelineStepRunStar(PipelineStep):
         #  - Recieved an output histogram file or output metrics file destination
 
         nucleotide_type = self.additional_attributes.get("nucleotide_type", "").lower()
-        log.write(f"FOOOOOOOOOOOOOOOOOOOOOO Nucleotide Type: {nucleotide_type}")
 
         paired = len(self.input_files[0]) == 3
-        log.write(f"FOOOOOOOOOOOOOOOOOOOOOO Paired: {paired}")
 
         self.output_metrics_file = self.additional_attributes.get("output_metrics_file")
-        log.write(f"FOOOOOOOOOOOOOOOOOOOOOO Output Metrics File: {self.output_metrics_file}")
         self.output_histogram_file = self.additional_attributes.get("output_histogram_file")
-        log.write(f"FOOOOOOOOOOOOOOOOOOOOOO Output Histogram File: {self.output_histogram_file}")
         requested_insert_size_metrics_output = bool(self.output_metrics_file or self.output_histogram_file)
 
         star_genome_dir = os.path.dirname(self.additional_files.get("star_genome"))
         gtf_path = os.path.join(star_genome_dir, "ERCC.gtf")
-        log.write(f"FOOOOOOOOOOOOOOOOOOOOOO GTF Path: {gtf_path}")
         has_gtf = s3.check_s3_presence(gtf_path)
-        log.write(f"FOOOOOOOOOOOOOOOOOOOOOO Has GTF: {has_gtf}")
 
         self.collect_insert_size_metrics_for = None
         if paired and requested_insert_size_metrics_output:
             self.collect_insert_size_metrics_for = nucleotide_type
-        log.write(f"FOOOOOOOOOOOOOOOOOOOOOO Insert Size Metrics For: {self.collect_insert_size_metrics_for}")
 
     def run(self):
         """Run STAR to filter out host reads."""
@@ -200,11 +193,8 @@ class PipelineStepRunStar(PipelineStep):
                 #  Aligned.toTranscriptome.out.bam with  TranscriptomeSAM, this doesn't 
                 #  appear to be configurable
                 is_dna = self.collect_insert_size_metrics_for == "dna"
-                log.write(f"FOOOOOOOOOOOOOOOOOOOOOO Insert Size Metrics For Two: {self.collect_insert_size_metrics_for}")
                 bam_filename = "Aligned.out.bam" if is_dna else "Aligned.toTranscriptome.out.bam"
-                log.write(f"FOOOOOOOOOOOOOOOOOOOOOO Bam filename: {bam_filename}")
                 if self.collect_insert_size_metrics_for:
-                    log.write(f"FOOOOOOOOOOOOOOOOOOOOOO Uploading")
                     bam_path = os.path.join(tmp, bam_filename)
                     metrics_output_path = os.path.join(tmp, self.output_metrics_file)
                     histogram_output_path = os.path.join(tmp, self.output_histogram_file)
@@ -212,7 +202,7 @@ class PipelineStepRunStar(PipelineStep):
                     # If this file wasn't generated but self.collect_insert_size_metrics_for has a value
                     #   something unexpected has gone wrong
                     assert(os.path.isfile(bam_path)), \
-                        f"Expected STAR to generate {bam_filename} but it was not found"
+                        "Expected STAR to generate Aligned.out.bam but it was not found"
                     self.collect_insert_size_metrics(tmp, bam_path, metrics_output_path, histogram_output_path)
 
                     if self.output_metrics_file:

--- a/idseq_dag/steps/run_star.py
+++ b/idseq_dag/steps/run_star.py
@@ -117,9 +117,8 @@ class PipelineStepRunStar(PipelineStep):
         self.output_histogram_file = self.additional_attributes.get("output_histogram_file")
         requested_insert_size_metrics_output = bool(self.output_metrics_file or self.output_histogram_file)
 
-        star_genome_dir = os.path.dirname(self.additional_files.get("star_genome"))
-        gtf_path = os.path.join(star_genome_dir, "ERCC.gtf")
-        has_gtf = s3.check_s3_presence(gtf_path)
+        star_genome_dir = os.path.dirname(self.additional_files.get("star_genome", ""))
+        has_gtf = s3.check_s3_presence_for_pattern(star_genome_dir, "\.gtf$")
 
         self.collect_insert_size_metrics_for = None
         if paired and requested_insert_size_metrics_output:

--- a/idseq_dag/steps/run_star.py
+++ b/idseq_dag/steps/run_star.py
@@ -118,7 +118,7 @@ class PipelineStepRunStar(PipelineStep):
 
         self.collect_insert_size_metrics_for = None
         if paired and requested_insert_size_metrics_output:
-            collect_insert_size_metrics_for.nucleotide_type
+            self.collect_insert_size_metrics_for = collect_insert_size_metrics_for.nucleotide_type
 
     def run(self):
         """Run STAR to filter out host reads."""

--- a/idseq_dag/steps/run_star.py
+++ b/idseq_dag/steps/run_star.py
@@ -118,7 +118,8 @@ class PipelineStepRunStar(PipelineStep):
         requested_insert_size_metrics_output = bool(self.output_metrics_file or self.output_histogram_file)
 
         star_genome_dir = os.path.dirname(self.additional_files.get("star_genome", ""))
-        has_gtf = s3.check_s3_presence_for_pattern(star_genome_dir, "\.gtf$")
+        # TODO remove the final x
+        has_gtf = s3.check_s3_presence_for_pattern(star_genome_dir, "\.gtfx$")
 
         self.collect_insert_size_metrics_for = None
         if paired and requested_insert_size_metrics_output:

--- a/idseq_dag/steps/run_star.py
+++ b/idseq_dag/steps/run_star.py
@@ -117,10 +117,10 @@ class PipelineStepRunStar(PipelineStep):
         requested_insert_size_metrics_output = bool(self.output_metrics_file or self.output_histogram_file)
 
         star_genome_dir = os.path.dirname(self.additional_files.get("star_genome", ""))
-        has_gtf = s3.check_s3_presence_for_pattern(star_genome_dir, "\.gtf$")
+        has_gtf = s3.check_s3_presence_for_pattern(star_genome_dir, r"\.gtf$")
 
         self.collect_insert_size_metrics_for = None
-        # If we have paired end reads and metrics output files were requested 
+        # If we have paired end reads and metrics output files were requested
         #   try to compute insert size metrics
         if paired and requested_insert_size_metrics_output:
             # Compute for RNA if host genome has a gtf file
@@ -199,8 +199,8 @@ class PipelineStepRunStar(PipelineStep):
                     command.move_file(gene_count_file, moved)
                     self.additional_files_to_upload.append(moved)
 
-                # STAR names the output BAM file Aligned.out.bam without TranscriptomeSAM and 
-                #  Aligned.toTranscriptome.out.bam with  TranscriptomeSAM, this doesn't 
+                # STAR names the output BAM file Aligned.out.bam without TranscriptomeSAM and
+                #  Aligned.toTranscriptome.out.bam with  TranscriptomeSAM, this doesn't
                 #  appear to be configurable
                 is_dna = self.collect_insert_size_metrics_for == "dna"
                 bam_filename = "Aligned.out.bam" if is_dna else "Aligned.toTranscriptome.out.bam"
@@ -291,7 +291,7 @@ class PipelineStepRunStar(PipelineStep):
                 params += ['--outSAMtype', 'BAM', 'Unsorted', '--outSAMmode', 'NoQS', ]
             else:
                 params += ['--outSAMmode', 'None']
-            
+
             count_file = f"{genome_dir}/sjdbList.fromGTF.out.tab"
             if count_genes and os.path.isfile(count_file):
                 params += ['--quantMode', 'GeneCounts']
@@ -302,7 +302,7 @@ class PipelineStepRunStar(PipelineStep):
                 '--seedPerReadNmax', '100000',
                 '--seedPerWindowNmax', '1000',
                 '--alignTranscriptsPerReadNmax', '100000',
-                '--alignTranscriptsPerWindowNmax', '10000']            
+                '--alignTranscriptsPerWindowNmax', '10000']
 
         command.execute(
             command_patterns.SingleCommand(

--- a/idseq_dag/steps/run_star.py
+++ b/idseq_dag/steps/run_star.py
@@ -99,7 +99,7 @@ class PipelineStepRunStar(PipelineStep):
         self.validated_input_counts_file = None
 
         # TODO remove me
-        self.additional_attributes["nucleotide_type"] = "dna"
+        self.additional_attributes["nucleotide_type"] = "rna"
         self.additional_attributes["output_metrics_file"] = "picard_insert_metrics.txt"
         self.additional_attributes["output_histogram_file"] = "insert_size_histogram.pdf"
 

--- a/idseq_dag/steps/run_star.py
+++ b/idseq_dag/steps/run_star.py
@@ -270,20 +270,20 @@ class PipelineStepRunStar(PipelineStep):
             '--readFilesIn', *input_files
         ]
 
-        count_file = f"{genome_dir}/sjdbList.fromGTF.out.tab"
-
         if self.collect_insert_size_metrics_for == "dna":
             params += ['--outSAMtype', 'BAM', 'Unsorted', '--outSAMmode', 'NoQS', ]
         elif self.collect_insert_size_metrics_for == "rna":
             params += [
                 '--outSAMtype', 'BAM', 'Unsorted',
                 '--outSAMmode', 'NoQS',
-                '--quantMode', 'TranscriptomeSAM', 'GeneCounts'
+                '--quantMode', 'TranscriptomeSAM',
             ]
-        elif count_genes and os.path.isfile(count_file):
-            params += ['--quantMode', 'GeneCounts']
         else:
             params += ['--outSAMmode', 'None']
+
+        count_file = f"{genome_dir}/sjdbList.fromGTF.out.tab"
+        if count_genes and os.path.isfile(count_file):
+            params += ['--quantMode', 'GeneCounts']
 
         if use_starlong:
             params += [

--- a/idseq_dag/steps/run_star.py
+++ b/idseq_dag/steps/run_star.py
@@ -98,6 +98,11 @@ class PipelineStepRunStar(PipelineStep):
         self.sequence_input_files = None
         self.validated_input_counts_file = None
 
+        # TODO remove me
+        self.additional_attributes["nucleotide_type"] = "dna"
+        self.additional_attributes["output_metrics_file"] = "picard_insert_metrics.txt"
+        self.additional_attributes["output_histogram_file"] = "insert_size_histogram.pdf"
+
         # Compute insert size metrics if all of the following are true:
         #  - Host is Human
         #  - Nucleotide Type is DNA

--- a/idseq_dag/steps/run_star.py
+++ b/idseq_dag/steps/run_star.py
@@ -112,7 +112,7 @@ class PipelineStepRunStar(PipelineStep):
         self.output_histogram_file = self.additional_attributes.get("output_histogram_file")
         requested_insert_size_metrics_output = bool(self.output_metrics_file or self.output_histogram_file)
 
-        star_genome_dir = os.path.dirname(self.additional_attributes.get("star_genome"))
+        star_genome_dir = os.path.dirname(self.additional_files.get("star_genome"))
         gtf_path = os.path.join(star_genome_dir, "ERCC.gtf")
         has_gtf = s3.check_s3_presence(gtf_path)
 

--- a/idseq_dag/steps/run_star.py
+++ b/idseq_dag/steps/run_star.py
@@ -105,20 +105,27 @@ class PipelineStepRunStar(PipelineStep):
         #  - Recieved an output histogram file or output metrics file destination
 
         nucleotide_type = self.additional_attributes.get("nucleotide_type", "").lower()
+        log.write(f"FOOOOOOOOOOOOOOOOOOOOOO Nucleotide Type: {nucleotide_type}")
 
         paired = len(self.input_files[0]) == 3
+        log.write(f"FOOOOOOOOOOOOOOOOOOOOOO Paired: {paired}")
 
         self.output_metrics_file = self.additional_attributes.get("output_metrics_file")
+        log.write(f"FOOOOOOOOOOOOOOOOOOOOOO Output Metrics File: {self.output_metrics_file}")
         self.output_histogram_file = self.additional_attributes.get("output_histogram_file")
+        log.write(f"FOOOOOOOOOOOOOOOOOOOOOO Output Histogram File: {self.output_histogram_file}")
         requested_insert_size_metrics_output = bool(self.output_metrics_file or self.output_histogram_file)
 
         star_genome_dir = os.path.dirname(self.additional_files.get("star_genome"))
         gtf_path = os.path.join(star_genome_dir, "ERCC.gtf")
+        log.write(f"FOOOOOOOOOOOOOOOOOOOOOO GTF Path: {gtf_path}")
         has_gtf = s3.check_s3_presence(gtf_path)
+        log.write(f"FOOOOOOOOOOOOOOOOOOOOOO Has GTF: {has_gtf}")
 
         self.collect_insert_size_metrics_for = None
         if paired and requested_insert_size_metrics_output:
             self.collect_insert_size_metrics_for = nucleotide_type
+        log.write(f"FOOOOOOOOOOOOOOOOOOOOOO Insert Size Metrics For: {self.collect_insert_size_metrics_for}")
 
     def run(self):
         """Run STAR to filter out host reads."""
@@ -193,8 +200,11 @@ class PipelineStepRunStar(PipelineStep):
                 #  Aligned.toTranscriptome.out.bam with  TranscriptomeSAM, this doesn't 
                 #  appear to be configurable
                 is_dna = self.collect_insert_size_metrics_for == "dna"
+                log.write(f"FOOOOOOOOOOOOOOOOOOOOOO Insert Size Metrics For Two: {self.collect_insert_size_metrics_for}")
                 bam_filename = "Aligned.out.bam" if is_dna else "Aligned.toTranscriptome.out.bam"
+                log.write(f"FOOOOOOOOOOOOOOOOOOOOOO Bam filename: {bam_filename}")
                 if self.collect_insert_size_metrics_for:
+                    log.write(f"FOOOOOOOOOOOOOOOOOOOOOO Uploading")
                     bam_path = os.path.join(tmp, bam_filename)
                     metrics_output_path = os.path.join(tmp, self.output_metrics_file)
                     histogram_output_path = os.path.join(tmp, self.output_histogram_file)
@@ -202,7 +212,7 @@ class PipelineStepRunStar(PipelineStep):
                     # If this file wasn't generated but self.collect_insert_size_metrics_for has a value
                     #   something unexpected has gone wrong
                     assert(os.path.isfile(bam_path)), \
-                        "Expected STAR to generate Aligned.out.bam but it was not found"
+                        f"Expected STAR to generate {bam_filename} but it was not found"
                     self.collect_insert_size_metrics(tmp, bam_path, metrics_output_path, histogram_output_path)
 
                     if self.output_metrics_file:

--- a/idseq_dag/steps/run_star.py
+++ b/idseq_dag/steps/run_star.py
@@ -118,7 +118,10 @@ class PipelineStepRunStar(PipelineStep):
 
         self.collect_insert_size_metrics_for = None
         if paired and requested_insert_size_metrics_output:
-            self.collect_insert_size_metrics_for = nucleotide_type
+            if nucleotide_type == "rna" and has_gtf:
+                self.collect_insert_size_metrics_for = nucleotide_type
+            elif nucleotide_type == "dna":
+                self.collect_insert_size_metrics_for = nucleotide_type
 
     def run(self):
         """Run STAR to filter out host reads."""

--- a/idseq_dag/util/s3.py
+++ b/idseq_dag/util/s3.py
@@ -3,6 +3,7 @@ import subprocess
 import os
 import multiprocessing
 import errno
+import re
 from urllib.parse import urlparse
 import traceback
 import boto3
@@ -80,6 +81,36 @@ def check_s3_presence(s3_path, allow_zero_byte_files=True):
     with botolock:
         rate_limit_boto()
         return _check_s3_presence(s3_path, allow_zero_byte_files)
+
+
+def _list_s3_keys(s3_path_prefix):
+    """Returns an iterator of s3 keys prefixed by s3_path_prefix."""
+    with log.log_context(context_name="s3.list_s3_objects", values={'s3_path_prefix': s3_path_prefix}, log_context_mode=log.LogContextMode.EXEC_LOG_EVENT) as lc:
+        parsed_url = urlparse(s3_path_prefix, allow_fragments=False)
+        bucket = parsed_url.netloc
+        prefix = parsed_url.path.lstrip('/')
+        client = boto3.client('s3')
+        paginator = client.get_paginator('list_objects')
+        for response in paginator.paginate(Bucket=bucket, Prefix=prefix):
+            for item in response['Contents']:
+                yield item['Key']
+
+
+def list_s3_keys(s3_path_prefix):
+    with botolock:
+        rate_limit_boto()
+        return _list_s3_keys(s3_path_prefix)
+
+
+def check_s3_presence_for_pattern(s3_path_prefix, pattern):
+    """
+    Returns True if s3 contains any keys in s3 that start with the s3 path
+    prefix match the pattern.
+    """
+    for key in list_s3_keys(s3_path_prefix):
+        if re.search(pattern, key):
+            return True
+    return False
 
 
 def check_s3_presence_for_file_list(s3_dir, file_list, allow_zero_byte_files=True):

--- a/idseq_dag/util/s3.py
+++ b/idseq_dag/util/s3.py
@@ -85,7 +85,7 @@ def check_s3_presence(s3_path, allow_zero_byte_files=True):
 
 def _list_s3_keys(s3_path_prefix):
     """Returns an iterator of s3 keys prefixed by s3_path_prefix."""
-    with log.log_context(context_name="s3.list_s3_objects", values={'s3_path_prefix': s3_path_prefix}, log_context_mode=log.LogContextMode.EXEC_LOG_EVENT) as lc:
+    with log.log_context(context_name="s3.list_s3_objects", values={'s3_path_prefix': s3_path_prefix}, log_context_mode=log.LogContextMode.EXEC_LOG_EVENT):
         parsed_url = urlparse(s3_path_prefix, allow_fragments=False)
         bucket = parsed_url.netloc
         prefix = parsed_url.path.lstrip('/')

--- a/idseq_dag/util/s3.py
+++ b/idseq_dag/util/s3.py
@@ -102,6 +102,9 @@ def list_s3_keys(s3_path_prefix):
         return _list_s3_keys(s3_path_prefix)
 
 
+# Something similar to this exist's in s3's REST API
+#  the --query flag, but it doesn't support full regexes and
+#  doesn't appear to be in the python API
 def check_s3_presence_for_pattern(s3_path_prefix, pattern):
     """
     Returns True if s3 contains any keys in s3 that start with the s3 path


### PR DESCRIPTION
# Description

This change computes insert size metrics for all paired end DNA samples and all paired end RNA samples provided we have a gtf file for the host genome.

# Version
- [x] I have increased the appropriate version number in https://github.com/chanzuckerberg/idseq-dag/blob/master/idseq_dag/__init__.py. Guidelines here: https://github.com/chanzuckerberg/idseq-dag/blob/pr-template/README.md#release-notes
- [x] I have added release notes for my new version to https://github.com/chanzuckerberg/idseq-dag/blob/pr-template/README.md#release-notes

# Tests
- [x] I have verified in IDseq staging that the pipeline still completes successfully:
    - [x] for single-end inputs
    - [x] for paired-end inputs
    - [x] for FASTQ inputs
    - [ ] for FASTA inputs.
- [x] I have validated that my change does not introduce any correctness bugs to existing output types.
- [x] I have validated that my change does not introduce significant performance regressions or I have discussed with the team that the benefits of the change are substantial enough that we're comfortable accepting the size of the measured performance penalty.
