### PR TITLE
steps.run_validate_input: do not clobber input files

### DIFF
--- a/idseq_dag/steps/run_validate_input.py
+++ b/idseq_dag/steps/run_validate_input.py
@@ -69,8 +69,7 @@ class PipelineStepRunValidateInput(PipelineStep):
                                 }
                             )
                         )
-                        command.remove_file(input_file)
-                        command.move_file(tmp_file, input_file)
+                        input_files[i] = tmp_file
                     except:
                         raise RuntimeError(f"Invalid fastq/fasta file")
 


### PR DESCRIPTION
Input files are bind mounted read-only in Docker. Avoid trying to
overwrite them.