### PR TITLE
[DO NOT MERGE] Fixed bug with combine taxon counts that resulted in missing input files

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,9 @@ Version numbers for this repo take the form X.Y.Z.
 - We increase X for a paradigm shift in how the pipeline is conceived. Example: adding a de-novo assembly step and then reassigning hits based on the assembled contigs.
 Changes to X or Y force recomputation of all results when a sample is rerun using idseq-web. Changes to Z do not force recomputation when the sample is rerun - the pipeline will lazily reuse existing outputs in AWS S3.
 
+- 3.21.1
+  - Fix bug with `PipelineStepCombineTaxonCounts` that causes it to not find input files
+
 - 3.21.0
   - work around cdhitdup bug affecting unpaired reads that sometimes discards half the unique reads in an unpaired sample
   - set stage for 4.0 release by changing cdhit identity threshold to 100%

--- a/idseq_dag/__init__.py
+++ b/idseq_dag/__init__.py
@@ -1,2 +1,2 @@
 ''' idseq_dag '''
-__version__ = "3.21.0"
+__version__ = "3.21.1"

--- a/idseq_dag/steps/combine_taxon_counts.py
+++ b/idseq_dag/steps/combine_taxon_counts.py
@@ -1,4 +1,5 @@
 import json
+import os
 from idseq_dag.engine.pipeline_step import PipelineStep
 from idseq_dag.util.count import DAG_SURGERY_HACKS_FOR_READ_COUNTING
 
@@ -18,10 +19,12 @@ class PipelineStepCombineTaxonCounts(PipelineStep):
         with_dcr = all(input_f.endswith("_with_dcr.json") for input_f in input_files)
         if not with_dcr:
             assert DAG_SURGERY_HACKS_FOR_READ_COUNTING
-            input_files = [input_f.replace(".json", "_with_dcr.json") for input_f in input_files]
-            output_file = output_file.replace(".json", "_with_dcr.json")
-            self.combine_counts(input_files, output_file)
-            self.additional_output_files_visible.append(output_file)
+            input_files_with_dcr = [input_f.replace(".json", "_with_dcr.json") for input_f in input_files]
+            for input_f, input_f_with_dcr in zip(input_files, input_files_with_dcr):
+                os.rename(input_f, input_files_with_dcr)
+            output_file_with_dcr = output_file.replace(".json", "_with_dcr.json")
+            self.combine_counts(input_files_with_dcr, output_file_with_dcr)
+            self.additional_output_files_visible.append(output_file_with_dcr)
 
     def count_reads(self):
         pass

--- a/idseq_dag/steps/combine_taxon_counts.py
+++ b/idseq_dag/steps/combine_taxon_counts.py
@@ -21,7 +21,7 @@ class PipelineStepCombineTaxonCounts(PipelineStep):
             assert DAG_SURGERY_HACKS_FOR_READ_COUNTING
             input_files_with_dcr = [input_f.replace(".json", "_with_dcr.json") for input_f in input_files]
             for input_f, input_f_with_dcr in zip(input_files, input_files_with_dcr):
-                os.rename(input_f, input_files_with_dcr)
+                os.rename(input_f, input_f_with_dcr)
             output_file_with_dcr = output_file.replace(".json", "_with_dcr.json")
             self.combine_counts(input_files_with_dcr, output_file_with_dcr)
             self.additional_output_files_visible.append(output_file_with_dcr)


### PR DESCRIPTION
# Description

This step fails, unable to find a file ending in `_with_dcr.json`. There is some backwards compatibility logic that appends this ending to local input files but it does not rename them. This leads to the files not being found. Here I have added a renaming step to this substitution. 

I am not completely sure this was the intent of this logic. @boris-dimitrov please advise.

# Version
- [x] I have increased the appropriate version number in https://github.com/chanzuckerberg/idseq-dag/blob/master/idseq_dag/__init__.py. Guidelines here: https://github.com/chanzuckerberg/idseq-dag/blob/pr-template/README.md#release-notes
- [x] I have added release notes for my new version to https://github.com/chanzuckerberg/idseq-dag/blob/master/README.md#release-notes

# Tests
- [ ] I have verified in IDseq staging that the pipeline still completes successfully:
    - [ ] for single-end inputs
    - [ ] for paired-end inputs
    - [ ] for FASTQ inputs
    - [ ] for FASTA inputs.
- [ ] I have validated that my change does not introduce any correctness bugs to existing output types.
- [ ] I have validated that my change does not introduce significant performance regressions or I have discussed with the team that the benefits of the change are substantial enough that we're comfortable accepting the size of the measured performance penalty.
