### PR TITLE
Add check for organism specific gtf

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,8 @@ Version numbers for this repo take the form X.Y.Z.
 - We increase X for a paradigm shift in how the pipeline is conceived. Example: adding a de-novo assembly step and then reassigning hits based on the assembled contigs.
 Changes to X or Y force recomputation of all results when a sample is rerun using idseq-web. Changes to Z do not force recomputation when the sample is rerun - the pipeline will lazily reuse existing outputs in AWS S3.
 
+- 3.16.0
+  - Only compute insert size metrics for RNA reads if we have an organism-specific gtf file
 - 3.15.0
   - Compute insert size metrics for all hosts for paired end DNA reads
   - Compute insert size metrics for hosts with gtf files for paired end RNA reads

--- a/idseq_dag/__init__.py
+++ b/idseq_dag/__init__.py
@@ -1,2 +1,2 @@
 ''' idseq_dag '''
-__version__ = "3.15.0"
+__version__ = "3.16.0"

--- a/idseq_dag/steps/run_star.py
+++ b/idseq_dag/steps/run_star.py
@@ -109,7 +109,7 @@ class PipelineStepRunStar(PipelineStep):
         self.validated_input_counts_file = None
 
         # Used to disable insert size metrics for run_star_downstream.py
-        insert_size_metrics_enabled = kwargs.get("insert_size_metrics_enabled", True)
+        disable_insert_size_metrics = kwargs.get("disable_insert_size_metrics")
         nucleotide_type = self.additional_attributes.get("nucleotide_type", "").lower()
         paired = len(self.input_files[0]) == 3
 
@@ -120,7 +120,7 @@ class PipelineStepRunStar(PipelineStep):
         self.collect_insert_size_metrics_for = None
         # If we have paired end reads and metrics output files were requested
         #   try to compute insert size metrics
-        if insert_size_metrics_enabled and paired and requested_insert_size_metrics_output:
+        if (not disable_insert_size_metrics) and paired and requested_insert_size_metrics_output:
             # Compute for RNA if host genome has an organism specific gtf file
             if nucleotide_type == "rna":
                 # Check if the STAR genome was generated with an organism specific gtf file

--- a/idseq_dag/steps/run_star.py
+++ b/idseq_dag/steps/run_star.py
@@ -109,7 +109,8 @@ class PipelineStepRunStar(PipelineStep):
         self.validated_input_counts_file = None
 
         # Used to disable insert size metrics for run_star_downstream.py
-        disable_insert_size_metrics = kwargs.get("disable_insert_size_metrics")
+        self.disable_insert_size_metrics = False
+
         nucleotide_type = self.additional_attributes.get("nucleotide_type", "").lower()
         paired = len(self.input_files[0]) == 3
 
@@ -120,7 +121,7 @@ class PipelineStepRunStar(PipelineStep):
         self.collect_insert_size_metrics_for = None
         # If we have paired end reads and metrics output files were requested
         #   try to compute insert size metrics
-        if (not disable_insert_size_metrics) and paired and requested_insert_size_metrics_output:
+        if (not self.disable_insert_size_metrics) and paired and requested_insert_size_metrics_output:
             # Compute for RNA if host genome has an organism specific gtf file
             if nucleotide_type == "rna":
                 # Check if the STAR genome was generated with an organism specific gtf file

--- a/idseq_dag/steps/run_star.py
+++ b/idseq_dag/steps/run_star.py
@@ -108,10 +108,6 @@ class PipelineStepRunStar(PipelineStep):
         self.sequence_input_files = None
         self.validated_input_counts_file = None
 
-        self.additional_attributes["output_metrics_file"] = "picard_insert_metrics.txt"
-        self.additional_attributes["output_histogram_file"] = "insert_size_histogram.pdf"
-        self.additional_attributes["nucleotide_type"] = "RNA"
-
         # Used to disable insert size metrics for run_star_downstream.py
         disable_insert_size_metrics = kwargs.get("disable_insert_size_metrics")
         nucleotide_type = self.additional_attributes.get("nucleotide_type", "").lower()

--- a/idseq_dag/steps/run_star.py
+++ b/idseq_dag/steps/run_star.py
@@ -103,13 +103,12 @@ class PipelineStepRunStar(PipelineStep):
     # Note that these attributes cannot be set in the __init__ method because required
     # file path information only becomes available once the wait_for_input_files() has run.
 
