### PR TITLE
complete the implementation of LRU cache policy for reference downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ Version numbers for this repo take the form X.Y.Z.
 Changes to X or Y force recomputation of all results when a sample is rerun using idseq-web. Changes to Z do not force recomputation when the sample is rerun - the pipeline will lazily reuse existing outputs in AWS S3.
 
 3.16.1
-  - touch current stage reference downloads before deleting LRU references
+  - implement LRU policy for reference downloads cache
 
 - 3.16.0
   - Only compute insert size metrics for RNA reads if we have an organism-specific gtf file

--- a/README.md
+++ b/README.md
@@ -232,13 +232,18 @@ Version numbers for this repo take the form X.Y.Z.
 - We increase X for a paradigm shift in how the pipeline is conceived. Example: adding a de-novo assembly step and then reassigning hits based on the assembled contigs.
 Changes to X or Y force recomputation of all results when a sample is rerun using idseq-web. Changes to Z do not force recomputation when the sample is rerun - the pipeline will lazily reuse existing outputs in AWS S3.
 
+3.16.1
+  - touch current stage reference downloads before deleting LRU references
+
 - 3.16.0
   - Only compute insert size metrics for RNA reads if we have an organism-specific gtf file
+
 - 3.15.1-4
   - change PySAM concurrency pattern to improve performance and eliminate deadlock
   - reduce logging from run_in_subprocess decorator
   - avoid using corrupt reference downloads
   - increase default Rapsearch timeout
+
 - 3.15.0
   - Compute insert size metrics for all hosts for paired end DNA reads
   - Compute insert size metrics for hosts with gtf files for paired end RNA reads

--- a/idseq_dag/__init__.py
+++ b/idseq_dag/__init__.py
@@ -1,2 +1,2 @@
 ''' idseq_dag '''
-__version__ = "3.16.0"
+__version__ = "3.16.1"

--- a/idseq_dag/engine/pipeline_flow.py
+++ b/idseq_dag/engine/pipeline_flow.py
@@ -256,6 +256,9 @@ class PipelineFlow(object):
             }
             log.log_event("Reference downloads cache efficiency report", values=structured_report)
         idseq_dag.util.s3.make_space()  # make sure to touch this stage's files before deleting LRU ones
+        # N.B. the default results folder /mnt/idseq/results is removed by the aegea
+        # command sript driven through idseq-web --- so we don't have to worry about
+        # clearing that space here
 
     def start(self):
         # Come up with the plan

--- a/idseq_dag/engine/pipeline_flow.py
+++ b/idseq_dag/engine/pipeline_flow.py
@@ -50,11 +50,18 @@ class PipelineFlow(object):
         return ".".join(version.split(".")[0:2])
 
     def prefetch_large_files(self):
+
+        def get_it(f, touch_only=False):
+            idseq_dag.util.s3.fetch_reference(
+                f, self.ref_dir_local, auto_unzip=True, auto_untar=True, allow_s3mi=True, touch_only=touch_only)
+
         with log.log_context("prefetch_large_files", values={"file_list": self.large_file_list}):
             for f in self.large_file_list:
+                get_it(f, touch_only=True)
+            idseq_dag.util.s3.make_space()
+            for f in self.large_file_list:
                 with log.log_context("fetch_reference", values={"file": f}):
-                    idseq_dag.util.s3.fetch_reference(
-                        f, self.ref_dir_local, auto_unzip=True, auto_untar=True, allow_s3mi=True)
+                    get_it(f)
 
     @staticmethod
     def parse_and_validate_conf(dag_json):

--- a/idseq_dag/engine/pipeline_flow.py
+++ b/idseq_dag/engine/pipeline_flow.py
@@ -50,11 +50,17 @@ class PipelineFlow(object):
         return ".".join(version.split(".")[0:2])
 
     def prefetch_large_files(self, touch_only=False):
