### PR TITLE
remove excess concurrent logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,8 +232,9 @@ Version numbers for this repo take the form X.Y.Z.
 - We increase X for a paradigm shift in how the pipeline is conceived. Example: adding a de-novo assembly step and then reassigning hits based on the assembled contigs.
 Changes to X or Y force recomputation of all results when a sample is rerun using idseq-web. Changes to Z do not force recomputation when the sample is rerun - the pipeline will lazily reuse existing outputs in AWS S3.
 
-- 3.15.1
+- 3.15.1-2
   - change PySAM concurrency pattern to improve performance and eliminate deadlock
+  - reduce logging from run_in_subprocess decorator
 
 - 3.15.0
   - Compute insert size metrics for all hosts for paired end DNA reads

--- a/idseq_dag/__init__.py
+++ b/idseq_dag/__init__.py
@@ -1,2 +1,2 @@
 ''' idseq_dag '''
-__version__ = "3.15.1"
+__version__ = "3.15.2"

--- a/idseq_dag/util/command.py
+++ b/idseq_dag/util/command.py
@@ -171,15 +171,12 @@ def run_in_subprocess(target):
 
     @wraps(target)
     def wrapper(*args, **kwargs):
-        with log.log_context("subprocess_scope", {"target": target.__qualname__, "original_caller": log.get_caller_info(3)}):  # TODO: Remove excess logging.
-            # holding this lock during fork reduces deadlock dangers related to file locking within CPython
-            # it's magic, but seems to help, and is the least painful of workarounds
-            with log.print_lock:
-                p = multiprocessing.Process(target=target, args=args, kwargs=kwargs)
-                p.start()
-            p.join()
-            if p.exitcode != 0:
-                raise RuntimeError(f"Failed {target.__qualname__} with code {p.exitcode} on {list(args)}, {kwargs}")  # singleton list prints prettier than singleton tuple
+        with log.print_lock:
+            p = multiprocessing.Process(target=target, args=args, kwargs=kwargs)
+            p.start()
+        p.join()
+        if p.exitcode != 0:
+            raise RuntimeError(f"Failed {target.__qualname__} with code {p.exitcode} on {list(args)}, {kwargs}")  # singleton list prints prettier than singleton tuple
     return wrapper
 
 


### PR DESCRIPTION
Logging in this place happens concurrently from many threads in the mt_map pattern (used in lzw and pysam) and that's a potential liability for deadlock.   Also, it's not super useful.

# Version
- [ ] I have increased the appropriate version number in https://github.com/chanzuckerberg/idseq-dag/blob/master/idseq_dag/__init__.py. Guidelines here: https://github.com/chanzuckerberg/idseq-dag/blob/pr-template/README.md#release-notes
- [ ] I have added release notes for my new version to https://github.com/chanzuckerberg/idseq-dag/blob/pr-template/README.md#release-notes

# Tests
- [ ] I have verified in IDseq staging that the pipeline still completes successfully:
    - [ ] for single-end inputs
    - [ ] for paired-end inputs
    - [ ] for FASTQ inputs
    - [ ] for FASTA inputs.
- [ ] I have validated that my change does not introduce any correctness bugs to existing output types.
- [ ] I have validated that my change does not introduce significant performance regressions or I have discussed with the team that the benefits of the change are substantial enough that we're comfortable accepting the size of the measured performance penalty.

# Notes
*Optional observations, comments or explanations.*
