### PR TITLE
Apply deuterostome_db, taxon_whitelist, taxon_blacklist, human filter to contigs

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,9 @@ Changes to X or Y force recomputation of all results when a sample is rerun usin
 
 When releasing a new version, please add a Git tag of the form `vX.Y.Z`.
 
+- 4.2.0
+ - Apply deuterostome, blacklist, whitelist and human filters to contigs.
+
 - 4.1.1
   - Removed `DAG_SURGERY_HACKS_FOR_READ_COUNTING` and related code.
 

--- a/idseq_dag/__init__.py
+++ b/idseq_dag/__init__.py
@@ -1,2 +1,2 @@
 ''' idseq_dag '''
-__version__ = "4.1.1"
+__version__ = "4.2.0"

--- a/idseq_dag/util/m8.py
+++ b/idseq_dag/util/m8.py
@@ -76,7 +76,8 @@ def parse_tsv(path, schema, expect_headers=False, raw_lines=False):
             try:
                 row = raw_line.rstrip("\n").split("\t")
                 assert len(row) == len(schema)
-                row_dict = {cname: ctype(vstr) for vstr, (cname, ctype) in zip(row, schema_items)}
+                row_dict = {cname: ctype(vstr) for vstr,
+                            (cname, ctype) in zip(row, schema_items)}
             except:
                 msg = f"{path}:{line_number + 1}:  Parse error.  Input does not conform to schema: {schema}"
                 log.write(msg, warning=True)
@@ -95,9 +96,11 @@ def unparse_tsv(path, schema, rows_generator):
 
 
 def log_corrupt(m8_file, line):
-    msg = m8_file + " is corrupt at line:\n" + line + "\n----> delete it and its corrupt ancestors before restarting run"
+    msg = m8_file + " is corrupt at line:\n" + line + \
+        "\n----> delete it and its corrupt ancestors before restarting run"
     log.write(msg)
     return msg
+
 
 def summarize_hits(hit_summary_file, min_reads_per_genus=0):
     ''' Parse the hit summary file from alignment and get the relevant into'''
@@ -115,7 +118,8 @@ def summarize_hits(hit_summary_file, min_reads_per_genus=0):
             total_reads += 1
             if accession_id == 'None' or accession_id == "":
                 continue
-            accession_dict[accession_id] = (species_taxid, genus_taxid, family_taxid)
+            accession_dict[accession_id] = (
+                species_taxid, genus_taxid, family_taxid)
             if int(genus_taxid) > 0:
                 genus_read_counts[genus_taxid] += 1
                 genus_species[genus_taxid].add(species_taxid)
@@ -209,11 +213,13 @@ def iterate_m8(m8_file, min_alignment_length=0, debug_caller=None, logging_inter
             line_count, m8_file, debug_caller)
         log.write(msg)
 
+
 def read_file_into_set(file_name):
     with open(file_name, 'r') as f:
         S = set(x.rstrip() for x in f)
         S.discard('')
     return S
