### PR TITLE
[Do Not Merge] Update NCBI index databases to those downloaded on 2020-02-03

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,9 @@ Version numbers for this repo take the form X.Y.Z.
 - We increase X for a paradigm shift in how the pipeline is conceived. Example: adding a de-novo assembly step and then reassigning hits based on the assembled contigs.
 Changes to X or Y force recomputation of all results when a sample is rerun using idseq-web. Changes to Z do not force recomputation when the sample is rerun - the pipeline will lazily reuse existing outputs in AWS S3.
 
+- 3.17.0
+  - Version marker: Update NCBI index databases to those downloaded on 2020-02-03.
+
 - 3.16.6
   - Isolate directories on alignment instances to chunks rather than whole samples
   - Clean up intermediate files from alignment instances after running alignment on a chunk

--- a/idseq_dag/__init__.py
+++ b/idseq_dag/__init__.py
@@ -1,2 +1,2 @@
 ''' idseq_dag '''
-__version__ = "3.16.6"
+__version__ = "3.17.0"


### PR DESCRIPTION
# Description
- To facilitate reruns on the new index, we bump the version marker to ensure that cached intermediate files are not used in rerunning samples.
- See: https://github.com/chanzuckerberg/idseq-dag/pull/213/files

# Version
- [ ] I have increased the appropriate version number in https://github.com/chanzuckerberg/idseq-dag/blob/master/idseq_dag/__init__.py. Guidelines here: https://github.com/chanzuckerberg/idseq-dag/blob/pr-template/README.md#release-notes
- [ ] I have added release notes for my new version to https://github.com/chanzuckerberg/idseq-dag/blob/master/README.md#release-notes

# Tests
- [ ] I have verified in IDseq staging that the pipeline still completes successfully:
    - [ ] for single-end inputs
    - [ ] for paired-end inputs
    - [ ] for FASTQ inputs
    - [ ] for FASTA inputs.
- [ ] I have validated that my change does not introduce any correctness bugs to existing output types.
- [ ] I have validated that my change does not introduce significant performance regressions or I have discussed with the team that the benefits of the change are substantial enough that we're comfortable accepting the size of the measured performance penalty.