### PR TITLE
 Put cdhitdup clstr file in additional_output_files_visible

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -71,7 +71,8 @@ WORKDIR /tmp
 # For aegea
 RUN apt-get install -y python3-pip cython python3.7-dev
 RUN pip3 install awscli-cwlogs==1.4.0 keymaker==0.2.1 boto3==1.4.3 awscli==1.11.44 dynamoq==0.0.5 tractorbeam==0.1.3
-RUN pip3 install pysam biopython
+# Avoid cython error in 0.15.4
+RUN pip3 install pysam==0.15.3 biopython
 #RUN echo iptables-persistent iptables-persistent/autosave_v4 boolean true | debconf-set-selections
 RUN apt-get update && apt-get install -y iptables-persistent debian-goodies bridge-utils pixz cryptsetup-bin mdadm btrfs-tools libffi-dev libssl-dev libxml2-dev libxslt1-dev libyaml-dev libcurl4-openssl-dev libjemalloc-dev libzip-dev libsnappy-dev liblz4-dev libgmp-dev libmpfr-dev libhts-dev libsqlite3-dev libncurses5-dev htop pydf jq httpie python-dev python-cffi python-pip python-setuptools python-wheel python-virtualenv python-requests python-yaml python3-dev python3-cffi python3-pip python3-setuptools python3-wheel python3-requests python3-yaml nfs-common unzip build-essential cmake libtool autoconf ruby sysstat dstat numactl gdebi-core sqlite3 stunnel moreutils curl wget git aria2 sift
 # Strange that we have to do this, but if we don't, aegea tries to do it, and it fails then with some urllib3 bug.

--- a/Dockerfile
+++ b/Dockerfile
@@ -71,8 +71,7 @@ WORKDIR /tmp
 # For aegea
 RUN apt-get install -y python3-pip cython python3.7-dev
 RUN pip3 install awscli-cwlogs==1.4.0 keymaker==0.2.1 boto3==1.4.3 awscli==1.11.44 dynamoq==0.0.5 tractorbeam==0.1.3
-# Avoid cython error in 0.15.4
-RUN pip3 install pysam==0.15.3 biopython
+RUN pip3 install pysam biopython
 #RUN echo iptables-persistent iptables-persistent/autosave_v4 boolean true | debconf-set-selections
 RUN apt-get update && apt-get install -y iptables-persistent debian-goodies bridge-utils pixz cryptsetup-bin mdadm btrfs-tools libffi-dev libssl-dev libxml2-dev libxslt1-dev libyaml-dev libcurl4-openssl-dev libjemalloc-dev libzip-dev libsnappy-dev liblz4-dev libgmp-dev libmpfr-dev libhts-dev libsqlite3-dev libncurses5-dev htop pydf jq httpie python-dev python-cffi python-pip python-setuptools python-wheel python-virtualenv python-requests python-yaml python3-dev python3-cffi python3-pip python3-setuptools python3-wheel python3-requests python3-yaml nfs-common unzip build-essential cmake libtool autoconf ruby sysstat dstat numactl gdebi-core sqlite3 stunnel moreutils curl wget git aria2 sift
 # Strange that we have to do this, but if we don't, aegea tries to do it, and it fails then with some urllib3 bug.

--- a/README.md
+++ b/README.md
@@ -232,6 +232,9 @@ Version numbers for this repo take the form X.Y.Z.
 - We increase X for a paradigm shift in how the pipeline is conceived. Example: adding a de-novo assembly step and then reassigning hits based on the assembled contigs.
 Changes to X or Y force recomputation of all results when a sample is rerun using idseq-web. Changes to Z do not force recomputation when the sample is rerun - the pipeline will lazily reuse existing outputs in AWS S3.
 
+- 3.19.2
+  - Use additional_output_files_visible
+
 - 3.19.1
   - Upload additional cdhitdup output.
 

--- a/idseq_dag/__init__.py
+++ b/idseq_dag/__init__.py
@@ -1,2 +1,2 @@
 ''' idseq_dag '''
-__version__ = "3.19.1"
+__version__ = "3.19.2"

--- a/idseq_dag/steps/run_cdhitdup.py
+++ b/idseq_dag/steps/run_cdhitdup.py
@@ -67,7 +67,7 @@ class PipelineStepRunCDHitDup(PipelineStep):
         clstr_file = output_fas + '.clstr'  # clusters
         clstr_file2 = output_fas + '2.clstr'  # chimeric clusters
         if os.path.isfile(clstr_file) and os.path.isfile(clstr_file2):
-            self.additional_files_to_upload += [clstr_file, clstr_file2]
+            self.additional_output_files_visible += [clstr_file, clstr_file2]
         else:
             log.write(
                 f"WARNING: Files not found: {clstr_file} and {clstr_file2}")


### PR DESCRIPTION
# Description
Following the refactor by @morsecodist, the clstr file now belongs in `additional_output_files_visible`. 

I also reverted the dockerfile change in https://github.com/chanzuckerberg/idseq-dag/pull/251/files#diff-3254677a7917c6c01f55212f86c57fbfR75 to avoid any prod disruption. 

# Version
- [x] I have increased the appropriate version number in https://github.com/chanzuckerberg/idseq-dag/blob/master/idseq_dag/__init__.py. Guidelines here: https://github.com/chanzuckerberg/idseq-dag/blob/pr-template/README.md#release-notes
- [x] I have added release notes for my new version to https://github.com/chanzuckerberg/idseq-dag/blob/master/README.md#release-notes

# Tests
- [x] I have verified in IDseq staging that the pipeline still completes successfully:
    - [x] for single-end inputs
    - [x] for paired-end inputs
    - [x] for FASTQ inputs
    - [x] for FASTA inputs.
- [x] I have validated that my change does not introduce any correctness bugs to existing output types.
- [x] I have validated that my change does not introduce significant performance regressions or I have discussed with the team that the benefits of the change are substantial enough that we're comfortable accepting the size of the measured performance penalty.