+
 
 @command.run_in_subprocess
 def call_hits_m8(input_m8, lineage_map_path, accession2taxid_dict_path,
@@ -282,6 +288,7 @@ def call_hits_m8(input_m8, lineage_map_path, accession2taxid_dict_path,
         _call_hits_m8_work(input_m8, lineage_map, accession2taxid_dict,
                            output_m8, output_summary, min_alignment_length)
 
+
 def _call_hits_m8_work(input_m8, lineage_map, accession2taxid_dict,
                        output_m8, output_summary, min_alignment_length):
     lineage_cache = {}
@@ -312,7 +319,8 @@ def _call_hits_m8_work(input_m8, lineage_map, accession2taxid_dict,
                 # provided by other accessions. This occurs a lot and
                 # handling it in this way seems to work well.
                 continue
-            accession_list = hits[level].get(taxid_at_level, []) + [accession_id]
+            accession_list = hits[level].get(
+                taxid_at_level, []) + [accession_id]
             hits[level][taxid_at_level] = accession_list
 
     def most_frequent_accession(accession_list):
@@ -343,7 +351,8 @@ def _call_hits_m8_work(input_m8, lineage_map, accession2taxid_dict,
             selected_taxid = taxid_candidates[0]
             if len(taxid_candidates) > 1:
                 selected_taxid = random.sample(taxid_candidates, 1)[0]
-            accession_id = most_frequent_accession(species_level_hits[selected_taxid])
+            accession_id = most_frequent_accession(
+                species_level_hits[selected_taxid])
             return 1, selected_taxid, accession_id
         return -1, "-1", None
 
@@ -417,7 +426,8 @@ def _call_hits_m8_work(input_m8, lineage_map, accession2taxid_dict,
                     genus_taxid = -1
                     family_taxid = -1
                     if best_accession_id != None:
-                        (species_taxid, genus_taxid, family_taxid) = get_lineage(best_accession_id)
+                        (species_taxid, genus_taxid, family_taxid) = get_lineage(
+                            best_accession_id)
 
                     msg = f"{read_id}\t{hit_level}\t{taxid}\t{best_accession_id}"
                     msg += f"\t{species_taxid}\t{genus_taxid}\t{family_taxid}\n"
@@ -434,7 +444,8 @@ def generate_taxon_count_json_from_m8(
 
     cdhit_cluster_sizes = load_cdhit_cluster_sizes(cdhit_cluster_sizes_path)
 
-    should_keep = build_should_keep_filter(deuterostome_path, taxon_whitelist_path, taxon_blacklist_path)
+    should_keep = build_should_keep_filter(
+        deuterostome_path, taxon_whitelist_path, taxon_blacklist_path)
     # Setup
     aggregation = {}
     with open(hit_level_file, 'r', encoding='utf-8') as hit_f, \
@@ -493,7 +504,8 @@ def generate_taxon_count_json_from_m8(
 
                 # Retrieve the taxon lineage and mark meaningless calls with fake
                 # taxids.
-                hit_taxids_all_levels = lineage_map.get(hit_taxid, lineage.NULL_LINEAGE)
+                hit_taxids_all_levels = lineage_map.get(
+                    hit_taxid, lineage.NULL_LINEAGE)
                 cleaned_hit_taxids_all_levels = lineage.validate_taxid_lineage(
                     hit_taxids_all_levels, hit_taxid, hit_level)
                 assert num_ranks == len(cleaned_hit_taxids_all_levels)
@@ -512,7 +524,8 @@ def generate_taxon_count_json_from_m8(
                                 'sum_e_value': 0.0
                             }
                             aggregation[agg_key] = agg_bucket
-                        agg_bucket['nonunique_count'] += get_read_cluster_size(cdhit_cluster_sizes, read_id)
+                        agg_bucket['nonunique_count'] += get_read_cluster_size(
+                            cdhit_cluster_sizes, read_id)
                         agg_bucket['unique_count'] += 1
                         agg_bucket['sum_percent_identity'] += percent_identity
                         agg_bucket['sum_alignment_length'] += alignment_length
@@ -569,15 +582,20 @@ def generate_taxon_count_json_from_m8(
             }
         }
 
-    with log.log_context("generate_taxon_count_json_from_m8", {"substep": "json_dump", "output_json_file": output_json_file}):
+    with log.log_context(
+        "generate_taxon_count_json_from_m8",
+        {"substep": "json_dump", "output_json_file": output_json_file}
+    ):
         with open(output_json_file, 'w') as outf:
             json.dump(output_dict, outf)
             outf.flush()
 
+
 def build_should_keep_filter(
     deuterostome_path,
     taxon_whitelist_path,
-    taxon_blacklist_path):
+    taxon_blacklist_path
+):
 
     # See also HOMO_SAPIENS_TAX_IDS in idseq-web
     taxids_to_remove = set('9605', '9606')

--- a/idseq_dag/util/m8.py
+++ b/idseq_dag/util/m8.py
@@ -598,7 +598,7 @@ def build_should_keep_filter(
 ):
 
     # See also HOMO_SAPIENS_TAX_IDS in idseq-web
-    taxids_to_remove = set('9605', '9606')
+    taxids_to_remove = set(['9605', '9606'])
 
     if taxon_blacklist_path:
         with log.log_context("generate_taxon_count_json_from_m8", {"substep": "read_blacklist_into_set"}):

--- a/idseq_dag/util/m8.py
+++ b/idseq_dag/util/m8.py
@@ -579,7 +579,8 @@ def build_should_keep_filter(
     taxon_whitelist_path,
     taxon_blacklist_path):
 
-    taxids_to_remove = set()
+    # See also HOMO_SAPIENS_TAX_IDS in idseq-web
+    taxids_to_remove = set('9605', '9606')
 
     if taxon_blacklist_path:
         with log.log_context("generate_taxon_count_json_from_m8", {"substep": "read_blacklist_into_set"}):

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -4,9 +4,10 @@
 # Version
 - [ ] I have increased the appropriate version number in https://github.com/chanzuckerberg/idseq-dag/blob/master/idseq_dag/__init__.py. Guidelines here: https://github.com/chanzuckerberg/idseq-dag/blob/pr-template/README.md#release-notes
 - [ ] I have added release notes for my new version to https://github.com/chanzuckerberg/idseq-dag/blob/master/README.md#release-notes
+- [ ] I will push a git tag after merging in the form `vX.Y.Z`
 
 # Tests
-- [ ] I have verified in IDseq staging that the pipeline still completes successfully:
+- [ ] I have verified that the pipeline still completes successfully:
     - [ ] for single-end inputs
     - [ ] for paired-end inputs
     - [ ] for FASTQ inputs


### PR DESCRIPTION
# Description

This covers IDSEQ-2379, IDSEQ-2389 and maybe even some of IDSEQ-2372. 

It makes contigs filtered the same way taxon counts are. **Except**: the human filter is new for both contigs and taxon counts at this point in the pipeline. 

Because we have had human-aligned reads slipping into both taxon counts and contigs tables, I think it's best to filter them out here in the same way. 

# Version
- [x] I have increased the appropriate version number in https://github.com/chanzuckerberg/idseq-dag/blob/master/idseq_dag/__init__.py. Guidelines here: https://github.com/chanzuckerberg/idseq-dag/blob/pr-template/README.md#release-notes
- [x] I have added release notes for my new version to https://github.com/chanzuckerberg/idseq-dag/blob/master/README.md#release-notes

# Tests

I confirmed that a blacklist taxid 1579933 was filtered out. 

I confirmed that the metadata taxid was filtered out
* contigs summary download

And no taxid shown in fasta headers of
* non-host contig download
* bulk DL of non-host contig download


- [ ] I have verified in IDseq local that the pipeline still completes successfully:
    - [ ] for single-end inputs
    - [x] for paired-end inputs
    - [x] for FASTQ inputs
    - [ ] for FASTA inputs.
- [x] I have validated that my change does not introduce any correctness bugs to existing output types.
- [ ] I have validated that my change does not introduce significant performance regressions or I have discussed with the team that the benefits of the change are substantial enough that we're comfortable accepting the size of the measured performance penalty.

# Notes

I also opportunistically updated the PR template to keep with #273 
