### PR TITLE
Insert Metrics Copy Update + Failure Resiliancy

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,7 @@ Changes to X or Y force recomputation of all results when a sample is rerun usin
 
 - 3.19.4
   - Copy change for STAR step
+  - Don't break STAR if picard can't generate metrics
 
 - 3.19.3
   - Handle case of null nucleotide type for collecting insert metrics

--- a/README.md
+++ b/README.md
@@ -232,6 +232,9 @@ Version numbers for this repo take the form X.Y.Z.
 - We increase X for a paradigm shift in how the pipeline is conceived. Example: adding a de-novo assembly step and then reassigning hits based on the assembled contigs.
 Changes to X or Y force recomputation of all results when a sample is rerun using idseq-web. Changes to Z do not force recomputation when the sample is rerun - the pipeline will lazily reuse existing outputs in AWS S3.
 
+- 3.19.4
+  - Copy change for STAR step
+
 - 3.19.3
   - Handle case of null nucleotide type for collecting insert metrics
 

--- a/idseq_dag/__init__.py
+++ b/idseq_dag/__init__.py
@@ -1,2 +1,2 @@
 ''' idseq_dag '''
-__version__ = "3.19.3"
+__version__ = "3.19.4"

--- a/idseq_dag/steps/run_star.py
+++ b/idseq_dag/steps/run_star.py
@@ -210,7 +210,6 @@ class PipelineStepRunStar(PipelineStep):
                     assert(os.path.isfile(bam_path)), \
                         "Expected STAR to generate Aligned.out.bam but it was not found"
                     try:
-                        {}['a']['b']
                         self.collect_insert_size_metrics(tmp, bam_path, self.output_metrics_file, self.output_histogram_file)
                         if os.path.exists(self.output_metrics_file):
                             self.additional_output_files_visible.append(self.output_metrics_file)

--- a/idseq_dag/steps/run_star.py
+++ b/idseq_dag/steps/run_star.py
@@ -324,7 +324,7 @@ class PipelineStepRunStar(PipelineStep):
                 *Host Subtraction*
             """
 
-        description = f"""
+        description += f"""
             The STAR aligner is used for rapid first-pass host filtration.
             Unmapped reads are passed to the subsequent step. The current implementation of STAR,
             will fail to remove host sequences that map to multiple regions, thus these are filtered

--- a/idseq_dag/steps/run_star.py
+++ b/idseq_dag/steps/run_star.py
@@ -209,17 +209,20 @@ class PipelineStepRunStar(PipelineStep):
                     #   something unexpected has gone wrong
                     assert(os.path.isfile(bam_path)), \
                         "Expected STAR to generate Aligned.out.bam but it was not found"
-                    self.collect_insert_size_metrics(tmp, bam_path, self.output_metrics_file, self.output_histogram_file)
-                    if os.path.exists(self.output_metrics_file):
-                        self.additional_output_files_visible.append(self.output_metrics_file)
-                    else:
-                        message = "expected picard to generate a metrics file but none was found"
-                        log.write(message=message, warning=True)
-                    if os.path.exists(self.output_histogram_file):
-                        self.additional_output_files_visible.append(self.output_histogram_file)
-                    else:
-                        message = "expected picard to generate a histogram file but none was found"
-                        log.write(message=message, warning=True)
+                    try:
+                        self.collect_insert_size_metrics(tmp, bam_path, self.output_metrics_file, self.output_histogram_file)
+                        if os.path.exists(self.output_metrics_file):
+                            self.additional_output_files_visible.append(self.output_metrics_file)
+                        else:
+                            message = "expected picard to generate a metrics file but none was found"
+                            log.write(message=message, warning=True)
+                        if os.path.exists(self.output_histogram_file):
+                            self.additional_output_files_visible.append(self.output_histogram_file)
+                        else:
+                            message = "expected picard to generate a histogram file but none was found"
+                            log.write(message=message, warning=True)
+                    except Exception as e:
+                        log.write(message=f"encountered error while running picard: {type(e).__name__}: {e}", warning=True)
 
         # Cleanup
         for src, dst in zip(unmapped, output_files_local):

--- a/idseq_dag/steps/run_star.py
+++ b/idseq_dag/steps/run_star.py
@@ -126,12 +126,7 @@ class PipelineStepRunStar(PipelineStep):
         #   try to compute insert size metrics
         if (not disable_insert_size_metrics) and nucleotide_type and host_is_human and paired and requested_insert_size_metrics_output:
             # Compute for RNA if host genome has an organism specific gtf file
-            self.collect_insert_size_metrics_for = nucleotide_type
-            # Flag that we need to generate these two files
-            if self.output_metrics_file:
-                self.additional_output_files_visible.append(self.output_metrics_file)
-            if self.output_histogram_file:
-                self.additional_output_files_visible.append(self.output_histogram_file)
+            self.collect_insert_size_metrics_for = nucleotide_type                
 
     def run(self):
         """Run STAR to filter out host reads."""
@@ -215,6 +210,8 @@ class PipelineStepRunStar(PipelineStep):
                     assert(os.path.isfile(bam_path)), \
                         "Expected STAR to generate Aligned.out.bam but it was not found"
                     self.collect_insert_size_metrics(tmp, bam_path, self.output_metrics_file, self.output_histogram_file)
+                    self.additional_output_files_visible.append(self.output_metrics_file)
+                    self.additional_output_files_visible.append(self.output_histogram_file)
 
         # Cleanup
         for src, dst in zip(unmapped, output_files_local):
@@ -318,7 +315,6 @@ class PipelineStepRunStar(PipelineStep):
             Implements the step for Host Subtraction.
         """
 
