### PR TITLE
IDSEQ-2336: Lz4 compress more files

### DIFF
--- a/templates/gsnap_index.json
+++ b/templates/gsnap_index.json
@@ -6,6 +6,9 @@
     ],
     "nt_index_tar": [
        "nt_k16.tar"
+    ],
+    "lz4_out": [
+      "nt.lz4",
     ]
   },
   "steps": [
@@ -16,6 +19,14 @@
       "module": "idseq_dag.steps.generate_gsnap_index",
       "additional_files": {},
       "additional_attributes": {"k": 16}
+    },
+    {
+      "in": ["nt_db"],
+      "out": "lz4_out",
+      "class": "PipelineStepGenerateLZ4",
+      "module": "idseq_dag.steps.generate_lz4",
+      "additional_files": {},
+      "additional_attributes": {}
     }
   ],
   "given_targets": {

--- a/templates/gsnap_index.json
+++ b/templates/gsnap_index.json
@@ -6,9 +6,6 @@
     ],
     "nt_index_tar": [
        "nt_k16.tar"
-    ],
-    "lz4_out": [
-      "nt.lz4",
     ]
   },
   "steps": [
@@ -19,14 +16,6 @@
       "module": "idseq_dag.steps.generate_gsnap_index",
       "additional_files": {},
       "additional_attributes": {"k": 16}
-    },
-    {
-      "in": ["nt_db"],
-      "out": "lz4_out",
-      "class": "PipelineStepGenerateLZ4",
-      "module": "idseq_dag.steps.generate_lz4",
-      "additional_files": {},
-      "additional_attributes": {}
     }
   ],
   "given_targets": {

--- a/templates/lineage_db.json
+++ b/templates/lineage_db.json
@@ -5,7 +5,7 @@
       "taxid-lineages.csv.gz"
     ],
     "lineage_db_out": [
-       "taxid-lineages.sqlite3"
+      "taxid-lineages.sqlite3"
     ],
     "lz4_only_input": [
       "taxid-lineages.db",
@@ -14,6 +14,7 @@
     "lz4_out": [
       "taxid-lineages.sqlite3.lz4",
       "taxid-lineages.db.lz4",
+      "deuterostome_taxids.txt.lz4"
     ]
   },
   "steps": [

--- a/templates/lineage_db.json
+++ b/templates/lineage_db.json
@@ -4,8 +4,16 @@
     "lineage_csv_input": [
       "taxid-lineages.csv.gz"
     ],
-    "lineage_db_out": [ 
+    "lineage_db_out": [
        "taxid-lineages.sqlite3"
+    ],
+    "lz4_only_input": [
+      "taxid-lineages.db",
+      "deuterostome_taxids.txt"
+    ],
+    "lz4_out": [
+      "taxid-lineages.sqlite3.lz4",
+      "taxid-lineages.db.lz4",
     ]
   },
   "steps": [
@@ -14,6 +22,14 @@
       "out": "lineage_db_out",
       "class": "PipelineStepGenerateLineageDB",
       "module": "idseq_dag.steps.generate_lineage_db",
+      "additional_files": {},
+      "additional_attributes": {}
+    },
+    {
+      "in": ["lineage_db_out", "lz4_only_input"],
+      "out": "lz4_out",
+      "class": "PipelineStepGenerateLZ4",
+      "module": "idseq_dag.steps.generate_lz4",
       "additional_files": {},
       "additional_attributes": {}
     }

--- a/templates/lineage_db.json
+++ b/templates/lineage_db.json
@@ -38,6 +38,9 @@
   "given_targets": {
     "lineage_csv_input": {
       "s3_dir":  "s3://idseq-database/taxonomy/<NCBI_DATE>", "count_reads": 0
+    },
+    "lz4_only_input": {
+      "s3_dir":  "s3://idseq-database/taxonomy/<NCBI_DATE>"
     }
   }
 }

--- a/templates/rapsearch2_index.json
+++ b/templates/rapsearch2_index.json
@@ -7,6 +7,10 @@
     "nr_index": [
       "nr_rapsearch",
       "nr_rapsearch.info"
+    ],
+    "lz4_out": [
+      "nr_rapsearch.lz4",
+      "nr_rapsearch.info.lz4"
     ]
   },
   "steps": [
@@ -15,6 +19,14 @@
       "out": "nr_index",
       "class": "PipelineStepGenerateRapsearch2Index",
       "module": "idseq_dag.steps.generate_rapsearch2_index",
+      "additional_files": {},
+      "additional_attributes": {}
+    },
+    {
+      "in": ["nr_index"],
+      "out": "lz4_out",
+      "class": "PipelineStepGenerateLZ4",
+      "module": "idseq_dag.steps.generate_lz4",
       "additional_files": {},
       "additional_attributes": {}
     }

--- a/templates/rapsearch2_index.json
+++ b/templates/rapsearch2_index.json
@@ -1,15 +1,11 @@
 {
   "output_dir_s3": "s3://idseq-database/alignment_indexes/<NCBI_DATE>",
   "targets": {
-    "nr_db": [
-      "nr"
-    ],
     "nr_index": [
       "nr_rapsearch",
       "nr_rapsearch.info"
     ],
     "lz4_out": [
-      "nr.lz4",
       "nr_rapsearch.lz4",
       "nr_rapsearch.info.lz4"
     ]
@@ -24,7 +20,7 @@
       "additional_attributes": {}
     },
     {
-      "in": ["nr_db", "nr_index"],
+      "in": ["nr_index"],
       "out": "lz4_out",
       "class": "PipelineStepGenerateLZ4",
       "module": "idseq_dag.steps.generate_lz4",

--- a/templates/rapsearch2_index.json
+++ b/templates/rapsearch2_index.json
@@ -9,6 +9,7 @@
       "nr_rapsearch.info"
     ],
     "lz4_out": [
+      "nr.lz4",
       "nr_rapsearch.lz4",
       "nr_rapsearch.info.lz4"
     ]
@@ -23,7 +24,7 @@
       "additional_attributes": {}
     },
     {
-      "in": ["nr_index"],
+      "in": ["nr_db", "nr_index"],
       "out": "lz4_out",
       "class": "PipelineStepGenerateLZ4",
       "module": "idseq_dag.steps.generate_lz4",

--- a/templates/rapsearch2_index.json
+++ b/templates/rapsearch2_index.json
@@ -1,6 +1,9 @@
 {
   "output_dir_s3": "s3://idseq-database/alignment_indexes/<NCBI_DATE>",
   "targets": {
+    "nr_db": [
+      "nr"
+    ],
     "nr_index": [
       "nr_rapsearch",
       "nr_rapsearch.info"


### PR DESCRIPTION
# Description

This compresses some more files with lz4 so they are robust to corruption in subsequent downloads. `fetch_reference` and `fetch_from_s3` prefers `.lz4` file extensions over others. 

# Notes

* Not changing pipeline version because this is an index generation only update
* The lineage dag is called from https://github.com/chanzuckerberg/idseq-infra/blob/master/terraform/envs/staging/index-lineages/templates/cloud_init.sh.tpl
* @morsecodist this change may be irrelevant given the upgrade to s3parcp. Please advise.

# Tests

* run modified dags
* see expected lz4 output files