### PR TITLE
Handle null nucleotide type

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,9 @@ Version numbers for this repo take the form X.Y.Z.
 - We increase X for a paradigm shift in how the pipeline is conceived. Example: adding a de-novo assembly step and then reassigning hits based on the assembled contigs.
 Changes to X or Y force recomputation of all results when a sample is rerun using idseq-web. Changes to Z do not force recomputation when the sample is rerun - the pipeline will lazily reuse existing outputs in AWS S3.
 
+- 3.19.3
+  - Handle case of null nucleotide type for collecting insert metrics
+
 - 3.19.2
   - Use additional_output_files_visible
 

--- a/idseq_dag/__init__.py
+++ b/idseq_dag/__init__.py
@@ -1,2 +1,2 @@
 ''' idseq_dag '''
-__version__ = "3.19.2"
+__version__ = "3.19.3"

--- a/idseq_dag/steps/run_star.py
+++ b/idseq_dag/steps/run_star.py
@@ -124,7 +124,7 @@ class PipelineStepRunStar(PipelineStep):
         self.collect_insert_size_metrics_for = None
         # If we have paired end reads, a human host genome, and metrics output files were requested
         #   try to compute insert size metrics
-        if (not disable_insert_size_metrics) and host_is_human and paired and requested_insert_size_metrics_output:
+        if (not disable_insert_size_metrics) and nucleotide_type and host_is_human and paired and requested_insert_size_metrics_output:
             # Compute for RNA if host genome has an organism specific gtf file
             self.collect_insert_size_metrics_for = nucleotide_type
             # Flag that we need to generate these two files


### PR DESCRIPTION
# Description

Some samples have a null `nucleotide_type` which causes the STAR step to expect to collect insert metrics but they never end up getting generated. I added a check for this case so we won't expect them.

# Version
- [X] I have increased the appropriate version number in https://github.com/chanzuckerberg/idseq-dag/blob/master/idseq_dag/__init__.py. Guidelines here: https://github.com/chanzuckerberg/idseq-dag/blob/pr-template/README.md#release-notes
- [X] I have added release notes for my new version to https://github.com/chanzuckerberg/idseq-dag/blob/master/README.md#release-notes