+        successes, failures = set(), set()
         with log.log_context("touch_large_files_and_make_space" if touch_only else "prefetch_large_files", values={"file_list": self.large_file_list}):
             for f in self.large_file_list:
                 with log.log_context("fetch_reference", values={"file": f, "touch_only": touch_only}):
-                    idseq_dag.util.s3.fetch_reference(
+                    success = idseq_dag.util.s3.fetch_reference(
                         f, self.ref_dir_local, auto_unzip=True, auto_untar=True, allow_s3mi=True, touch_only=touch_only)
+                    if success:
+                        successes.add(f)
+                    else:
+                        failures.add(f)
+        return successes, failures
 
     @staticmethod
     def parse_and_validate_conf(dag_json):
@@ -228,12 +234,34 @@ class PipelineFlow(object):
             json.dump({}, status_file)
         idseq_dag.util.s3.upload_with_retries(self.step_status_local, self.output_dir_s3 + "/")
 
+    def manage_reference_downloads_cache(self):
+        present_set, missing_set = self.prefetch_large_files(touch_only=True)
+        total_set = present_set | missing_set
+        if total_set:
+            present = len(present_set)
+            missing = len(missing_set)
+            total = len(total_set)
+            log.write(f"Reference download cache: {present} of {total} large files ({100 * present / total:3.1f} percent) already exist locally.")
+            structured_report = {
+                "summary_stats": {
+                    "cache_requests": total,
+                    "cache_hits": present,
+                    "cache_misses": missing,
+                    "cache_hit_rate": present / total
+                },
+                "per_request_stats": {
+                    f: "hit" if f in present_set else "miss"
+                    for f in sorted(total_set)
+                }
+            }
+            log.log_event("Reference downloads cache efficiency report", values=structured_report)
+        idseq_dag.util.s3.make_space()  # make sure to touch this stage's files before deleting LRU ones
+
     def start(self):
         # Come up with the plan
         (step_list, self.large_file_list, covered_targets) = self.plan()
 
-        self.prefetch_large_files(touch_only=True)
-        idseq_dag.util.s3.make_space()  # make sure to touch this stage's files before deleting LRU ones
+        self.manage_reference_downloads_cache()
         threading.Thread(target=self.prefetch_large_files).start()
 
         for step in step_list:  # download the files from s3 when necessary

--- a/idseq_dag/engine/pipeline_flow.py
+++ b/idseq_dag/engine/pipeline_flow.py
@@ -257,7 +257,7 @@ class PipelineFlow(object):
             log.log_event("Reference downloads cache efficiency report", values=structured_report)
         idseq_dag.util.s3.make_space()  # make sure to touch this stage's files before deleting LRU ones
         # N.B. the default results folder /mnt/idseq/results is removed by the aegea
-        # command sript driven through idseq-web --- so we don't have to worry about
+        # command script driven through idseq-web --- so we don't have to worry about
         # clearing that space here
 
     def start(self):

--- a/idseq_dag/util/command.py
+++ b/idseq_dag/util/command.py
@@ -5,14 +5,12 @@ import sys
 import os
 import threading
 import time
-import datetime
 import glob as _glob
 import shutil
-import shlex
-import pkg_resources
+import pathlib
 from functools import wraps
-import pytz
-from typing import List, Union, Dict, Any
+from typing import Union
+import pkg_resources
 import idseq_dag.util.log as log
 from idseq_dag.util.trace_lock import TraceLock
 import idseq_dag.util.command_patterns as command_patterns
@@ -315,6 +313,16 @@ def copy_file(src: str, dst: str):
 def move_file(src: str, dst: str):
     with log.log_context(context_name='command.move_file', values={'src': src, 'dest': dst}, log_context_mode=log.LogContextMode.EXEC_LOG_EVENT):
         shutil.move(src, dst)
+
+
+def rename(src: str, dst: str):
+    with log.log_context(context_name='command.rename', values={'src': src, 'dest': dst}, log_context_mode=log.LogContextMode.EXEC_LOG_EVENT):
+        os.rename(src, dst)
+
+
+def touch(path, exist_ok=True):
+    with log.log_context(context_name='command.touch', values={'path': path}, log_context_mode=log.LogContextMode.EXEC_LOG_EVENT):
+        pathlib.Path(path).touch(exist_ok=exist_ok)
 
 
 def remove_file(file_path: str):

--- a/idseq_dag/util/s3.py
+++ b/idseq_dag/util/s3.py
@@ -153,7 +153,8 @@ def refreshed_credentials(credentials_mutex=multiprocessing.RLock(), credentials
 
 def find_oldest_reference(refdir):
     try:
-        ls = subprocess.run(f"ls -t {refdir} | tail -1", shell=True, executable="/bin/bash", check=True, capture_output=True)
+        # To understand this ls command, please see the path forming explained in fetch_from_s3 when is_reference=True.
+        ls = subprocess.run(f"ls -td {refdir}/*/* | tail -1", shell=True, executable="/bin/bash", check=True, capture_output=True)
     except:
         # This happens when there are no reference files to delete.
         return None
@@ -179,7 +180,7 @@ def really_make_space():
         if not lru:
             log.write("WARNING:  Too little available space on instance, and could not find any reference downloads to delete.")
             break
-        command.remove_rf(os.path.join(refdir, lru))
+        command.remove_rf(lru)
 
 
 def make_space(done={}, mutex=TraceLock("make_space", multiprocessing.RLock())):  # pylint: disable=dangerous-default-value

--- a/idseq_dag/util/s3.py
+++ b/idseq_dag/util/s3.py
@@ -249,8 +249,8 @@ def fetch_from_s3(src,  # pylint: disable=dangerous-default-value
     to update its timestamp.
 
     When touch_only=True, if the destination does not already exist, the function
-    simply returns None (as if the download failed), after touching the existing
-    destination.  This is useful in implementing an LRU refernece caching policy.
+    simply returns None (as if the download failed).  If the destination does exist,
+    it is touched as usual.  This is useful in implementing an LRU cache policy.
 
     An exception is raised only if there is a coding error or equivalent problem,
     not if src simply doesn't exist.
@@ -316,8 +316,6 @@ def fetch_from_s3(src,  # pylint: disable=dangerous-default-value
 
         if touch_only:
             return None
-        else:
-            make_space()
 
         for (kind, ddir) in [("destinaiton", destdir), ("temporary download", tmp_destdir)]:
             try:

--- a/idseq_dag/util/s3.py
+++ b/idseq_dag/util/s3.py
@@ -249,8 +249,8 @@ def fetch_from_s3(src,  # pylint: disable=dangerous-default-value
     to update its timestamp.
 
     When touch_only=True, if the destination does not already exist, the function
-    simply returns None (as if the download failed).  This is useful in implementing
-    an LRU refernece caching policy.
+    simply returns None (as if the download failed), after touching the existing
+    destination.  This is useful in implementing an LRU refernece caching policy.
 
     An exception is raised only if there is a coding error or equivalent problem,
     not if src simply doesn't exist.


### PR DESCRIPTION
see https://jira.czi.team/browse/IDSEQ-1866

# Version
- [x] I have increased the appropriate version number in https://github.com/chanzuckerberg/idseq-dag/blob/master/idseq_dag/__init__.py. Guidelines here: https://github.com/chanzuckerberg/idseq-dag/blob/pr-template/README.md#release-notes
- [x] I have added release notes for my new version to https://github.com/chanzuckerberg/idseq-dag/blob/pr-template/README.md#release-notes

# Tests
- [x] I have verified in IDseq staging that the pipeline still completes successfully:
    - [ ] for single-end inputs
    - [x] for paired-end inputs
    - [x] for FASTQ inputs
    - [ ] for FASTA inputs.
- [ ] I have validated that my change does not introduce any correctness bugs to existing output types.
- [x] I have validated that my change does not introduce significant performance regressions or I have discussed with the team that the benefits of the change are substantial enough that we're comfortable accepting the size of the measured performance penalty.

# Notes
*Optional observations, comments or explanations.*
