### PR TITLE
tolerate assert failures in SPADES assembler

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,12 @@ Version numbers for this repo take the form X.Y.Z.
 - We increase X for a paradigm shift in how the pipeline is conceived. Example: adding a de-novo assembly step and then reassigning hits based on the assembled contigs.
 Changes to X or Y force recomputation of all results when a sample is rerun using idseq-web. Changes to Z do not force recomputation when the sample is rerun - the pipeline will lazily reuse existing outputs in AWS S3.
 
+- 3.21.0
+  - work around cdhitdup bug affecting unpaired reads that sometimes discards half the unique reads in an unpaired sample
+  - set stage for 4.0 release by changing cdhit identity threshold to 100%
+  - emit new files taxon_count_with_dcr.json, cdhit_cluster_sizes.tsv, dedup1.clstr
+  - compute ReadCountingMode.COUNT_ALL but still emit COUNT_UNIQUE
+
 - 3.20.1
   - Update s3parcp
   - Switch uploads to s3parcp

--- a/README.md
+++ b/README.md
@@ -232,6 +232,9 @@ Version numbers for this repo take the form X.Y.Z.
 - We increase X for a paradigm shift in how the pipeline is conceived. Example: adding a de-novo assembly step and then reassigning hits based on the assembled contigs.
 Changes to X or Y force recomputation of all results when a sample is rerun using idseq-web. Changes to Z do not force recomputation when the sample is rerun - the pipeline will lazily reuse existing outputs in AWS S3.
 
+- 3.21.1
+  - bugfix affecting samples where SPADES crashed and we only have read alignment data
+
 - 3.21.0
   - work around cdhitdup bug affecting unpaired reads that sometimes discards half the unique reads in an unpaired sample
   - set stage for 4.0 release by changing cdhit identity threshold to 100%

--- a/idseq_dag/__init__.py
+++ b/idseq_dag/__init__.py
@@ -1,2 +1,2 @@
 ''' idseq_dag '''
-__version__ = "3.20.1"
+__version__ = "3.21.0"

--- a/idseq_dag/__init__.py
+++ b/idseq_dag/__init__.py
@@ -1,2 +1,2 @@
 ''' idseq_dag '''
-__version__ = "3.21.0"
+__version__ = "3.21.1"

--- a/idseq_dag/engine/pipeline_flow.py
+++ b/idseq_dag/engine/pipeline_flow.py
@@ -14,6 +14,7 @@ import idseq_dag.util.log as log
 import idseq_dag.util.count as count
 from idseq_dag.util.trace_lock import TraceLock
 from idseq_dag.engine.pipeline_step import PipelineStep, InvalidInputFileError
+from idseq_dag.util.count import DAG_SURGERY_HACKS_FOR_READ_COUNTING
 
 DEFAULT_OUTPUT_DIR_LOCAL = '/mnt/idseq/results/%d' % os.getpid()
 DEFAULT_REF_DIR_LOCAL = '/mnt/idseq/ref'
@@ -79,6 +80,25 @@ class PipelineFlow(object):
           "given_targets": input files that are given
         '''
         dag = json.loads(open(dag_json).read())
+
+        # hack -- add some targets here to support cd-hit-dup work
+        if DAG_SURGERY_HACKS_FOR_READ_COUNTING:
+            cdhitdup_cluster_sizes_path = "cdhitdup_cluster_sizes.tsv"
+            cdhitdup_cluster_sizes_target = "cdhitdup_cluster_sizes"
+            if dag["name"] in ("postprocess", "non_host_alignment"):
+                if cdhitdup_cluster_sizes_target not in dag["targets"]:
+                    dag["targets"][cdhitdup_cluster_sizes_target] = [
+                        cdhitdup_cluster_sizes_path
+                    ]
+                if cdhitdup_cluster_sizes_target not in dag["given_targets"]:
+                    dag["given_targets"][cdhitdup_cluster_sizes_target] = {
+                        "s3_dir": dag["given_targets"]["host_filter_out"]["s3_dir"]
+                    }
+            if dag["name"] == "host_filter":
+                for fff in ["dedup1.fa.clstr", cdhitdup_cluster_sizes_path]:
+                    if fff not in dag["targets"]["cdhitdup_out"]:
+                        dag["targets"]["cdhitdup_out"].append(fff)
+
         log.log_event("pipeline_flow.dag_json_loaded", values={"file": dag_json, "contents": dag})
         output_dir = dag["output_dir_s3"]  # noqa
         targets = dag["targets"]
@@ -87,6 +107,15 @@ class PipelineFlow(object):
         dag['name'] = dag.get("name", _get_name_from_path(dag_json))
         covered_targets = set()
         for s in steps:
+            if DAG_SURGERY_HACKS_FOR_READ_COUNTING:
+                # hack -- augment post-host-filtering step that need to consume cluster sizes output of cdhitdup (but no other outputs)
+                if s["class"] in ("PipelineStepBlastContigs", "PipelineStepRunAlignmentRemotely", "PipelineStepRunAssembly", "PipelineStepGenerateAnnotatedFasta"):
+                    if cdhitdup_cluster_sizes_target not in s["in"]:
+                        s["in"].append(cdhitdup_cluster_sizes_target)
+                # hack -- host filtering steps consume cdhitdup_out
+                if s["class"] in ("PipelineStepRunLZW", "PipelineStepRunBowtie2", "PipelineStepRunGsnapFilter", "PipelineStepRunSubsample"):
+                    if "cdhitdup_out" not in s["in"]:
+                        s["in"].append("cdhitdup_out")
             # validate each step in/out are valid targets
             for itarget in s["in"]:
                 if itarget not in targets:

--- a/idseq_dag/steps/combine_taxon_counts.py
+++ b/idseq_dag/steps/combine_taxon_counts.py
@@ -1,7 +1,6 @@
 import json
 from idseq_dag.engine.pipeline_step import PipelineStep
-import idseq_dag.util.command as command
-import idseq_dag.util.count as count
+from idseq_dag.util.count import DAG_SURGERY_HACKS_FOR_READ_COUNTING
 
 class PipelineStepCombineTaxonCounts(PipelineStep):
     '''
@@ -13,6 +12,16 @@ class PipelineStepCombineTaxonCounts(PipelineStep):
             input_files.append(target[3])
         output_file = self.output_files_local()[0]
         self.combine_counts(input_files, output_file)
