### PR TITLE
okay_if_missing should not mean okay_if_corrupt

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,9 +232,10 @@ Version numbers for this repo take the form X.Y.Z.
 - We increase X for a paradigm shift in how the pipeline is conceived. Example: adding a de-novo assembly step and then reassigning hits based on the assembled contigs.
 Changes to X or Y force recomputation of all results when a sample is rerun using idseq-web. Changes to Z do not force recomputation when the sample is rerun - the pipeline will lazily reuse existing outputs in AWS S3.
 
-- 3.15.1-2
+- 3.15.1-3
   - change PySAM concurrency pattern to improve performance and eliminate deadlock
   - reduce logging from run_in_subprocess decorator
+  - avoid using corrupt reference downloads
 
 - 3.15.0
   - Compute insert size metrics for all hosts for paired end DNA reads

--- a/idseq_dag/__init__.py
+++ b/idseq_dag/__init__.py
@@ -1,2 +1,2 @@
 ''' idseq_dag '''
-__version__ = "3.15.2"
+__version__ = "3.15.3"

--- a/idseq_dag/util/s3.py
+++ b/idseq_dag/util/s3.py
@@ -354,6 +354,8 @@ def fetch_from_s3(src,  # pylint: disable=dangerous-default-value
                             log.write(
                                 "Failed to download with s3mi. Trying with aws s3 cp..."
                             )
+                        else:
+                            raise
                 if try_cli:
                     if okay_if_missing:
                         script = r'aws s3 cp --quiet "${src}" - ' + command_params
@@ -370,7 +372,7 @@ def fetch_from_s3(src,  # pylint: disable=dangerous-default-value
                     # Move staged download into final location.
                     command.move_file(tmp_dst, dst)
                 return dst
-            except subprocess.CalledProcessError:
+            except:
                 if okay_if_missing:
                     # We presume.
                     log.write(

--- a/idseq_dag/util/s3.py
+++ b/idseq_dag/util/s3.py
@@ -346,7 +346,7 @@ def fetch_from_s3(src,  # pylint: disable=dangerous-default-value
                                 named_args=named_args
                             )
                         )
-                    except:
+                    except subprocess.CalledProcessError:
                         try_cli = not okay_if_missing
                         allow_s3mi = False
                         S3MI_SEM.release()
@@ -372,7 +372,7 @@ def fetch_from_s3(src,  # pylint: disable=dangerous-default-value
                     # Move staged download into final location.
                     command.move_file(tmp_dst, dst)
                 return dst
-            except:
+            except subprocess.CalledProcessError:
                 if okay_if_missing:
                     # We presume.
                     log.write(


### PR DESCRIPTION
sometimes an error occurs while fetching a reference, and because of the bug being fixed here, the incomplete reference file ends up being used, causing crashes later on

see https://jira.czi.team/browse/IDSEQ-2015 and https://jira.czi.team/browse/IDSEQ-2019

# Version
- [x] I have increased the appropriate version number in https://github.com/chanzuckerberg/idseq-dag/blob/master/idseq_dag/__init__.py. Guidelines here: https://github.com/chanzuckerberg/idseq-dag/blob/pr-template/README.md#release-notes
- [x] I have added release notes for my new version to https://github.com/chanzuckerberg/idseq-dag/blob/pr-template/README.md#release-notes

# Tests
- [x] I have verified in IDseq staging that the pipeline still completes successfully:
    - [ ] for single-end inputs
    - [x] for paired-end inputs
    - [x] for FASTQ inputs
    - [ ] for FASTA inputs.
- [ ] I have validated that my change does not introduce any correctness bugs to existing output types.
- [ ] I have validated that my change does not introduce significant performance regressions or I have discussed with the team that the benefits of the change are substantial enough that we're comfortable accepting the size of the measured performance penalty.

# Notes
*Optional observations, comments or explanations.*
