### PR TITLE
Fail gracefully when no reads are left after LZW filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,9 @@ Version numbers for this repo take the form X.Y.Z.
 - We increase X for a paradigm shift in how the pipeline is conceived. Example: adding a de-novo assembly step and then reassigning hits based on the assembled contigs.
 Changes to X or Y force recomputation of all results when a sample is rerun using idseq-web. Changes to Z do not force recomputation when the sample is rerun - the pipeline will lazily reuse existing outputs in AWS S3.
 
+- 3.16.4
+  - Fail gracefully with INSUFFICIENT_READS error if all reads drop out during LZW filtering.
+
 - 3.16.3
   - Use s3parcp with checksum for rapsearch index uploads
 

--- a/idseq_dag/__init__.py
+++ b/idseq_dag/__init__.py
@@ -1,2 +1,2 @@
 ''' idseq_dag '''
-__version__ = "3.16.3"
+__version__ = "3.16.4"

--- a/idseq_dag/steps/run_lzw.py
+++ b/idseq_dag/steps/run_lzw.py
@@ -1,15 +1,16 @@
-from multiprocessing import cpu_count
-from typing import Iterator
-import os
-from idseq_dag.engine.pipeline_step import PipelineStep, InputFileErrors
 import idseq_dag.util.command as command
 import idseq_dag.util.command_patterns as command_patterns
-from idseq_dag.util.command import run_in_subprocess
-import idseq_dag.util.log as log
 import idseq_dag.util.count as count
 import idseq_dag.util.fasta as fasta
-from idseq_dag.util.thread_with_result import mt_map
+import idseq_dag.util.log as log
 import math
+import os
+
+from idseq_dag.engine.pipeline_step import InputFileErrors, PipelineStep
+from idseq_dag.util.command import run_in_subprocess
+from idseq_dag.util.thread_with_result import mt_map
+from multiprocessing import cpu_count
+from typing import Iterator
 
 
 class PipelineStepRunLZW(PipelineStep):
@@ -207,6 +208,8 @@ class PipelineStepRunLZW(PipelineStep):
 
         if kept_count == 0:
             self.input_file_error = InputFileErrors.INSUFFICIENT_READS
+            self.status = StepStatus.INVALID_INPUT
+            return
 
         kept_ratio = float(kept_count) / float(total_reads)
         msg = "LZW filter: cutoff_frac: %f, total reads: %d, filtered reads: %d, " \

--- a/idseq_dag/steps/run_lzw.py
+++ b/idseq_dag/steps/run_lzw.py
@@ -143,8 +143,7 @@ class PipelineStepRunLZW(PipelineStep):
             os.remove(tfn)
         return coalesced_score_file
 
-    @staticmethod
-    def generate_lzw_filtered(fasta_files, output_files, cutoff_scores, threshold_readlength):
+    def generate_lzw_filtered(self, fasta_files, output_files, cutoff_scores, threshold_readlength):
         assert len(fasta_files) == len(output_files)
 
         cutoff_scores.sort(reverse=True)  # Make sure cutoff is from high to low
@@ -207,7 +206,7 @@ class PipelineStepRunLZW(PipelineStep):
                 break
 
         if kept_count == 0:
-            raise RuntimeError("All the reads are filtered by LZW with lowest cutoff: %f" % cutoff_frac)
+            self.input_file_error = InputFileErrors.INSUFFICIENT_READS
 
         kept_ratio = float(kept_count) / float(total_reads)
         msg = "LZW filter: cutoff_frac: %f, total reads: %d, filtered reads: %d, " \

--- a/idseq_dag/steps/run_lzw.py
+++ b/idseq_dag/steps/run_lzw.py
@@ -46,7 +46,7 @@ class PipelineStepRunLZW(PipelineStep):
         output_fas = self.output_files_local()
         cutoff_scores = self.additional_attributes["thresholds"]
         threshold_readlength = self.additional_attributes.get("threshold_readlength", 150)
-        PipelineStepRunLZW.generate_lzw_filtered(input_fas, output_fas, cutoff_scores, threshold_readlength)
+        self.generate_lzw_filtered(input_fas, output_fas, cutoff_scores, threshold_readlength)
 
     def count_reads(self):
         self.should_count_reads = True

--- a/idseq_dag/steps/run_lzw.py
+++ b/idseq_dag/steps/run_lzw.py
@@ -6,7 +6,7 @@ import idseq_dag.util.log as log
 import math
 import os
 
-from idseq_dag.engine.pipeline_step import InputFileErrors, PipelineStep
+from idseq_dag.engine.pipeline_step import InputFileErrors, PipelineStep, StepStatus
 from idseq_dag.util.command import run_in_subprocess
 from idseq_dag.util.thread_with_result import mt_map
 from multiprocessing import cpu_count

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -3,7 +3,7 @@
 
 # Version
 - [ ] I have increased the appropriate version number in https://github.com/chanzuckerberg/idseq-dag/blob/master/idseq_dag/__init__.py. Guidelines here: https://github.com/chanzuckerberg/idseq-dag/blob/pr-template/README.md#release-notes
-- [ ] I have added release notes for my new version to https://github.com/chanzuckerberg/idseq-dag/blob/pr-template/README.md#release-notes
+- [ ] I have added release notes for my new version to https://github.com/chanzuckerberg/idseq-dag/blob/master/README.md#release-notes
 
 # Tests
 - [ ] I have verified in IDseq staging that the pipeline still completes successfully:


### PR DESCRIPTION
# Description
When all reads are filtered out by LZW, then the user should get an INSUFFICIENT READS warning, rather than a failure message. 

# Version
- [x] I have increased the appropriate version number in https://github.com/chanzuckerberg/idseq-dag/blob/master/idseq_dag/__init__.py. Guidelines here: https://github.com/chanzuckerberg/idseq-dag/blob/pr-template/README.md#release-notes
- [x] I have added release notes for my new version to https://github.com/chanzuckerberg/idseq-dag/blob/pr-template/README.md#release-notes

# Tests
- [x] I have verified in IDseq staging that the pipeline still completes successfully:
    - [ ] for single-end inputs
    - [x] for paired-end inputs
    - [x] for FASTQ inputs
    - [ ] for FASTA inputs.
- [x] I have validated that my change does not introduce any correctness bugs to existing output types.
- [x] I have validated that my change does not introduce significant performance regressions or I have discussed with the team that the benefits of the change are substantial enough that we're comfortable accepting the size of the measured performance penalty.

# Notes
*Optional observations, comments or explanations.*
