### PR TITLE
Append [Datadog] to AmrAlleleMismatchError log

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,9 @@ Version numbers for this repo take the form X.Y.Z.
 - We increase X for a paradigm shift in how the pipeline is conceived. Example: adding a de-novo assembly step and then reassigning hits based on the assembled contigs.
 Changes to X or Y force recomputation of all results when a sample is rerun using idseq-web. Changes to Z do not force recomputation when the sample is rerun - the pipeline will lazily reuse existing outputs in AWS S3.
 
+- 3.18.1
+  - Update log statement for AMR bug for alerting purposes.
+
 - 3.18.0
   - Version marker: Update NCBI index databases to those downloaded on 2020-02-10.
 

--- a/idseq_dag/__init__.py
+++ b/idseq_dag/__init__.py
@@ -1,2 +1,2 @@
 ''' idseq_dag '''
-__version__ = "3.18.0"
+__version__ = "3.18.1"

--- a/idseq_dag/steps/run_srst2.py
+++ b/idseq_dag/steps/run_srst2.py
@@ -236,7 +236,7 @@ class PipelineStepRunSRST2(PipelineStep):
                 # because there were typos in allele names in ARGannot_r2.fasta that caused mismatches with argannot_genome.bed.
                 # Log an error. The following line will crash the pipeline step, which is intended.
                 # We prefer failing the pipeline step to showing incorrect or missing data while failing silently to the user.
-                log.write(f"AmrAlleleMismatchError: {row.allele} (from ARGannot_r2.fasta) could not be found in argannot_genome.bed")
+                log.write(f"[Datadog] AmrAlleleMismatchError: {row.allele} (from ARGannot_r2.fasta) could not be found in argannot_genome.bed")
 
             reads_for_allele = rpm_df[rpm_df["allele"] == row.allele]["reads"].values[0]
             total_reads_list.append(reads_for_allele)


### PR DESCRIPTION
# Description

See IDSEQ-2239 and https://github.com/chanzuckerberg/idseq-web/pull/3104.

As a temporary stopgap measure as we move away from using Datadog, relevant alerting log lines will have "[Datadog]" appended to the front, and only those logs will be sent via the Lambda.

# Version
- [x] I have increased the appropriate version number in https://github.com/chanzuckerberg/idseq-dag/blob/master/idseq_dag/__init__.py. Guidelines here: https://github.com/chanzuckerberg/idseq-dag/blob/pr-template/README.md#release-notes
- [x] I have added release notes for my new version to https://github.com/chanzuckerberg/idseq-dag/blob/master/README.md#release-notes

# Tests
- [ ] I have verified in IDseq staging that the pipeline still completes successfully:
    - [ ] for single-end inputs
    - [ ] for paired-end inputs
    - [ ] for FASTQ inputs
    - [ ] for FASTA inputs.
- [ ] I have validated that my change does not introduce any correctness bugs to existing output types.
- [ ] I have validated that my change does not introduce significant performance regressions or I have discussed with the team that the benefits of the change are substantial enough that we're comfortable accepting the size of the measured performance penalty.