-        # TODO: settle on heading choice
         if self.collect_insert_size_metrics_for:
             description += """
                 **Host Subtraction**
@@ -372,7 +368,6 @@ class PipelineStepRunStar(PipelineStep):
         """
 
         if self.collect_insert_size_metrics_for:
-            # TODO: settle on heading choice
             description += """
                 **Insert Metrics**
 

--- a/idseq_dag/steps/run_star.py
+++ b/idseq_dag/steps/run_star.py
@@ -314,17 +314,17 @@ class PipelineStepRunStar(PipelineStep):
                 --outSAMmode NoQS
                 --quantMode TranscriptomeSAM GeneCounts"""
 
-        description = ""
+        description = """
+            Implements the step for Host Subtraction.
+        """
 
         # TODO: settle on heading choice
         if self.collect_insert_size_metrics_for:
             description += """
-                ##### STAR
+                *Host Subtraction*
             """
 
         description = f"""
-            Implements the step for Host Subtraction.
-
             The STAR aligner is used for rapid first-pass host filtration.
             Unmapped reads are passed to the subsequent step. The current implementation of STAR,
             will fail to remove host sequences that map to multiple regions, thus these are filtered
@@ -374,7 +374,7 @@ class PipelineStepRunStar(PipelineStep):
         if self.collect_insert_size_metrics_for:
             # TODO: settle on heading choice
             description += """
-                ##### Insert Metrics
+                *Insert Metrics*
 
                 This step also computes insert size metrics for Paired End samples from human hosts.
                 These metrics are computed by the Broad Institute's Picard toolkit.

--- a/idseq_dag/steps/run_star.py
+++ b/idseq_dag/steps/run_star.py
@@ -210,6 +210,7 @@ class PipelineStepRunStar(PipelineStep):
                     assert(os.path.isfile(bam_path)), \
                         "Expected STAR to generate Aligned.out.bam but it was not found"
                     try:
+                        {}['a']['b']
                         self.collect_insert_size_metrics(tmp, bam_path, self.output_metrics_file, self.output_histogram_file)
                         if os.path.exists(self.output_metrics_file):
                             self.additional_output_files_visible.append(self.output_metrics_file)

--- a/idseq_dag/steps/run_star.py
+++ b/idseq_dag/steps/run_star.py
@@ -212,8 +212,14 @@ class PipelineStepRunStar(PipelineStep):
                     self.collect_insert_size_metrics(tmp, bam_path, self.output_metrics_file, self.output_histogram_file)
                     if os.path.exists(self.output_metrics_file):
                         self.additional_output_files_visible.append(self.output_metrics_file)
+                    else:
+                        message = "expected picard to generate a metrics file but none was found"
+                        log.write(message=message, warning=True)
                     if os.path.exists(self.output_histogram_file):
                         self.additional_output_files_visible.append(self.output_histogram_file)
+                    else:
+                        message = "expected picard to generate a histogram file but none was found"
+                        log.write(message=message, warning=True)
 
         # Cleanup
         for src, dst in zip(unmapped, output_files_local):

--- a/idseq_dag/steps/run_star.py
+++ b/idseq_dag/steps/run_star.py
@@ -321,7 +321,7 @@ class PipelineStepRunStar(PipelineStep):
         # TODO: settle on heading choice
         if self.collect_insert_size_metrics_for:
             description += """
-                *Host Subtraction*
+                **Host Subtraction**
             """
 
         description += f"""
@@ -374,7 +374,7 @@ class PipelineStepRunStar(PipelineStep):
         if self.collect_insert_size_metrics_for:
             # TODO: settle on heading choice
             description += """
-                *Insert Metrics*
+                **Insert Metrics**
 
                 This step also computes insert size metrics for Paired End samples from human hosts.
                 These metrics are computed by the Broad Institute's Picard toolkit.

--- a/idseq_dag/steps/run_star.py
+++ b/idseq_dag/steps/run_star.py
@@ -210,8 +210,10 @@ class PipelineStepRunStar(PipelineStep):
                     assert(os.path.isfile(bam_path)), \
                         "Expected STAR to generate Aligned.out.bam but it was not found"
                     self.collect_insert_size_metrics(tmp, bam_path, self.output_metrics_file, self.output_histogram_file)