+    # disable_insert_size_metrics is used to disable insert size metrics for run_star_downstream.py
     def __init__(self, *args, disable_insert_size_metrics=False, **kwargs):
         super().__init__(*args, **kwargs)
         self.sequence_input_files = None
         self.validated_input_counts_file = None
 
-        # Used to disable insert size metrics for run_star_downstream.py
-        disable_insert_size_metrics = kwargs.get("disable_insert_size_metrics")
         nucleotide_type = self.additional_attributes.get("nucleotide_type", "").lower()
         paired = len(self.input_files[0]) == 3
 

--- a/idseq_dag/steps/run_star.py
+++ b/idseq_dag/steps/run_star.py
@@ -109,8 +109,7 @@ class PipelineStepRunStar(PipelineStep):
         self.validated_input_counts_file = None
 
         # Used to disable insert size metrics for run_star_downstream.py
-        self.disable_insert_size_metrics = False
-
+        disable_insert_size_metrics = kwargs.get("disable_insert_size_metrics")
         nucleotide_type = self.additional_attributes.get("nucleotide_type", "").lower()
         paired = len(self.input_files[0]) == 3
 
@@ -121,7 +120,7 @@ class PipelineStepRunStar(PipelineStep):
         self.collect_insert_size_metrics_for = None
         # If we have paired end reads and metrics output files were requested
         #   try to compute insert size metrics
-        if (not self.disable_insert_size_metrics) and paired and requested_insert_size_metrics_output:
+        if (not disable_insert_size_metrics) and paired and requested_insert_size_metrics_output:
             # Compute for RNA if host genome has an organism specific gtf file
             if nucleotide_type == "rna":
                 # Check if the STAR genome was generated with an organism specific gtf file

--- a/idseq_dag/steps/run_star.py
+++ b/idseq_dag/steps/run_star.py
@@ -116,11 +116,12 @@ class PipelineStepRunStar(PipelineStep):
         self.output_histogram_file = self.additional_attributes.get("output_histogram_file")
         requested_insert_size_metrics_output = bool(self.output_metrics_file or self.output_histogram_file)
 
-        # Check if the STAR genome was generated with an organism-specific gtf file
+        # Check if the STAR genome was generated with an organism specific gtf file
         #  This file will be in the same s3 directory, it is needed to prevent overestimation
         #  of insert size for RNA because genomic alignments of RNA may cross introns.
-        #  The ERCC.gtf file is not sufficient for this purpose. An organism-specific gtf
-        #  file will have a name other than ERCC.gtf.
+        #  The ERCC.gtf file is not sufficient for this purpose. An organism specific gtf
+        #  file will have a name other than ERCC.gtf. The organism specific gtf files
+        #  come from the RefSeq Database.
         star_genome_dir = os.path.dirname(self.additional_files.get("star_genome", ""))
         has_gtf = s3.check_s3_presence_for_pattern(star_genome_dir, r"(?<!/ERCC)\.gtf$")
 
@@ -128,7 +129,7 @@ class PipelineStepRunStar(PipelineStep):
         # If we have paired end reads and metrics output files were requested
         #   try to compute insert size metrics
         if paired and requested_insert_size_metrics_output:
-            # Compute for RNA if host genome has an origanisn-specific gtf file
+            # Compute for RNA if host genome has an organism specific gtf file
             if nucleotide_type == "rna" and has_gtf:
                 self.collect_insert_size_metrics_for = nucleotide_type
             # Always compute for DNA

--- a/idseq_dag/steps/run_star.py
+++ b/idseq_dag/steps/run_star.py
@@ -103,7 +103,7 @@ class PipelineStepRunStar(PipelineStep):
     # Note that these attributes cannot be set in the __init__ method because required
     # file path information only becomes available once the wait_for_input_files() has run.
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, disable_insert_size_metrics=False, **kwargs):
         super().__init__(*args, **kwargs)
         self.sequence_input_files = None
         self.validated_input_counts_file = None

--- a/idseq_dag/steps/run_star.py
+++ b/idseq_dag/steps/run_star.py
@@ -108,6 +108,7 @@ class PipelineStepRunStar(PipelineStep):
         self.sequence_input_files = None
         self.validated_input_counts_file = None
 
+        # Used to disable insert size metrics for run_star_downstream.py
         insert_size_metrics_enabled = kwargs.get("insert_size_metrics_enabled", True)
         nucleotide_type = self.additional_attributes.get("nucleotide_type", "").lower()
         paired = len(self.input_files[0]) == 3

--- a/idseq_dag/steps/run_star.py
+++ b/idseq_dag/steps/run_star.py
@@ -108,30 +108,30 @@ class PipelineStepRunStar(PipelineStep):
         self.sequence_input_files = None
         self.validated_input_counts_file = None
 
