### PR TITLE
Raise default Rapsearch timeout from 1 hr to 3 hrs

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,10 +232,11 @@ Version numbers for this repo take the form X.Y.Z.
 - We increase X for a paradigm shift in how the pipeline is conceived. Example: adding a de-novo assembly step and then reassigning hits based on the assembled contigs.
 Changes to X or Y force recomputation of all results when a sample is rerun using idseq-web. Changes to Z do not force recomputation when the sample is rerun - the pipeline will lazily reuse existing outputs in AWS S3.
 
-- 3.15.1-3
+- 3.15.1-4
   - change PySAM concurrency pattern to improve performance and eliminate deadlock
   - reduce logging from run_in_subprocess decorator
   - avoid using corrupt reference downloads
+  - increase default Rapsearch timeout
 
 - 3.15.0
   - Compute insert size metrics for all hosts for paired end DNA reads

--- a/idseq_dag/__init__.py
+++ b/idseq_dag/__init__.py
@@ -1,2 +1,2 @@
 ''' idseq_dag '''
-__version__ = "3.15.3"
+__version__ = "3.15.4"

--- a/idseq_dag/steps/run_alignment_remotely.py
+++ b/idseq_dag/steps/run_alignment_remotely.py
@@ -24,7 +24,8 @@ CORRECT_NUMBER_OF_OUTPUT_COLUMNS = 12
 CHUNK_MAX_TRIES = 3
 
 # Please override this with gsnap_chunk_timeout or rapsearch_chunk_timeout in DAG json.
-# Default 60 minutes is several sigmas beyond the pale and indicates the data has to be QC-ed better.
+# Default is several sigmas beyond the pale and indicates the data has to be QC-ed better.
+# Note(2020-01-10): Raised to 3 hrs to mitigate Rapsearch chunk timeouts after recent index update.
 DEFAULT_CHUNK_TIMEOUT = 60 * 60 * 3
 
 class PipelineStepRunAlignmentRemotely(PipelineStep):

--- a/idseq_dag/steps/run_alignment_remotely.py
+++ b/idseq_dag/steps/run_alignment_remotely.py
@@ -25,7 +25,7 @@ CHUNK_MAX_TRIES = 3
 
 # Please override this with gsnap_chunk_timeout or rapsearch_chunk_timeout in DAG json.
 # Default 60 minutes is several sigmas beyond the pale and indicates the data has to be QC-ed better.
-DEFAULT_CHUNK_TIMEOUT = 60 * 60
+DEFAULT_CHUNK_TIMEOUT = 60 * 60 * 3
 
 class PipelineStepRunAlignmentRemotely(PipelineStep):
     """ Runs gsnap/rapsearch2 remotely.


### PR DESCRIPTION
# Description
- We decided to raise the default Rapsearch timeout to 3 hrs due to many samples timing out on the 1 hr threshold. We have a hypothesis that this is due to the recent index update.

# Version
- [x] I have increased the appropriate version number in https://github.com/chanzuckerberg/idseq-dag/blob/master/idseq_dag/__init__.py. Guidelines here: https://github.com/chanzuckerberg/idseq-dag/blob/pr-template/README.md#release-notes
- [x] I have added release notes for my new version to https://github.com/chanzuckerberg/idseq-dag/blob/pr-template/README.md#release-notes

# Tests
- Tested in recent project reruns that succeeded with the fix.
- [x] I have verified in IDseq staging that the pipeline still completes successfully:
    - [x] for single-end inputs
    - [x] for paired-end inputs
    - [x] for FASTQ inputs
    - [x] for FASTA inputs.
- [x] I have validated that my change does not introduce any correctness bugs to existing output types.
- [x] I have validated that my change does not introduce significant performance regressions or I have discussed with the team that the benefits of the change are substantial enough that we're comfortable accepting the size of the measured performance penalty.

# Notes
*Optional observations, comments or explanations.*