### PR TITLE
Add checksum uploads for rapsearch

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "python.pythonPath": "/usr/bin/python"
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python.pythonPath": "/usr/bin/python"
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -150,6 +150,11 @@ RUN mv picard.jar /usr/local/bin/
 RUN printf '#!/bin/bash\njava -jar /usr/local/bin/picard.jar "$@"\n' > /usr/local/bin/picard
 RUN chmod +x /usr/local/bin/picard
 
+# Install s3parcp
+WORKDIR /tmp
+RUN curl -L https://github.com/chanzuckerberg/s3parcp/releases/download/v0.0.11-alpha/s3parcp_0.0.11-alpha_Linux_x86_64.tar.gz | tar zx
+RUN mv s3parcp /usr/local/bin
+
 # Cleanup
 RUN rm -rf /tmp/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -152,7 +152,7 @@ RUN chmod +x /usr/local/bin/picard
 
 # Install s3parcp
 WORKDIR /tmp
-RUN curl -L https://github.com/chanzuckerberg/s3parcp/releases/download/v0.0.11-alpha/s3parcp_0.0.11-alpha_Linux_x86_64.tar.gz | tar zx
+RUN curl -L https://github.com/chanzuckerberg/s3parcp/releases/download/v0.0.13-alpha/s3parcp_0.0.13-alpha_Linux_x86_64.tar.gz | tar zx
 RUN mv s3parcp /usr/local/bin
 
 # Cleanup

--- a/Dockerfile
+++ b/Dockerfile
@@ -150,11 +150,6 @@ RUN mv picard.jar /usr/local/bin/
 RUN printf '#!/bin/bash\njava -jar /usr/local/bin/picard.jar "$@"\n' > /usr/local/bin/picard
 RUN chmod +x /usr/local/bin/picard
 