+        insert_size_metrics_enabled = kwargs.get("insert_size_metrics_enabled", True)
         nucleotide_type = self.additional_attributes.get("nucleotide_type", "").lower()
-
         paired = len(self.input_files[0]) == 3
 
         self.output_metrics_file = self.additional_attributes.get("output_metrics_file")
         self.output_histogram_file = self.additional_attributes.get("output_histogram_file")
         requested_insert_size_metrics_output = bool(self.output_metrics_file or self.output_histogram_file)
 
-        # Check if the STAR genome was generated with an organism specific gtf file
-        #  This file will be in the same s3 directory, it is needed to prevent overestimation
-        #  of insert size for RNA because genomic alignments of RNA may cross introns.
-        #  The ERCC.gtf file is not sufficient for this purpose. An organism specific gtf
-        #  file will have a name other than ERCC.gtf. The organism specific gtf files
-        #  come from the RefSeq Database.
-        star_genome_dir = os.path.dirname(self.additional_files.get("star_genome", ""))
-        has_gtf = s3.check_s3_presence_for_pattern(star_genome_dir, r"(?<!/ERCC)\.gtf$")
-
         self.collect_insert_size_metrics_for = None
         # If we have paired end reads and metrics output files were requested
         #   try to compute insert size metrics
-        if paired and requested_insert_size_metrics_output:
+        if insert_size_metrics_enabled and paired and requested_insert_size_metrics_output:
             # Compute for RNA if host genome has an organism specific gtf file
-            if nucleotide_type == "rna" and has_gtf:
-                self.collect_insert_size_metrics_for = nucleotide_type
+            if nucleotide_type == "rna":
+                # Check if the STAR genome was generated with an organism specific gtf file
+                #  This file will be in the same s3 directory, it is needed to prevent overestimation
+                #  of insert size for RNA because genomic alignments of RNA may cross introns.
+                #  The ERCC.gtf file is not sufficient for this purpose. An organism specific gtf
+                #  file will have a name other than ERCC.gtf. The organism specific gtf files
+                #  come from the RefSeq Database.
+                star_genome_dir = os.path.dirname(self.additional_files.get("star_genome", ""))
+                has_gtf = s3.check_s3_presence_for_pattern(star_genome_dir, r"(?<!/ERCC)\.gtf$")
+                if has_gtf:
+                    self.collect_insert_size_metrics_for = nucleotide_type
             # Always compute for DNA
             elif nucleotide_type == "dna":
                 self.collect_insert_size_metrics_for = nucleotide_type

--- a/idseq_dag/steps/run_star.py
+++ b/idseq_dag/steps/run_star.py
@@ -108,6 +108,10 @@ class PipelineStepRunStar(PipelineStep):
         self.sequence_input_files = None
         self.validated_input_counts_file = None
 
+        self.additional_attributes["output_metrics_file"] = "picard_insert_metrics.txt"
+        self.additional_attributes["output_histogram_file"] = "insert_size_histogram.pdf"
+        self.additional_attributes["nucleotide_type"] = "RNA"
+
         # Used to disable insert size metrics for run_star_downstream.py
         disable_insert_size_metrics = kwargs.get("disable_insert_size_metrics")
         nucleotide_type = self.additional_attributes.get("nucleotide_type", "").lower()

--- a/idseq_dag/steps/run_star_downstream.py
+++ b/idseq_dag/steps/run_star_downstream.py
@@ -9,10 +9,11 @@ class PipelineStepRunStarDownstream(PipelineStepRunStar):
             because we use the files from (1)
     """
     def __init__(self, *args, **kwargs):
-        super().__init__(*args, disable_insert_size_metrics=True, **kwargs)
+        super().__init__(*args, **kwargs)
+        # Don't collect insert size metrics at this stage
+        self.disable_insert_size_metrics = True
 
     def run(self):
         self.sequence_input_files = self.input_files_local[0][:2]
         self.validated_input_counts_file = self.input_files_local[1][0]
-        # Don't collect insert size metrics at this stage
         super().run()

--- a/idseq_dag/steps/run_star_downstream.py
+++ b/idseq_dag/steps/run_star_downstream.py
@@ -9,11 +9,10 @@ class PipelineStepRunStarDownstream(PipelineStepRunStar):
             because we use the files from (1)
     """
     def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        # Don't collect insert size metrics at this stage