-                    self.additional_output_files_visible.append(self.output_metrics_file)
-                    self.additional_output_files_visible.append(self.output_histogram_file)
+                    if os.path.exists(self.output_metrics_file):
+                        self.additional_output_files_visible.append(self.output_metrics_file)
+                    if os.path.exists(self.output_histogram_file):
+                        self.additional_output_files_visible.append(self.output_histogram_file)
 
         # Cleanup
         for src, dst in zip(unmapped, output_files_local):

--- a/idseq_dag/steps/run_star.py
+++ b/idseq_dag/steps/run_star.py
@@ -126,7 +126,7 @@ class PipelineStepRunStar(PipelineStep):
         #   try to compute insert size metrics
         if (not disable_insert_size_metrics) and nucleotide_type and host_is_human and paired and requested_insert_size_metrics_output:
             # Compute for RNA if host genome has an organism specific gtf file
-            self.collect_insert_size_metrics_for = nucleotide_type                
+            self.collect_insert_size_metrics_for = nucleotide_type
 
     def run(self):
         """Run STAR to filter out host reads."""

--- a/idseq_dag/steps/run_star.py
+++ b/idseq_dag/steps/run_star.py
@@ -314,8 +314,16 @@ class PipelineStepRunStar(PipelineStep):
                 --outSAMmode NoQS
                 --quantMode TranscriptomeSAM GeneCounts"""
 
+        description = ""
+
+        # TODO: settle on heading choice
+        if self.collect_insert_size_metrics_for:
+            description += """
+                ##### STAR
+            """
+
         description = f"""
-            Implements the step for running STAR.
+            Implements the step for Host Subtraction.
 
             The STAR aligner is used for rapid first-pass host filtration.
             Unmapped reads are passed to the subsequent step. The current implementation of STAR,
@@ -364,7 +372,10 @@ class PipelineStepRunStar(PipelineStep):
         """
 
         if self.collect_insert_size_metrics_for:
+            # TODO: settle on heading choice
             description += """
+                ##### Insert Metrics
+
                 This step also computes insert size metrics for Paired End samples from human hosts.
                 These metrics are computed by the Broad Institute's Picard toolkit.
 

--- a/idseq_dag/steps/run_trimmomatic.py
+++ b/idseq_dag/steps/run_trimmomatic.py
@@ -57,7 +57,7 @@ class PipelineStepRunTrimmomatic(PipelineStep):
     CTGTCTCTTATACACATCTCCGAGCCCACGAGAC
     ```
 
-    __note:__ the output reads at this step include full-length reads that have no adapter,
+    Note: The output reads at this step include full-length reads that have no adapter,
     plus reads where the adapter has been identified and lopped off, leaving a shorter read
     (but not shorter than 35nt). In cases where the insert size is small, resulting in adapter
     read-through, R2 will be a direct reverse complement of R1; the "true" parameter enables


### PR DESCRIPTION
# Description

Adds copy changes to the step description for `run_star`. These changes require https://github.com/chanzuckerberg/idseq-web/pull/3133 to see the bold effect though it won't break without this change.

#### Sample Screen Shots:

With insert metrics:

![Selection_036](https://user-images.githubusercontent.com/24242714/75736564-8c4a0880-5ccb-11ea-9d4c-b121ee080ec4.png)
![Selection_037](https://user-images.githubusercontent.com/24242714/75736569-8e13cc00-5ccb-11ea-9d6c-9ca3f7717e08.png)

Without:

![Selection_038](https://user-images.githubusercontent.com/24242714/75736620-bb607a00-5ccb-11ea-80c2-e2d8652433e6.png)
![Selection_039](https://user-images.githubusercontent.com/24242714/75736623-bd2a3d80-5ccb-11ea-8be3-475c36928ca6.png)


@lvreynoso brought to my attention that for some samples picard won't generate metrics files. Previously I had intentionally flagged the files as mandatory if it was determined we would attempt to generate them. In light of some samples failing I think it is too risky to make this assumption. I am now only adding the files as output if we generate them.

# Version
- [X] I have increased the appropriate version number in https://github.com/chanzuckerberg/idseq-dag/blob/master/idseq_dag/__init__.py. Guidelines here: https://github.com/chanzuckerberg/idseq-dag/blob/pr-template/README.md#release-notes
- [X] I have added release notes for my new version to https://github.com/chanzuckerberg/idseq-dag/blob/master/README.md#release-notes

# Tests
- [x] I have verified in IDseq staging that the pipeline still completes successfully:
    - [x] for single-end inputs
    - [x] for paired-end inputs
    - [x] for FASTQ inputs
    - [x] for FASTA inputs.
- [x] I have validated that my change does not introduce any correctness bugs to existing output types.
- [x] I have validated that my change does not introduce significant performance regressions or I have discussed with the team that the benefits of the change are substantial enough that we're comfortable accepting the size of the measured performance penalty.