+
+        # TODO:  Remove this hack as soon as the webapp has been updated so that
+        # the regular inputs and outputs of this step are "_with_dcr.json".
+        with_dcr = all(input_f.endswith("_with_dcr.json") for input_f in input_files)
+        if not with_dcr:
+            assert DAG_SURGERY_HACKS_FOR_READ_COUNTING
+            input_files = [input_f.replace(".json", "_with_dcr.json") for input_f in input_files]
+            output_file = output_file.replace(".json", "_with_dcr.json")
+            self.combine_counts(input_files, output_file)
+            self.additional_output_files_visible.append(output_file)
 
     def count_reads(self):
         pass

--- a/idseq_dag/steps/combine_taxon_counts.py
+++ b/idseq_dag/steps/combine_taxon_counts.py
@@ -1,6 +1,8 @@
 import json
+import os
 from idseq_dag.engine.pipeline_step import PipelineStep
 from idseq_dag.util.count import DAG_SURGERY_HACKS_FOR_READ_COUNTING
+import idseq_dag.util.log as log
 
 class PipelineStepCombineTaxonCounts(PipelineStep):
     '''
@@ -20,8 +22,13 @@ class PipelineStepCombineTaxonCounts(PipelineStep):
             assert DAG_SURGERY_HACKS_FOR_READ_COUNTING
             input_files = [input_f.replace(".json", "_with_dcr.json") for input_f in input_files]
             output_file = output_file.replace(".json", "_with_dcr.json")
-            self.combine_counts(input_files, output_file)
-            self.additional_output_files_visible.append(output_file)
+            if all(os.path.isfile(f) for f in input_files):
+                self.combine_counts(input_files, output_file)
+                self.additional_output_files_visible.append(output_file)
+            else:
+                # This is fine -- it means the assembler crashed, so we are not going to emit
+                # these files in pipeline v3;  in pipeline v4 this code path will be gone
+                log.write("Post-assembly combined taxon counts with DCR unavailable because assembler crashed.  See pre-assembly combined count.  This problem will diseappear after idseq-web fix to emit correct DAG json, long before v4.")
 
     def count_reads(self):
         pass

--- a/idseq_dag/steps/generate_annotated_fasta.py
+++ b/idseq_dag/steps/generate_annotated_fasta.py
@@ -1,27 +1,35 @@
-from idseq_dag.engine.pipeline_step import PipelineStep
+from idseq_dag.engine.pipeline_step import PipelineCountingStep
 import idseq_dag.util.command as command
 import idseq_dag.util.command_patterns as command_patterns
-import idseq_dag.util.count as count
 import idseq_dag.util.m8 as m8
 
-class PipelineStepGenerateAnnotatedFasta(PipelineStep):
+class PipelineStepGenerateAnnotatedFasta(PipelineCountingStep):
     '''
     generate annotated fasta
     '''
+    def _annotated_fasta(self):
+        return self.output_files_local()[0]
+
+    def _unidentified_fasta(self):
+        return self.output_files_local()[1]
+
     def run(self):
         ''' annotate fasta '''
         merged_fasta = self.input_files_local[0][-1]
         gsnap_m8 = self.input_files_local[1][1]
         rapsearch2_m8 = self.input_files_local[2][1]
-        annotated_fasta = self.output_files_local()[0]
-        unidentified_fasta = self.output_files_local()[1]
+        annotated_fasta = self._annotated_fasta()
+        unidentified_fasta = self._unidentified_fasta()
         self.annotate_fasta_with_accessions(merged_fasta, gsnap_m8, rapsearch2_m8, annotated_fasta)
         self.generate_unidentified_fasta(annotated_fasta, unidentified_fasta)
 
     def count_reads(self):
-        # count unidenfitied reads
-        self.should_count_reads = True
-        self.counts_dict["unidentified_fasta"] = count.reads_in_group([self.output_files_local()[1]])
+        # The webapp expects this count to be called "unidentified_fasta"
+        super()._count_reads_work(
+            cluster_key=PipelineStepGenerateAnnotatedFasta.old_read_name,
+            counter_name="unidentified_fasta",
+            fasta_files=[self._unidentified_fasta()]
+        )
 
     @staticmethod
     def annotate_fasta_with_accessions(merged_input_fasta, nt_m8, nr_m8, output_fasta):
@@ -42,7 +50,7 @@ class PipelineStepGenerateAnnotatedFasta(PipelineStep):
                 while sequence_name and sequence_data:
                     read_id = sequence_name.rstrip().lstrip('>')
                     # Need to annotate NR then NT in this order for alignment viz
-                    new_read_name = "NR:{nr_accession}:NT:{nt_accession}:{read_id}".format(
+                    new_read_name = "NR:{nr_accession}:NT:{nt_accession}:{read_id}".format(  # Its inverse is old_read_name()
                         nr_accession=nr_map.get(read_id, ''),
                         nt_accession=nt_map.get(read_id, ''),
                         read_id=read_id)
@@ -63,3 +71,9 @@ class PipelineStepGenerateAnnotatedFasta(PipelineStep):
                 ]
             )
         )
+
+    @staticmethod
+    def old_read_name(new_read_name):
+        # Inverse of new_read_name creation above.  Needed to cross-reference to original read_id
+        # in order to identify all duplicate reads for this read_id.
+        return new_read_name.split(":", 4)[-1]

--- a/idseq_dag/steps/generate_coverage_viz.py
+++ b/idseq_dag/steps/generate_coverage_viz.py
@@ -11,6 +11,7 @@ import idseq_dag.util.s3 as s3
 
 from idseq_dag.engine.pipeline_step import PipelineStep
 from idseq_dag.util.dict import IdSeqDictValue, open_file_db_by_extension
+from idseq_dag.util.m8 import MIN_CONTIG_SIZE
 
 # These constants can be overridden with the additional_attributes dict:
 # The maximum number of bins to divide the accession length into when computing coverage.
@@ -19,8 +20,6 @@ MAX_NUM_BINS_COVERAGE = 500
 # For each taxon, we show all accessions with a contig (even if there are more than num_accessions_per_taxon of them).
 # We then add accessions with only reads until we reach num_accessions_per_taxon.
 NUM_ACCESSIONS_PER_TAXON = 10
-# The minimum read count for a valid contig. We ignore contigs below this read count.
-MIN_CONTIG_SIZE = 4
 
 class PipelineStepGenerateCoverageViz(PipelineStep):  # pylint: disable=abstract-method
     """Pipeline step to generate JSON files for coverage viz to

--- a/idseq_dag/steps/prepare_taxon_fasta.py
+++ b/idseq_dag/steps/prepare_taxon_fasta.py
@@ -29,7 +29,7 @@ class PipelineStepPrepareTaxonFasta(PipelineStep):
             partial_fasta_files.append(local_file)
         self.fasta_union(partial_fasta_files, output_file)
         for fasta in partial_fasta_files + [output_file]:
-            print(f"{count.reads(fasta)} reads in {fasta}")
+            print(f"{count.reads(fasta)} unique reads in {fasta}")
 
         # Trim Illumina adapters
         # TODO: consider moving this to the beginning of the main pipeline

--- a/idseq_dag/steps/run_assembly.py
+++ b/idseq_dag/steps/run_assembly.py
@@ -7,6 +7,10 @@ from idseq_dag.engine.pipeline_step import PipelineStep
 import idseq_dag.util.command as command
 import idseq_dag.util.command_patterns as command_patterns
 
+from idseq_dag.util.m8 import MIN_CONTIG_SIZE
+from idseq_dag.util.count import get_read_cluster_size, load_cdhit_cluster_sizes, READ_COUNTING_MODE, ReadCountingMode
+
+
 class PipelineStepRunAssembly(PipelineStep):
     """ To obtain longer contigs for improved sensitivity in mapping, short reads must be
     de novo assembled using SPADES.
@@ -57,17 +61,20 @@ class PipelineStepRunAssembly(PipelineStep):
         if len(self.input_files_local[0]) >= 2:
             input_fasta = self.input_files_local[0][0]
             input_fasta2 = self.input_files_local[0][1]
+        cdhitdup_cluster_sizes_path, = self.input_files_local[1]
+        assert cdhitdup_cluster_sizes_path.endswith(".tsv"), self.input_files_local[1]
 
         assembled_contig, assembled_scaffold, bowtie_sam, contig_stats = self.output_files_local()
         read2contig = {}
         memory = self.additional_attributes.get('memory', 100)
-        self.assemble(input_fasta, input_fasta2, bowtie_fasta, assembled_contig, assembled_scaffold,
+        self.assemble(input_fasta, input_fasta2, bowtie_fasta, cdhitdup_cluster_sizes_path, assembled_contig, assembled_scaffold,
                       bowtie_sam, contig_stats, read2contig, int(memory))
 
     @staticmethod
     def assemble(input_fasta,
                  input_fasta2,
                  bowtie_fasta,  # fasta file for running bowtie against contigs
+                 cdhitdup_cluster_sizes_path,
                  assembled_contig,
                  assembled_scaffold,
                  bowtie_sam,
@@ -121,7 +128,7 @@ class PipelineStepRunAssembly(PipelineStep):
             command.move_file(assembled_scaffold_tmp, assembled_scaffold)
 
             PipelineStepRunAssembly.generate_read_to_contig_mapping(assembled_contig, bowtie_fasta,
-                                                                    read2contig, bowtie_sam, contig_stats)
+                                                                    read2contig, cdhitdup_cluster_sizes_path, bowtie_sam, contig_stats)
         except:
             # Assembly failed. create dummy output files
             command.write_text_to_file(';ASSEMBLY FAILED', assembled_contig)
@@ -135,6 +142,7 @@ class PipelineStepRunAssembly(PipelineStep):
     def generate_read_to_contig_mapping(assembled_contig,
                                         fasta_file,
                                         read2contig,
+                                        cdhitdup_cluster_sizes_path,
                                         output_bowtie_sam,
                                         output_contig_stats):
         ''' read -> contig mapping through bowtie2 alignment '''
@@ -161,13 +169,15 @@ class PipelineStepRunAssembly(PipelineStep):
                 }
             )
         )
-        contig_stats = defaultdict(int)
-        PipelineStepRunAssembly.generate_info_from_sam(output_bowtie_sam, read2contig, contig_stats)
+        contig_stats = PipelineStepRunAssembly.generate_info_from_sam(output_bowtie_sam, read2contig, cdhitdup_cluster_sizes_path)
         with open(output_contig_stats, 'w') as ocf:
             json.dump(contig_stats, ocf)
 
     @staticmethod
-    def generate_info_from_sam(bowtie_sam_file, read2contig, contig_stats):
+    def generate_info_from_sam(bowtie_sam_file, read2contig, cdhitdup_cluster_sizes_path):
+        contig_stats = defaultdict(int)
+        contig_unique_counts = defaultdict(int)
+        cdhit_cluster_sizes = load_cdhit_cluster_sizes(cdhitdup_cluster_sizes_path)
         with open(bowtie_sam_file, "r", encoding='utf-8') as samf:
             for line in samf:
                 if line[0] == '@':
@@ -175,9 +185,16 @@ class PipelineStepRunAssembly(PipelineStep):
                 fields = line.split("\t")
                 read = fields[0]
                 contig = fields[2]
-                contig_stats[contig] += 1
+                contig_stats[contig] += get_read_cluster_size(cdhit_cluster_sizes, read)  # these are non-unique read counts now
+                contig_unique_counts[contig] += 1
                 if contig != '*':
                     read2contig[read] = contig
+        for contig, unique_count in contig_unique_counts.items():  # TODO can't we just filter those out after spades, IN ONE PLACE
+            if unique_count < MIN_CONTIG_SIZE:
+                del contig_stats[contig]
+            elif READ_COUNTING_MODE == ReadCountingMode.COUNT_UNIQUE:
+                contig_stats[contig] = unique_count
+        return contig_stats
 
     def count_reads(self):
         ''' count reads '''

--- a/idseq_dag/steps/run_bowtie2.py
+++ b/idseq_dag/steps/run_bowtie2.py
@@ -1,6 +1,6 @@
 import os
 import multiprocessing
-from idseq_dag.engine.pipeline_step import PipelineStep, InputFileErrors
+from idseq_dag.engine.pipeline_step import PipelineCountingStep, InputFileErrors
 import idseq_dag.util.command as command
 import idseq_dag.util.command_patterns as command_patterns
 import idseq_dag.util.count as count
@@ -9,7 +9,7 @@ import idseq_dag.util.log as log
 from idseq_dag.util.s3 import fetch_reference
 
 
-class PipelineStepRunBowtie2(PipelineStep):
+class PipelineStepRunBowtie2(PipelineCountingStep):
     """ Removes remaining host reads.
 
     While STAR provides an initial, rapid removal of host sequences,
@@ -33,12 +33,16 @@ class PipelineStepRunBowtie2(PipelineStep):
     If the input is single-end the `-U [input R, if not paired]` argument is used instead of `-1` and `-2`.
     Bowtie2 documentation can be found [here](http://bowtie-bio.sourceforge.net/bowtie2/manual.shtml#the-bowtie2-aligner)
     """
+
+    def input_fas(self):
+        return self.input_files_local[0][0:2]
+
     def validate_input_files(self):
-        if not count.files_have_min_reads(self.input_files_local[0][0:2], 1):
+        if not count.files_have_min_reads(self.input_fas(), 1):
             self.input_file_error = InputFileErrors.INSUFFICIENT_READS
 
     def run(self):
-        input_fas = self.input_files_local[0][0:2]
+        input_fas = self.input_fas()
         output_fas = self.output_files_local()
         genome_dir = fetch_reference(
             self.additional_files["bowtie2_genome"],
@@ -91,8 +95,3 @@ class PipelineStepRunBowtie2(PipelineStep):
         else:
             convert.generate_unmapped_singles_from_sam(output_sam_file,
                                                        output_fas[0])
-
-    def count_reads(self):
-        self.should_count_reads = True
-        self.counts_dict[self.name] = count.reads_in_group(
-            self.output_files_local()[0:2])

--- a/idseq_dag/steps/run_cdhitdup.py
+++ b/idseq_dag/steps/run_cdhitdup.py
@@ -1,38 +1,40 @@
-import os
-
 import idseq_dag.util.command as command
 import idseq_dag.util.command_patterns as command_patterns
 import idseq_dag.util.count as count
-import idseq_dag.util.log as log
+import idseq_dag.util.fasta as fasta
 
 from idseq_dag.engine.pipeline_step import InputFileErrors, PipelineStep
+from idseq_dag.util.count import save_cdhit_cluster_sizes, DAG_SURGERY_HACKS_FOR_READ_COUNTING
 
 
-class PipelineStepRunCDHitDup(PipelineStep):
+class PipelineStepRunCDHitDup(PipelineStep):  # Deliberately not PipelineCountingStep
     """ Removes duplicate reads.
 
     ```
     cd-hit-dup
     -i {input_fasta}
     -o {output_fasta}
-    -e 0.05
+    -e 0.0
     -u 70
     ```
 
-    Per the CDHit Documentation, available [here](https://github.com/weizhongli/cdhit/wiki),
-    this command uses a 0.05 threshold for the number of mismatches - indicating that if
-    two reads are > 95% similar they will be considered duplicates. It uses only the
-    first/last 70 bases of each read to do the analysis on sequence similarity.
+    Require exact match (-e 0.0) on first 70 nucleotides (-u 70) to deem fragments identical.
+    Only 70, because sequencer errors increase toward the end of a read.  For an illustration
+    of this effect, look [here](https://insilicoseq.readthedocs.io/en/latest/iss/model.html).
 
-    cd-hit-dup will output three or four files. Two of them are the same as the
-    output files of CD-HIT: one (named exactly the same as the file name
-    specified by the “-o” option) is the cluster (or duplicate) representatives,
-    the other is the clustering file (xxx.clstr) relating each duplicate to its
-    representative. For paired end reads, another file by the “-o2” option is
-    the cluster representatives for R2 reads. The last file (xxx2.clstr)
-    contains the chimeric clusters. In this file, the description for each
-    chimeric cluster contains cluster ids of its parent clusters from the
-    clustering file xxx.clstr.
+    Per the CDHit Documentation, available [here](https://github.com/weizhongli/cdhit/wiki/3.-User's-Guide#cdhitdup),
+    the cd-hit-dup command above will output two or three non-empty files.  The first output is named exactly as
+    directed via the “-o” option, and contains all cluster (or duplicate) representatives.
+    The second output with extension “.clstr” relates each duplicate read ID to its
+    distinct representative.  For paired end reads, a third output named by the “-o2” option
+    lists the cluster representatives for R2 reads.
+
+    (If the “-f” option were to be specified, a second ”.clstr” file would show
+    all chimeric reads;  but that output is empty when “-f” is absent.)
+
+    This step also outputs a TSV file mapping each cluster representative
+    to its cluster size, which is useful when converting counts of clusters
+    to counts of original fragments.
     """
 
     def validate_input_files(self):
@@ -42,32 +44,135 @@ class PipelineStepRunCDHitDup(PipelineStep):
     def run(self):
         ''' Invoking cd-hit-dup '''
         input_fas = self.input_files_local[0]
-        output_fas = self.output_files_local()
+
+        output_files = self.output_files_local()
+        assert len(output_files) == len(input_fas) + 2, f"Context: {input_fas} -> {output_files}."
+        output_fas = output_files[:len(input_fas)]
+        cdhit_cluster_sizes_path = output_files[-1]
+        assert cdhit_cluster_sizes_path.endswith(".tsv"), str(output_files)
+        cdhit_clusters_path = output_files[-2]
+        assert cdhit_clusters_path.endswith(".clstr"), str(output_files)
+
+        # See docstring above for explanation of these options.
         cdhitdup_params = [
             '-i', input_fas[0], '-o', output_fas[0],
-            '-e', '0.05', '-u', '70'
+            '-e', '0.0', '-u', '70'
         ]
         if len(input_fas) == 2:
             cdhitdup_params += ['-i2', input_fas[1], '-o2', output_fas[1]]
+        else:
+            # This is a workaround for a cdhitdup bug with unpaired end reads.  Basically
+            # it doesn't work with unpaired reads.  It emits the correct number of reads,
+            # but not the cluster representatives --- instead emits multiple reads from some
+            # clusters, and no reads at all for other clusters.  To work around this issue
+            # we simply run cdhitdup with a second input argument that is identical to the
+            # first, and place the second output in a dummy.  Note that cdhit actually will
+            # segfault if you give it /dev/null for the second output file.
+            # TODO: Run "cmp dedup1.fa ignore_me_please.fa" each time as a sanity check.
+            cdhitdup_params += ['-i2', input_fas[0], '-o2', "ignore_me_please.fa"]
         command.execute(
             command_patterns.SingleCommand(
                 cmd='cd-hit-dup',
                 args=cdhitdup_params
             )
         )
-        self._add_clstr_files()
+        PipelineStepRunCDHitDup._emit_cluster_sizes(cdhit_cluster_sizes_path, cdhit_clusters_path, output_fas[0])
+
+        # TODO: When the matching idseq-web request is deployed, remove this line, because those would
+        # then become bona-fide outputs of the step and thus would not need to be added here.
+        if DAG_SURGERY_HACKS_FOR_READ_COUNTING:
+            self.additional_output_files_visible.extend([cdhit_clusters_path, cdhit_cluster_sizes_path])
+
+    @staticmethod
+    def _emit_cluster_sizes(cdhit_cluster_sizes_path, cdhit_clusters_path, deduped_fasta_path):
+        # Emit cluster sizes.  One line per cluster.  Format "<cluster_size> <cluster_read_id>".
+        # This info is loaded in multiple subsequent steps using m8.load_cdhit_cluster_sizes,
+        # and used to convert unique read counts to original read counts, and also to compute
+        # per-taxon DCRs emitted alongside taxon_counts.
+
+        # First identify the cluster representative reads emitted by cd-hit-dup.  Originally we
+        # used the ".clstr" output of cd-hit-dup for this, but turns out that for unpaired reads
+        # the actual deduped output of cdhit contains different representatives.
+        cluster_sizes_dict = {}
+        for read in fasta.iterator(deduped_fasta_path):
+            # A read header looks someting like
+            #
+            #    >M05295:357:000000000-CRPNR:1:1101:22051:10534 OPTIONAL RANDOM STUFF"
+            #     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+            #
+            # where the first character on the line is '>' and the read ID (underlined above)
+            # extends from '>' to the first whitespace character, not including '>' itself.
+            #
+            # The fasta iterator already asserts that read.header[0] is '>'.
+            #
+            read_id = read.header.split(None, 1)[0][1:]
+            cluster_sizes_dict[read_id] = None  # not yet known
+
+        def record_cluster_size(cluster_size, emitted_reads_from_cluster, line_number, _read_id):
+            assert emitted_reads_from_cluster, f"If this assertion fails, CD-HIT-DUP has forgotten to emit a read for this cluster.  In that case, just use the current read_id as cluster_representative.  Everything will work fine, aside from reduced sensitivity. {line_number}"
+            assert len(emitted_reads_from_cluster) == 1, f"If this assertion fails, CD-HIT-DUP has emitted multiple reads from the same cluster.  Feel free to comment out this assertion if that happens a lot in practice.  Everything will run fine, but read counts contributed by that cluster will be exaggerated.  If you want to fix that, make the cluster sizes a float --- divide the actual cluster size by the number of reads emitted for the cluster, i.e. by len(emitted_reads_from_cluster). Probably an even better way of fixing it would be to emit your own fasta based on the .clstr file if that's reliable, or use a tool other than cdhit that doesn't have this bug.  {line_number}: {emitted_reads_from_cluster}"
+            cluster_representative = emitted_reads_from_cluster.pop()
+            assert cluster_representative in cluster_sizes_dict, "If this fails it's our bug here."
+            cluster_sizes_dict[cluster_representative] = cluster_size
+
+        # Example input lines that form a cluster:
+        #
+        #    "0       140nt, >M05295:357:000000000-CRPNR:1:2119:16143:8253... *"
+        #    "1       140nt, >M05295:357:000000000-CRPNR:1:1101:22051:10534... at 1:140:1:140/+/100.00%"
+        #    "2       140nt, >M05295:357:000000000-CRPNR:1:1102:15401:7483... at 1:140:1:140/+/100.00%"
+        #    ...
+        #    "2334    140nt, >M05295:357:000000000-CRPNR:1:1102:13405:3483... at 1:140:1:140/+/100.00%"
+        #
+        # Corresponding output line for that cluster:
+        #
+        #    "2335    140nt, >M05295:357:000000000-CRPNR:1:2119:16143:8253"
+        #
+        # Please note that "..." above does not indicate truncation. CD-HIT-DUP appends "..." to the read
+        # IDs even if the read IDs have not been truncated.
+        #
+        # Per CD-HIT-DUP docs, when a "-d" argument is not specified, each read ID is obtained by
+        # splitting the corresponding FASTA line on whitespace and taking the first item.  That is also
+        # how we do it throughout this pipeline.  The code below assumes (and relies upon) the read IDs
+        # being free from whitespace.
+        #
+        # Furthremore, we expect read IDs to be unique in a sequencing run.  Violating that assumption,
+        # if it does not break cdhit itself, might produce slightly bogus numbers, because of how it
+        # affects subsampling and per-read DCR correction.  Preserving this uniqueness is why we do not
+        # specify a "-d" flag to cdhit, and allow it thus to use the entire read id.
+        #
+        # Further note that, although CD-HIT-DUP documentation states the read marked with '*' is the
+        # one chosen as representative, we have found, particularly with unpaired fasta, the emitted
+        # deduplicated read is not the one marked with '*'.  Hence we handle that case correctly below,
+        # and put a lot of assertions to make sure problems with cdhit output are detected.
+        with open(cdhit_clusters_path, "r") as clusters_file:
+            emitted_reads_from_cluster = set()  # set of reads in both dedup1.fa and current cluster; cardinality 1!
+            cluster_size = 0
+            read_id = None
+            line_number = 0
+            for line in clusters_file:
+                line_number += 1
+                if line.startswith(">"):
+                    continue
+                parts = line.strip().split()
+                serial = int(parts[0])
+                assert parts[2][0] == ">", line
+                assert parts[2].endswith("..."), line
+                if serial == 0 and cluster_size > 0:
+                    # We've just encountered the first read of a new cluster.  Emit all data held for the old cluster.
+                    record_cluster_size(cluster_size, emitted_reads_from_cluster, line_number, read_id)
+                    emitted_reads_from_cluster = set()
+                    cluster_size = 0
+                assert cluster_size == serial, f"{line_number}: {cluster_size}, {serial}, {line}"
+                read_id = parts[2][1:-3]
+                cluster_size += 1
+                if read_id in cluster_sizes_dict:
+                    emitted_reads_from_cluster.add(read_id)
+            if cluster_size > 0:
+                record_cluster_size(cluster_size, emitted_reads_from_cluster, line_number, read_id)
+
+        save_cdhit_cluster_sizes(cdhit_cluster_sizes_path, cluster_sizes_dict)
 
     def count_reads(self):
         self.should_count_reads = True
-        self.counts_dict[self.name] = count.reads_in_group(
-            self.output_files_local()[0:2])
-
-    def _add_clstr_files(self):
-        output_fas = self.output_files_local()[0]
-        clstr_file = output_fas + '.clstr'  # clusters
-        clstr_file2 = output_fas + '2.clstr'  # chimeric clusters
-        if os.path.isfile(clstr_file) and os.path.isfile(clstr_file2):
-            self.additional_output_files_visible += [clstr_file, clstr_file2]
-        else:
-            log.write(
-                f"WARNING: Files not found: {clstr_file} and {clstr_file2}")
+        # Here we intentionally count unique reads.
+        self.counts_dict[self.name] = count.reads_in_group(self.output_files_local()[:-2])  # last two outputs are not fastas

--- a/idseq_dag/steps/run_gsnap_filter.py
+++ b/idseq_dag/steps/run_gsnap_filter.py
@@ -1,5 +1,5 @@
 import os
-from idseq_dag.engine.pipeline_step import PipelineStep, InputFileErrors
+from idseq_dag.engine.pipeline_step import PipelineCountingStep, InputFileErrors
 import idseq_dag.util.command as command
 import idseq_dag.util.command_patterns as command_patterns
 import idseq_dag.util.convert as convert
@@ -8,7 +8,7 @@ import idseq_dag.util.count as count
 from idseq_dag.util.s3 import fetch_reference
 
 
-class PipelineStepRunGsnapFilter(PipelineStep):
+class PipelineStepRunGsnapFilter(PipelineCountingStep):
     """ Regardless of specified “host” organism, it is essential to remove all potentially-human
     sequences for privacy reasons. Thus, a final GSNAP alignment is performed against the human
     genome for samples from all host types.
@@ -34,12 +34,15 @@ class PipelineStepRunGsnapFilter(PipelineStep):
     """
     # Two input FASTAs means paired reads.
 
+    def input_fas(self):
+        return self.input_files_local[0][0:2]
+
     def validate_input_files(self):
-        if not count.files_have_min_reads(self.input_files_local[0][0:2], 1):
+        if not count.files_have_min_reads(self.input_fas(), 1):
             self.input_file_error = InputFileErrors.INSUFFICIENT_READS
 
     def run(self):
-        input_fas = self.input_files_local[0][0:2]
+        input_fas = self.input_fas()
         output_fas = self.output_files_local()
         output_sam_file = os.path.join(self.output_dir_local,
                                        self.additional_attributes["output_sam_file"])
@@ -74,7 +77,3 @@ class PipelineStepRunGsnapFilter(PipelineStep):
         else:
             convert.generate_unmapped_singles_from_sam(
                 output_sam_file, output_fas[0])
-
-    def count_reads(self):
-        self.should_count_reads = True
-        self.counts_dict[self.name] = count.reads_in_group(self.output_files_local()[0:2])

--- a/idseq_dag/steps/run_subsample.py
+++ b/idseq_dag/steps/run_subsample.py
@@ -1,12 +1,12 @@
 import random
 
-from idseq_dag.engine.pipeline_step import PipelineStep, InputFileErrors
+from idseq_dag.engine.pipeline_step import PipelineCountingStep, InputFileErrors
 import idseq_dag.util.command as command
 import idseq_dag.util.command_patterns as command_patterns
 import idseq_dag.util.log as log
 import idseq_dag.util.count as count
 
-class PipelineStepRunSubsample(PipelineStep):
+class PipelineStepRunSubsample(PipelineCountingStep):
     """
     Randomly subsample 1 million fragments.
 
@@ -17,27 +17,29 @@ class PipelineStepRunSubsample(PipelineStep):
     1 million total fragments (1 million single-end reads or 2 million paired-end reads).
     """
 
+    def input_fas(self):
+        return self.input_files_local[0]
+
     def validate_input_files(self):
-        if not count.files_have_min_reads(self.input_files_local[0][0:2], 1):
+        if not count.files_have_min_reads(self.input_fas(), 1):
             self.input_file_error = InputFileErrors.INSUFFICIENT_READS
 
     def run(self):
         ''' Invoking subsampling '''
-        input_fas = self.input_files_local[0]
+        input_fas = self.input_fas()
         output_fas = self.output_files_local()
         max_fragments = self.additional_attributes["max_fragments"]
         PipelineStepRunSubsample.subsample_fastas(input_fas, output_fas, max_fragments)
 
     def count_reads(self):
-        self.should_count_reads = True
+        # First count the unique reads, to determine if subsampling has occurred.
         files_to_count = self.output_files_local()[0:2]
-        read_count = count.reads_in_group(files_to_count)
-        self.counts_dict[self.name] = read_count
-        # If the read count is exactly equal to the maximum allowed number,
-        # infer that subsampling occurred:
-        max_read_count = len(files_to_count) * self.additional_attributes["max_fragments"]
-        if read_count == max_read_count:
+        unique_read_count = count.reads_in_group(files_to_count)
+        max_unique_read_count = len(files_to_count) * self.additional_attributes["max_fragments"]
+        if unique_read_count == max_unique_read_count:
             self.counts_dict["subsampled"] = 1
+        # Then count non-unique reads as required for the step.
+        return super().count_reads()
 
     @staticmethod
     def subsample_fastas(input_fas, output_fas, max_fragments):

--- a/idseq_dag/util/count.py
+++ b/idseq_dag/util/count.py
@@ -1,18 +1,27 @@
+import multiprocessing
+
+from enum import Enum
+
 import idseq_dag.util.command as command
 import idseq_dag.util.command_patterns as command_patterns
+import idseq_dag.util.fasta as fasta
+from idseq_dag import __version__
 
-def reads_in_group(file_group, max_fragments=None):
-    '''
-    Count reads in a group of matching files, up to a maximum number of fragments.
-    The term "fragment" refers to the physical DNA fragments the reads derive from.
-    If the input is single, then 1 fragment == 1 read.
-    If the input is paired, then 1 fragment == 2 reads.
-    '''
-    num_files = len(file_group)
-    reads_in_first_file = reads(file_group[0], max_fragments)
-    return num_files * reads_in_first_file
+class ReadCountingMode(Enum):
+    COUNT_UNIQUE = "COUNT UNIQUE READS"
+    COUNT_ALL = "COUNT ALL READS"
 
-def reads(local_file_path, max_reads=None):
+
+# Feel free to delete the support for COUNT_UNIQUE after pipeline 4.0 has been released and well accepted.
+PIPELINE_MAJOR_VERSION = int(__version__.split(".", 1)[0])
+READ_COUNTING_MODE = ReadCountingMode.COUNT_ALL if PIPELINE_MAJOR_VERSION >= 4 else ReadCountingMode.COUNT_UNIQUE
+
+# Change this to False and delete all code guarded by it, after the
+# webapp change to emit the correct DAG has been deployed.  This is
+# part of the deployment process for ReadCountingMode.
+DAG_SURGERY_HACKS_FOR_READ_COUNTING = True
+
+def _count_reads_via_wc(local_file_path, max_reads):
     '''
     Count reads in a local file based on file format inferred from extension,
     up to a maximum of max_reads.