-# Install s3parcp
-WORKDIR /tmp
-RUN curl -L https://github.com/chanzuckerberg/s3parcp/releases/download/v0.0.11-alpha/s3parcp_0.0.11-alpha_Linux_x86_64.tar.gz | tar zx
-RUN mv s3parcp /usr/local/bin
-
 # Cleanup
 RUN rm -rf /tmp/*
 

--- a/README.md
+++ b/README.md
@@ -232,6 +232,9 @@ Version numbers for this repo take the form X.Y.Z.
 - We increase X for a paradigm shift in how the pipeline is conceived. Example: adding a de-novo assembly step and then reassigning hits based on the assembled contigs.
 Changes to X or Y force recomputation of all results when a sample is rerun using idseq-web. Changes to Z do not force recomputation when the sample is rerun - the pipeline will lazily reuse existing outputs in AWS S3.
 
+- 3.16.3
+  - Use s3parcp with checksum for rapsearch index uploads
+
 - 3.16.2
   - fix botocore import issue for util.s3
   - switch to subprocess command for `util.s3.list_s3_keys` for thread safety

--- a/idseq_dag/__init__.py
+++ b/idseq_dag/__init__.py
@@ -1,2 +1,2 @@
 ''' idseq_dag '''
-__version__ = "3.16.2"
+__version__ = "3.16.3"

--- a/idseq_dag/engine/pipeline_step.py
+++ b/idseq_dag/engine/pipeline_step.py
@@ -60,6 +60,7 @@ class PipelineStep(object):
         self.should_count_reads = False
 
         self.input_file_error = None
+        self.upload_results_with_checksum = False
 
     @abstractmethod
     def run(self):
@@ -95,7 +96,7 @@ class PipelineStep(object):
         for f in files_to_upload:
             # upload to S3 - TODO(Boris): parallelize the following with better calls
             s3_path = self.s3_path(f)
-            idseq_dag.util.s3.upload_with_retries(f, s3_path)
+            idseq_dag.util.s3.upload_with_retries(f, s3_path, checksum=self.upload_results_with_checksum)
         for f in self.additional_folders_to_upload:
             idseq_dag.util.s3.upload_folder_with_retries(f, self.s3_path(f))
         self.status = StepStatus.UPLOADED

--- a/idseq_dag/steps/generate_rapsearch2_index.py
+++ b/idseq_dag/steps/generate_rapsearch2_index.py
@@ -6,6 +6,10 @@ import idseq_dag.util.command as command
 import idseq_dag.util.command_patterns as command_patterns
 
 class PipelineStepGenerateRapsearch2Index(PipelineStep):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.upload_results_with_checksum = True
+
     ''' Generate   RAPSearch index from NR '''
     def run(self):
         """

--- a/idseq_dag/util/s3.py
+++ b/idseq_dag/util/s3.py
@@ -512,11 +512,9 @@ def upload_with_retries(from_f, to_f, checksum=False):
             if checksum:
                 command.execute(
                     command_patterns.SingleCommand(
-                        cmd="aws",
+                        cmd="s3parcp",
                         args=[
-                            "s3",
-                            "cp",
-                            "--only-show-errors",
+                            "--checksum",
                             from_f,
                             to_f
                         ],
@@ -526,9 +524,11 @@ def upload_with_retries(from_f, to_f, checksum=False):
             else:
                 command.execute(
                     command_patterns.SingleCommand(
-                        cmd="s3parcp",
+                        cmd="aws",
                         args=[
-                            "--checksum",
+                            "s3",
+                            "cp",
+                            "--only-show-errors",
                             from_f,
                             to_f
                         ],

--- a/idseq_dag/util/s3.py
+++ b/idseq_dag/util/s3.py
@@ -234,6 +234,7 @@ def install_s3parcp(installed={}, mutex=TraceLock("install_s3parcp", multiproces
         finally:
             installed['time'] = time.time()
 
+
 DEFAULT_AUTO_UNZIP = False
 DEFAULT_AUTO_UNTAR = False
 DEFAULT_ALLOW_S3MI = False

--- a/idseq_dag/util/s3.py
+++ b/idseq_dag/util/s3.py
@@ -506,22 +506,35 @@ def fetch_byterange(first_byte, last_byte, bucket, key, output_file):
 
 
 @command.retry
-def upload_with_retries(from_f, to_f):
+def upload_with_retries(from_f, to_f, checksum=False):
     with IOSTREAM_UPLOADS:
         with IOSTREAM:
-            command.execute(
-                command_patterns.SingleCommand(
-                    cmd="aws",
-                    args=[
-                        "s3",
-                        "cp",
-                        "--only-show-errors",
-                        from_f,
-                        to_f
-                    ],
-                    env=dict(os.environ, **refreshed_credentials())
+            if checksum:
+                command.execute(
+                    command_patterns.SingleCommand(
+                        cmd="aws",
+                        args=[
+                            "s3",
+                            "cp",
+                            "--only-show-errors",
+                            from_f,
+                            to_f
+                        ],
+                        env=dict(os.environ, **refreshed_credentials())
+                    )
                 )
-            )
+            else:
+                command.execute(
+                    command_patterns.SingleCommand(
+                        cmd="s3parcp",
+                        args=[
+                            "--checksum",
+                            from_f,
+                            to_f
+                        ],
+                        env=dict(os.environ, **refreshed_credentials())
+                    )
+                )
 
 
 @command.retry

--- a/idseq_dag/util/s3.py
+++ b/idseq_dag/util/s3.py
@@ -222,6 +222,18 @@ def install_s3mi(installed={}, mutex=TraceLock("install_s3mi", multiprocessing.R
             installed['time'] = time.time()
 
 
+def install_s3parcp(installed={}, mutex=TraceLock("install_s3parcp", multiprocessing.RLock())):  # pylint: disable=dangerous-default-value
+    with mutex:
+        if installed:  # Mutable default value persists
+            return
+        try:
+            # This is typically a no-op.
+            command.execute(
+                "which s3parcp || (curl -L https://github.com/chanzuckerberg/s3parcp/releases/download/v0.0.11-alpha/s3parcp_0.0.11-alpha_Linux_x86_64.tar.gz | tar zx; mv s3parcp /usr/local/bin)"
+            )
+        finally:
+            installed['time'] = time.time()
+
 DEFAULT_AUTO_UNZIP = False
 DEFAULT_AUTO_UNTAR = False
 DEFAULT_ALLOW_S3MI = False
@@ -524,6 +536,7 @@ def upload_with_retries(from_f, to_f, checksum=False):
                     )
                 )
             else:
+                install_s3parcp()
                 command.execute(
                     command_patterns.SingleCommand(
                         cmd="s3parcp",

--- a/idseq_dag/util/s3.py
+++ b/idseq_dag/util/s3.py
@@ -222,19 +222,6 @@ def install_s3mi(installed={}, mutex=TraceLock("install_s3mi", multiprocessing.R
             installed['time'] = time.time()
 
 
-def install_s3parcp(installed={}, mutex=TraceLock("install_s3parcp", multiprocessing.RLock())):  # pylint: disable=dangerous-default-value
-    with mutex:
-        if installed:  # Mutable default value persists
-            return
-        try:
-            # This is typically a no-op.
-            command.execute(
-                "which s3parcp || (curl -L https://github.com/chanzuckerberg/s3parcp/releases/download/v0.0.11-alpha/s3parcp_0.0.11-alpha_Linux_x86_64.tar.gz | tar zx; mv s3parcp /usr/local/bin)"
-            )
-        finally:
-            installed['time'] = time.time()
-
-
 DEFAULT_AUTO_UNZIP = False
 DEFAULT_AUTO_UNTAR = False
 DEFAULT_ALLOW_S3MI = False
@@ -537,7 +524,6 @@ def upload_with_retries(from_f, to_f, checksum=False):
                     )
                 )
             else:
-                install_s3parcp()
                 command.execute(
                     command_patterns.SingleCommand(
                         cmd="s3parcp",

--- a/templates/rapsearch2_index.json
+++ b/templates/rapsearch2_index.json
@@ -21,14 +21,6 @@
       "module": "idseq_dag.steps.generate_rapsearch2_index",
       "additional_files": {},
       "additional_attributes": {}
-    },
-    {
-      "in": ["nr_index"],
-      "out": "nr_index_lz4",
-      "class": "PipelineStepGenerateLZ4",
-      "module": "idseq_dag.steps.generate_lz4",
-      "additional_files": {},
-      "additional_attributes": {}
     }
   ],
   "given_targets": {


### PR DESCRIPTION
# Description

Use s3parcp to compute checksums when uploading rapsearch indexes.

# Version
- [X] I have increased the appropriate version number in https://github.com/chanzuckerberg/idseq-dag/blob/master/idseq_dag/__init__.py. Guidelines here: https://github.com/chanzuckerberg/idseq-dag/blob/pr-template/README.md#release-notes
- [X] I have added release notes for my new version to https://github.com/chanzuckerberg/idseq-dag/blob/pr-template/README.md#release-notes

# Tests

The test checklist is not applicable because this changes index generation and not runtime.

I did three tests:

I tested normal pipeline operation on this branch to ensure this won't interfere with typical pipeline runs.

I switched the default to checksum uploads and ran a pipeline to ensure if checksum uploads are ever enabled for other pipeline steps they will still work.

I did the test described in this PR for index generation https://github.com/chanzuckerberg/idseq-infra/pull/296. I simulated the uploading after an index generation by switching the index generation with a copy command and using an existing index. The uploading code from this branch was used for that test.
