### PR TITLE
Fix boto import + concurrency issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,11 @@ Version numbers for this repo take the form X.Y.Z.
 - We increase X for a paradigm shift in how the pipeline is conceived. Example: adding a de-novo assembly step and then reassigning hits based on the assembled contigs.
 Changes to X or Y force recomputation of all results when a sample is rerun using idseq-web. Changes to Z do not force recomputation when the sample is rerun - the pipeline will lazily reuse existing outputs in AWS S3.
 
-3.16.1
+- 3.16.2
+  - fix botocore import issue for util.s3
+  - switch to subprocess command for `util.s3.list_s3_keys` for thread safety
+
+- 3.16.1
   - implement LRU policy for reference downloads cache
 
 - 3.16.0

--- a/idseq_dag/__init__.py
+++ b/idseq_dag/__init__.py
@@ -1,2 +1,2 @@
 ''' idseq_dag '''
-__version__ = "3.16.1"
+__version__ = "3.16.2"

--- a/idseq_dag/util/s3.py
+++ b/idseq_dag/util/s3.py
@@ -91,6 +91,7 @@ def list_s3_keys(s3_path_prefix):
         parsed_url = urlparse(s3_path_prefix, allow_fragments=False)
         bucket = parsed_url.netloc
         prefix = parsed_url.path.lstrip('/')
+        # Use the AWS CLI instead of boto for thread safety
         raw_response = command.execute(
             command_patterns.SingleCommand(
                 cmd="aws",

--- a/idseq_dag/util/s3.py
+++ b/idseq_dag/util/s3.py
@@ -105,7 +105,7 @@ def list_s3_keys(s3_path_prefix):
             capture_stdout=True,
         )
         parsed_response = json.loads(raw_response)
-        return [ item['Key'] for item in parsed_response['Contents'] ]
+        return [item['Key'] for item in parsed_response['Contents']]
 
 
 # Something similar to this exist's in s3's REST API

--- a/idseq_dag/util/s3.py
+++ b/idseq_dag/util/s3.py
@@ -4,10 +4,12 @@ import os
 import multiprocessing
 import errno
 import re
+import json
 from urllib.parse import urlparse
 import traceback
 import boto3
-import botocore
+import botocore.exceptions
+import botocore.session
 from idseq_dag.util.trace_lock import TraceLock
 import idseq_dag.util.command_patterns as command_patterns
 
@@ -83,23 +85,27 @@ def check_s3_presence(s3_path, allow_zero_byte_files=True):
         return _check_s3_presence(s3_path, allow_zero_byte_files)
 
 
-def _list_s3_keys(s3_path_prefix):
-    """Returns an iterator of s3 keys prefixed by s3_path_prefix."""
+def list_s3_keys(s3_path_prefix):
+    """Returns a list of s3 keys prefixed by s3_path_prefix."""
     with log.log_context(context_name="s3.list_s3_objects", values={'s3_path_prefix': s3_path_prefix}, log_context_mode=log.LogContextMode.EXEC_LOG_EVENT):
         parsed_url = urlparse(s3_path_prefix, allow_fragments=False)
         bucket = parsed_url.netloc
         prefix = parsed_url.path.lstrip('/')
-        client = boto3.client('s3')
-        paginator = client.get_paginator('list_objects')
-        for response in paginator.paginate(Bucket=bucket, Prefix=prefix):
-            for item in response['Contents']:
-                yield item['Key']
-
-
-def list_s3_keys(s3_path_prefix):
-    with botolock:
-        rate_limit_boto()
-        return _list_s3_keys(s3_path_prefix)
+        raw_response = command.execute(
+            command_patterns.SingleCommand(
+                cmd="aws",
+                args=[
+                    "s3api",
+                    "list-objects-v2",
+                    "--bucket", bucket,
+                    "--prefix", prefix,
+                ],
+                env=dict(os.environ, **refreshed_credentials()),
+            ),
+            capture_stdout=True,
+        )
+        parsed_response = json.loads(raw_response)
+        return [ item['Key'] for item in parsed_response['Contents'] ]
 
 
 # Something similar to this exist's in s3's REST API


### PR DESCRIPTION
# Description
Fixes the `botocore` imports for s3. This caused an issue in index generation.

Switch to subprocess command for `list_s3_keys` for thread safety.

# Version
- [x] I have increased the appropriate version number in https://github.com/chanzuckerberg/idseq-dag/blob/master/idseq_dag/__init__.py. Guidelines here: https://github.com/chanzuckerberg/idseq-dag/blob/pr-template/README.md#release-notes
- [x] I have added release notes for my new version to https://github.com/chanzuckerberg/idseq-dag/blob/pr-template/README.md#release-notes

# Tests

I tested locally and with the benchmark sample. If this were to break something it would break it universally and it is a relatively low risk change.

- [ ] I have verified in IDseq staging that the pipeline still completes successfully:
    - [ ] for single-end inputs
    - [x] for paired-end inputs
    - [ ] for FASTQ inputs
    - [ ] for FASTA inputs.
- [ ] I have validated that my change does not introduce any correctness bugs to existing output types.
- [ ] I have validated that my change does not introduce significant performance regressions or I have discussed with the team that the benefits of the change are substantial enough that we're comfortable accepting the size of the measured performance penalty.