-        self.disable_insert_size_metrics = True
+        super().__init__(*args, disable_insert_size_metrics=True, **kwargs)
 
     def run(self):
         self.sequence_input_files = self.input_files_local[0][:2]
         self.validated_input_counts_file = self.input_files_local[1][0]
+        # Don't collect insert size metrics at this stage
         super().run()

--- a/idseq_dag/steps/run_star_downstream.py
+++ b/idseq_dag/steps/run_star_downstream.py
@@ -13,4 +13,4 @@ class PipelineStepRunStarDownstream(PipelineStepRunStar):
         self.sequence_input_files = self.input_files_local[0][:2]
         self.validated_input_counts_file = self.input_files_local[1][0]
         # Don't collect insert size metrics at this stage
-        super(insert_size_metrics_enabled=False).run()
+        super(disable_insert_size_metrics=True).run()

--- a/idseq_dag/steps/run_star_downstream.py
+++ b/idseq_dag/steps/run_star_downstream.py
@@ -12,4 +12,5 @@ class PipelineStepRunStarDownstream(PipelineStepRunStar):
     def run(self):
         self.sequence_input_files = self.input_files_local[0][:2]
         self.validated_input_counts_file = self.input_files_local[1][0]
+        # Don't collect insert size metrics at this stage
         super(insert_size_metrics_enabled=False).run()

--- a/idseq_dag/steps/run_star_downstream.py
+++ b/idseq_dag/steps/run_star_downstream.py
@@ -11,7 +11,6 @@ class PipelineStepRunStarDownstream(PipelineStepRunStar):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, disable_insert_size_metrics=True, **kwargs)
 
-
     def run(self):
         self.sequence_input_files = self.input_files_local[0][:2]
         self.validated_input_counts_file = self.input_files_local[1][0]

--- a/idseq_dag/steps/run_star_downstream.py
+++ b/idseq_dag/steps/run_star_downstream.py
@@ -12,4 +12,4 @@ class PipelineStepRunStarDownstream(PipelineStepRunStar):
     def run(self):
         self.sequence_input_files = self.input_files_local[0][:2]
         self.validated_input_counts_file = self.input_files_local[1][0]
-        super().run()
+        super(insert_size_metrics_enabled=False).run()

--- a/idseq_dag/steps/run_star_downstream.py
+++ b/idseq_dag/steps/run_star_downstream.py
@@ -8,9 +8,12 @@ class PipelineStepRunStarDownstream(PipelineStepRunStar):
         --> first file is a count json; remaining files are sanitized sequence files which we don't need
             because we use the files from (1)
     """
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, disable_insert_size_metrics=True, **kwargs)
+
 
     def run(self):
         self.sequence_input_files = self.input_files_local[0][:2]
         self.validated_input_counts_file = self.input_files_local[1][0]
         # Don't collect insert size metrics at this stage
-        super(disable_insert_size_metrics=True).run()
+        super().run()

--- a/idseq_dag/steps/run_star_downstream.py
+++ b/idseq_dag/steps/run_star_downstream.py
@@ -9,10 +9,10 @@ class PipelineStepRunStarDownstream(PipelineStepRunStar):
             because we use the files from (1)
     """
     def __init__(self, *args, **kwargs):
+        # Don't collect insert size metrics at this stage
         super().__init__(*args, disable_insert_size_metrics=True, **kwargs)
 
     def run(self):
         self.sequence_input_files = self.input_files_local[0][:2]
         self.validated_input_counts_file = self.input_files_local[1][0]
-        # Don't collect insert size metrics at this stage
         super().run()


### PR DESCRIPTION
# Description
This excludes ERCC.gtf files from counting as organism-specific gtf files when considering collecting insert size metrics for RNA.

# Version
- [x] I have increased the appropriate version number in https://github.com/chanzuckerberg/idseq-dag/blob/master/idseq_dag/__init__.py. Guidelines here: https://github.com/chanzuckerberg/idseq-dag/blob/pr-template/README.md#release-notes
- [x] I have added release notes for my new version to https://github.com/chanzuckerberg/idseq-dag/blob/pr-template/README.md#release-notes

# Tests
- [x] I have verified in IDseq staging that the pipeline still completes successfully:
    - [x] for single-end inputs
    - [x] for paired-end inputs
    - [x] for FASTQ inputs
    - [x] for FASTA inputs.
- [x] I have validated that my change does not introduce any correctness bugs to existing output types.
- [x] I have validated that my change does not introduce significant performance regressions or I have discussed with the team that the benefits of the change are substantial enough that we're comfortable accepting the size of the measured performance penalty.
