### PR TITLE
Removed final instance of optional_files_to_upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,9 @@ Version numbers for this repo take the form X.Y.Z.
 - We increase X for a paradigm shift in how the pipeline is conceived. Example: adding a de-novo assembly step and then reassigning hits based on the assembled contigs.
 Changes to X or Y force recomputation of all results when a sample is rerun using idseq-web. Changes to Z do not force recomputation when the sample is rerun - the pipeline will lazily reuse existing outputs in AWS S3.
 
+- 3.19.6
+  - Finished removal of optional_files_to_upload
+
 - 3.19.5
   - Switch title of STAR description to be above first line of description
 

--- a/idseq_dag/__init__.py
+++ b/idseq_dag/__init__.py
@@ -1,2 +1,2 @@
 ''' idseq_dag '''
-__version__ = "3.19.5"
+__version__ = "3.19.6"

--- a/idseq_dag/steps/generate_phylo_tree.py
+++ b/idseq_dag/steps/generate_phylo_tree.py
@@ -131,7 +131,7 @@ class PipelineStepGeneratePhyloTree(PipelineStep):
             ])
             snps_all_annotated = f"{ksnp_output_dir}/SNPs_all_annotated"
             if os.path.isfile(snps_all_annotated):
-                self.optional_files_to_upload.append(snps_all_annotated)
+                self.additional_output_files_hidden.append(snps_all_annotated)
 
         # Produce VCF file with respect to first reference genome in annotated_genome_input:
         if os.path.isfile(annotated_genome_input):
@@ -157,7 +157,7 @@ class PipelineStepGeneratePhyloTree(PipelineStep):
         # Upload all kSNP3 output files for potential future reference
         supplementary_files = [f for f in glob.glob(f"{ksnp_output_dir}/*")
                                if os.path.isfile(f) and
-                               f not in self.additional_output_files_hidden + self.optional_files_to_upload]
+                               f not in self.additional_output_files_hidden]
         self.additional_output_files_hidden.extend(supplementary_files)
 
     def count_reads(self):


### PR DESCRIPTION
# Description

As a part of standardizing the additional output file, and after some discussion I removed the `optional_files_to_upload` field from `PipelineStep`. It was only used once and now it is the responsibility of the steps to do the check for the file. When I removed this I did a global search for instances and removed them. And I added the file check but for some reason it's still here. I am not sure how that happened. I suspect a bad git merge.

# Version
- [x] I have increased the appropriate version number in https://github.com/chanzuckerberg/idseq-dag/blob/master/idseq_dag/__init__.py. Guidelines here: https://github.com/chanzuckerberg/idseq-dag/blob/pr-template/README.md#release-notes
- [x] I have added release notes for my new version to https://github.com/chanzuckerberg/idseq-dag/blob/master/README.md#release-notes