@@ -29,7 +38,7 @@ def reads(local_file_path, max_reads=None):
     }
 
     if max_reads:
-        max_lines = reads2lines(max_reads, file_format)
+        max_lines = _reads2lines(max_reads, file_format)
         assert max_lines is not None, "Could not convert max_reads to max_lines"
         cmd += r''' | head -n "${max_lines}"'''
         named_args.update({
@@ -45,9 +54,9 @@ def reads(local_file_path, max_reads=None):
         )
     )
     line_count = int(cmd_output.strip().split(' ')[0])
-    return lines2reads(line_count, file_format)
+    return _lines2reads(line_count, file_format)
 
-def lines2reads(line_count, file_format):
+def _lines2reads(line_count, file_format):
     '''
     Convert line count to read count based on file format.
     Supports fastq and SINGLE-LINE fasta formats.
@@ -70,7 +79,7 @@ def lines2reads(line_count, file_format):
         read_count = line_count
     return read_count
 
-def reads2lines(read_count, file_format):
+def _reads2lines(read_count, file_format):
     '''
     Convert read count to line count based on file format.
     Currently supports fastq or SINGLE-LINE fasta.
@@ -88,7 +97,151 @@ def files_have_min_reads(input_files, min_reads):
     Pipeline steps can use this method for input validation.
     """
     for input_file in input_files:
-        num_reads = reads(input_file, max_reads=min_reads)
+        num_reads = _count_reads_via_wc(input_file, max_reads=min_reads)
         if num_reads < min_reads:
             return False
     return True
+
+def _count_reads_expanding_duplicates(local_file_path, cluster_sizes, cluster_key):
+    # See documentation for reads_in_group use case with cluster_sizes, below.
+    unique_count, nonunique_count = 0, 0
+    for read in fasta.iterator(local_file_path):
+        # A read header looks someting like
+        #
+        #    >M05295:357:000000000-CRPNR:1:1101:22051:10534 OPTIONAL RANDOM STUFF"
+        #     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+        #
+        # where the first character on the line is '>' and the read ID (underlined above)
+        # extends from '>' to the first whitespace character, not including '>' itself.
+        #
+        # The fasta iterator already asserts that read.header[0] is '>'.
+        #
+        # As we proceed down along the pipeline, read IDs get annotated with taxonomic information,
+        # changing the above into something like
+        #
+        #   >NT:ABC2433.1:NR:ABC5656.2:M05295:357:000000000-CRPNR:1:1101:22051:10534 OPTIONAL RANDOM STUFF"
+        #    ^^^^^^^^^^^^^^^^^^^^^^^^^^
+        #
+        # The underlined annotation has to be stripped out by the cluster_key function,
+        # so that we can use the original read ID to look up the cluster size.
+        #
+        read_id = read.header.split(None, 1)[0][1:]
+        unique_count += 1
+        nonunique_count += get_read_cluster_size(cluster_sizes, cluster_key(read_id))
+    return unique_count, nonunique_count
+
+def get_read_cluster_size(cdhit_cluster_sizes, read_id):
+    suffix = None
+    cluster_size = cdhit_cluster_sizes.get(read_id)
+    if cluster_size == None:
+        prefix, suffix = read_id[:-2], read_id[-2:]
+        cluster_size = cdhit_cluster_sizes.get(prefix)
+    assert cluster_size != None and suffix in (None, "/1", "/2"), f"Read ID not found in cdhit_cluster_sizes dict: {read_id}"
+    return cluster_size
+
+def _load_cdhit_cluster_sizes_work(filename):
+    cdhit_cluster_sizes = {}
+    with open(filename, "r") as f:
+        for line in f:
+            cluster_size_str, read_id = line.split(None, 1)
+            cdhit_cluster_sizes[read_id.strip()] = int(cluster_size_str)
+    return cdhit_cluster_sizes
+
+
+# Loading cluster sizes can be expensive prior to subsampling (for some exceptionally large
+# samples with over 100 million reads).  To ameliorate this cost, we make sure it is only
+# paid once per stage (not once per step).
+_CDHIT_CLUSTER_SIZES_CACHE = {}
+_CDHIT_CLUSTER_SIZES_LOCK = multiprocessing.RLock()
+
+def load_cdhit_cluster_sizes(filename):
+    with _CDHIT_CLUSTER_SIZES_LOCK:
+        if filename not in _CDHIT_CLUSTER_SIZES_CACHE:
+            _CDHIT_CLUSTER_SIZES_CACHE[filename] = _load_cdhit_cluster_sizes_work(filename)
+        return _CDHIT_CLUSTER_SIZES_CACHE[filename]
+
+def save_cdhit_cluster_sizes(filename, cdhit_cluster_sizes):
+    with _CDHIT_CLUSTER_SIZES_LOCK:
+        _CDHIT_CLUSTER_SIZES_CACHE[filename] = cdhit_cluster_sizes
+    with open(filename, "w") as tsv:
+        for read_id, cluster_size in cdhit_cluster_sizes.items():
+            assert cluster_size != None, f"If this happened, probably dedup1.fa output of cdhit contains reads that are not mentioned in dedup1.fa.clstr.  Perhaps set cluster_size=1 for those reads but also follow up with cdhit.  Read id: {read_id}"
+            tsv.write(f"{cluster_size}\t{read_id}\n")
+
+def reads(local_file_path):
+    '''
+    Count reads in given FASTA or FASTQ file.
+    Implemented via wc, so very fast.
+    '''
+    return _count_reads_via_wc(local_file_path, max_reads=None)
+
+def reads_in_group(file_group, max_fragments=None, cluster_sizes=None, cluster_key=None):
+    '''
+    OVERVIEW
+
+    Count reads in a group of matching files, up to a maximum number of fragments,
+    optionally expanding each fragment to its cdhit cluster size.  Inputs in
+    FASTA and FASTQ format are supported, subject to restrictions below.
+
+    DEFINITIONS
+
+    The term "fragment" refers to the physical DNA fragments the reads derive from.
+    If the input is single, then 1 fragment == 1 read.
+    If the input is paired, then 1 fragment == 2 reads.
+
+    The term "cluster" refers to the output of the pipeline step cd-hit-dup, which
+    identifies and groups together duplicate fragments into clusters.  Duplicates
+    typically result from PCR or other amplificaiton.  It is cost effective for the
+    pipeline to operate on a single representative fragment from each cluster, then
+    infer back the original fragment count using the cluster sizes information
+    emitted by the cd-hit-dup step.  The caller should load that information via
+    m8.load_cluster_sizes() before passing it to this function.
+
+    RESTRICTIONS
+
+    When cluster_sizes is specified, the input must be in FASTA format, and the max_reads
+    argument must be unspecified (None).  Thus, the caller should choose between two
+    distinct use cases:
+
+       (*) Expand clusters when counting FASTA fragments.
+
+       (*) Count FASTA or FASTQ fragments without expanding clusters,
+           optionally truncating to max_fragments.  The input may
+           even be gz compressed.
+
+    PERFORMANCE
+
+    When cluster_sizes is not specified, the implementation is very fast, via wc.
+
+    When cluster_sizes is specified, the python implementation can process only about
+    3-4 million reads per minute. Fortunately, only steps run_lzw and run_bowtie2 can
+    have more than a million fragments, and even that is extremely unlikely (deeply
+    sequenced microbiome samples are rare in idseq at this time).  All other steps either
+    operate on at most 1 million fragments or do not specify cluster_sizes. If this
+    performance ever becomes a concern, the relevant private function can be reimplemented
+    easily in GO.
+
+    INTERFACE
+
+    It may be better to expose the two use cases as separate functions, so that users do
+    not encounter surprising restrictions or performance differences.  However, that would
+    fracture the documentation, obfuscate points of use, and cement a separation that is
+    quite arbitrary and forced only by current implementation choices.  Instead, keeping it
+    all in one would allow a future reimplementation in a more performant language that
+    could lift all restrictions and make all code paths performant.  The choice, then, is
+    this better future, and just fail an assert where the present falls short.
+    '''
+    assert None in (max_fragments, cluster_sizes), "Truncating to max_fragments is not supported at the same time as expanding cluster_sizes.  Consider setting max_fragments=None."
+    assert (cluster_sizes == None) == (cluster_key == None), "Please specify cluster_key when using cluster_sizes."
+    first_file = file_group[0]
+    unique_fast = _count_reads_via_wc(first_file, max_fragments)  # This is so fast, just do it always as a sanity check.
+    if cluster_sizes:
+        # Run this even if ReadCountingMode.COUNT_UNIQUE to get it well tested before release.  Dark launch.
+        unique, nonunique = _count_reads_expanding_duplicates(first_file, cluster_sizes, cluster_key)
+        assert unique_fast == unique, f"Different read counts from wc ({unique_fast}) and fasta.iterator ({unique}) for file {first_file}."
+        assert unique <= nonunique, f"Unique count ({unique}) should not exceed nonunique count ({nonunique}) for file {first_file}."
+    reads_in_first_file = unique_fast
+    if cluster_sizes and READ_COUNTING_MODE == ReadCountingMode.COUNT_ALL:
+        reads_in_first_file = nonunique
+    num_files = len(file_group)
+    return num_files * reads_in_first_file

--- a/idseq_dag/util/fasta.py
+++ b/idseq_dag/util/fasta.py
@@ -31,7 +31,7 @@ def synchronized_iterator(fasta_files: List[str]) -> Iterator[Tuple[Read, ...]]:
     unpaired or paired-end reads."""
     return zip(*map(iterator, fasta_files))
 
-def count_reads(fasta_files: List[str]) -> int:
+def _count_reads(fasta_files: List[str]) -> int:
     return sum(1 for _ in synchronized_iterator(fasta_files))
 
 def input_file_type(input_file):
@@ -72,4 +72,4 @@ def multilinefa2singlelinefa(input_fasta, output_fasta):
 
 if __name__ == "__main__":
     # Count reads.  Run with fasta filenames as args.  Just for testing.
-    print(count_reads(sys.argv[1:]))
+    print(_count_reads(sys.argv[1:]))


### PR DESCRIPTION
Evidently SPADES is expected to crash for some samples (usually samples with too few reads --- it fails an assert), and we normally deal with this by copying the read alignment taxon counts produced in the non-host-alignment stage. 

This will continue to happen for the normal non-DCR taxon counts, which are the ones shown on the report page in the webapp.  However, for now, we will not combine the DCR counts here if the assembler crashed.  The combining of those files will start happening naturally again, as soon as we've deployed the idseq-web PR that emits the correct DAG json.  Hopefully with the next scheduled idseq-web deployment.

Users who really want the new DCR counts in this transitional period, for samples where the assembler crashed, could find them in the outputs of the non-host-alignment stage, which continue to be available via the pipeline viz.  