### PR TITLE
Alignment isolation and cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,11 @@ Version numbers for this repo take the form X.Y.Z.
 - We increase X for a paradigm shift in how the pipeline is conceived. Example: adding a de-novo assembly step and then reassigning hits based on the assembled contigs.
 Changes to X or Y force recomputation of all results when a sample is rerun using idseq-web. Changes to Z do not force recomputation when the sample is rerun - the pipeline will lazily reuse existing outputs in AWS S3.
 
+- 3.16.4
+  - Isolate directories on alignment instances to chunks rather than whole samples
+  - Clean up intermediate files from alignment instances after running alignment on a chunk
+  - Ensure alignment instance is clean before running alignment on a chunk
+
 - 3.16.3
   - Use s3parcp with checksum for rapsearch index uploads
 

--- a/idseq_dag/__init__.py
+++ b/idseq_dag/__init__.py
@@ -1,2 +1,2 @@
 ''' idseq_dag '''
-__version__ = "3.16.3"
+__version__ = "3.16.4"

--- a/idseq_dag/steps/run_alignment_remotely.py
+++ b/idseq_dag/steps/run_alignment_remotely.py
@@ -370,7 +370,7 @@ class PipelineStepRunAlignmentRemotely(PipelineStep):
         This needs to happen while we are holding the machine reservation,
         i.e., inside the "with ASGInstnace" context.
         """
-        rm_command = command_patterns.SingleCommand("rm", ["-r", remote_dir])
+        rm_command = f"rm -r {remote_dir}"
         command.execute(command.remote(rm_command, key_path, remote_username, instance_ip))
 
     def run_chunk(self, part_suffix, remote_home_dir, remote_index_dir, remote_work_dir,

--- a/idseq_dag/steps/run_alignment_remotely.py
+++ b/idseq_dag/steps/run_alignment_remotely.py
@@ -406,8 +406,6 @@ class PipelineStepRunAlignmentRemotely(PipelineStep):
         else:
             commands = base_str + "/usr/local/bin/rapsearch -d {remote_index_dir}/nr_rapsearch -e -6 -l 10 -a T -b 0 -v 50 -z 24 -q {remote_input_files} -o {multihit_remote_outfile}"
 
-        commands += " ; rm -r {remote_work_dir}"
-
         commands = commands.format(
             remote_work_dir=shlex.quote(remote_work_dir),
             download_input_from_s3=download_input_from_s3,

--- a/idseq_dag/steps/run_alignment_remotely.py
+++ b/idseq_dag/steps/run_alignment_remotely.py
@@ -1,4 +1,4 @@
-import is
+import os
 import threading
 import shutil
 import random


### PR DESCRIPTION
# Description

This is one of two fixes ([the other fix](https://github.com/chanzuckerberg/idseq-web/pull/3003)) for a bug with rapsearch.

The issue is that rapsearch generates intermediate files. Our current system does not clean these files. If rapsearch fails for whatever reason the intermediate files from that run will remain on the instance it ran on. If the retry is run on the same instance these incomplete intermediate break the subsequent run. At times of low volume when there are few instances this is actually not so unlikely.

This change does a few things:

- **Creates working directories for each chunk instead of each sample**. Currently, the working directory was namespaced to the sample. This means that two chunks of the same sample running on the same instance would use the same working directory. This is a little untidy in my opinion. It also makes deleting intermediate files more of a hassle because you may risk deleting files still in use by another chunk. It could also have other unintended consequences. I felt it would be cleanest to isolate these chunks further.
- **Cleans up intermediate files after aligning each chunk**. Currently, any files generated from running a chunk will remain on the instance until it is terminated. This means that theoretically the disk space of the instance could fill up and it means our system is dependent on the assumption that instances will be terminated before this happens. There is also a chance that these extra files could push the index out of the file system cache though I have done no research on this at all so I could easily be wrong.
- **Cleans up working directory before aligning each chunk**. This is the most important for the actual bug fix. Since rapsearch may fail before the cleanup is run there is a chance that a directory filled with incomplete intermediate files remains on an instance. If the failed chunk were retried on that instance it would fail again. Cleaning the working directory before aligning a chunk ensures that this doesn't happen.

# Version
- [x] I have increased the appropriate version number in https://github.com/chanzuckerberg/idseq-dag/blob/master/idseq_dag/__init__.py. Guidelines here: https://github.com/chanzuckerberg/idseq-dag/blob/pr-template/README.md#release-notes
- [x] I have added release notes for my new version to https://github.com/chanzuckerberg/idseq-dag/blob/pr-template/README.md#release-notes

# Tests
- [ ] I have verified in IDseq staging that the pipeline still completes successfully:
    - [ ] for single-end inputs
    - [x] for paired-end inputs
    - [ ] for FASTQ inputs
    - [x] for FASTA inputs.
- [x] I have validated that my change does not introduce any correctness bugs to existing output types.
- [x] I have validated that my change does not introduce significant performance regressions or I have discussed with the team that the benefits of the change are substantial enough that we're comfortable accepting the size of the measured performance penalty.
