### PR TITLE
Use temp db in call_hits_m8 to avoid OOM

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,9 @@ Changes to X or Y force recomputation of all results when a sample is rerun usin
 
 When releasing a new version, please add a Git tag of the form `vX.Y.Z`.
 
+- 4.2.1
+ - Use temp db in call_hits_m8 to avoid OOM
+
 - 4.2.0
  - Apply deuterostome, blacklist, whitelist and human filters to contigs.
 

--- a/idseq_dag/__init__.py
+++ b/idseq_dag/__init__.py
@@ -1,2 +1,2 @@
 ''' idseq_dag '''
-__version__ = "4.2.0"
+__version__ = "4.2.1"

--- a/idseq_dag/util/dict.py
+++ b/idseq_dag/util/dict.py
@@ -8,6 +8,7 @@ import tempfile
 from enum import IntEnum
 
 import idseq_dag.util.log as log
+import idseq_dag.util.s3 as s3
 
 DICT_DELIMITER = chr(1)  # Delimiter for an array of values
 
@@ -220,9 +221,10 @@ def open_file_db_by_extension(db_path, value_type=IdSeqDictValue.VALUE_TYPE_SCAL
 
 def open_file_db_temp():
     """
-    Creates a new BDB for temporary storage. NOTE: writeback=True, so you
-    need to call sync() to save.
+    Creates a new BDB for temporary storage. The file will go in the local ref
+    dir set by PipelineFlow if available to maximize space.
+    NOTE: writeback=True, so you need to call sync() to save.
     """
-    fd, filename = tempfile.mkstemp(suffix='.db')
+    fd, filename = tempfile.mkstemp(suffix='.db', dir=s3.config.get("REF_DIR"))
     os.close(fd)  # don't need file descriptor
     return shelve.open(filename, 'n', writeback=True)

--- a/idseq_dag/util/m8.py
+++ b/idseq_dag/util/m8.py
@@ -235,7 +235,7 @@ def read_file_into_set(file_name):
     return S
 
 
-# @command.run_in_subprocess
+@command.run_in_subprocess
 def call_hits_m8(input_m8, lineage_map_path, accession2taxid_dict_path,
                  output_m8, output_summary, min_alignment_length):
     """
@@ -297,7 +297,7 @@ def call_hits_m8(input_m8, lineage_map_path, accession2taxid_dict_path,
         * http://www.metagenomics.wiki/tools/blast/blastn-output-format-6
         * http://www.metagenomics.wiki/tools/blast/evalue
     """
-    with open_file_db_by_extension(lineage_map_path) as lineage_map, \
+    with open_file_db_by_extension(lineage_map_path, IdSeqDictValue.VALUE_TYPE_ARRAY) as lineage_map, \
          open_file_db_by_extension(accession2taxid_dict_path) as accession2taxid_dict:  # noqa
         _call_hits_m8_work(input_m8, lineage_map, accession2taxid_dict,
                            output_m8, output_summary, min_alignment_length)
@@ -462,7 +462,7 @@ def _call_hits_m8_work(input_m8, lineage_map, accession2taxid_dict,
                     outf_sum.write(msg)
 
 
-# @command.run_in_subprocess
+@command.run_in_subprocess
 def generate_taxon_count_json_from_m8(
         m8_file, hit_level_file, e_value_type, count_type, lineage_map_path,
         deuterostome_path, taxon_whitelist_path, taxon_blacklist_path,

--- a/idseq_dag/util/m8.py
+++ b/idseq_dag/util/m8.py
@@ -416,10 +416,6 @@ def _call_hits_m8_work(input_m8, lineage_map, accession2taxid_dict,
     log.write("Summarized hits for all {} read ids from {}.".format(
         count, input_m8))
 
-    if use_temp_db:
-        m8.clear()  # free space
-        _safe_sync(m8)
-
     # Generate output files. outf is the main output_m8 file and outf_sum is
     # the summary level info.
     emitted = set()
@@ -463,10 +459,6 @@ def _call_hits_m8_work(input_m8, lineage_map, accession2taxid_dict,
                     msg = f"{read_id}\t{hit_level}\t{taxid}\t{best_accession_id}"
                     msg += f"\t{species_taxid}\t{genus_taxid}\t{family_taxid}\n"
                     outf_sum.write(msg)
-
-    if use_temp_db:
-        summary.clear()  # free space
-        _safe_sync(summary)
 
 
 @command.run_in_subprocess

--- a/idseq_dag/util/m8.py
+++ b/idseq_dag/util/m8.py
@@ -416,6 +416,10 @@ def _call_hits_m8_work(input_m8, lineage_map, accession2taxid_dict,
     log.write("Summarized hits for all {} read ids from {}.".format(
         count, input_m8))
 
+    if use_temp_db:
+        m8.clear()  # free space
+        _safe_sync(m8)
+
     # Generate output files. outf is the main output_m8 file and outf_sum is
     # the summary level info.
     emitted = set()
@@ -459,6 +463,10 @@ def _call_hits_m8_work(input_m8, lineage_map, accession2taxid_dict,
                     msg = f"{read_id}\t{hit_level}\t{taxid}\t{best_accession_id}"
                     msg += f"\t{species_taxid}\t{genus_taxid}\t{family_taxid}\n"
                     outf_sum.write(msg)
+
+    if use_temp_db:
+        summary.clear()  # free space
+        _safe_sync(summary)
 
 
 @command.run_in_subprocess
@@ -659,10 +667,11 @@ def build_should_keep_filter(
     return should_keep
 
 
-def _safe_sync(db, line_count):
+def _safe_sync(db, line_count=0):
     try:
         db.sync()
     except Exception as e:
         log.write("Error in sync of temp db: {}. Trying once more.".format(e), warning=True)
         db.sync()
-    log.write("Wrote entries up to line {} to temp db.".format(line_count))
+    if line_count:
+        log.write("Wrote entries up to line {} to temp db.".format(line_count))


### PR DESCRIPTION
# Description

This is motivated by a bunch of OOM errors when we ran the pipeline without subsampling on large fastq inputs. A quick inspection of the code and the log output showed that the `call_hits_m8` ran out of memory in updating two dicts, `m8` and `summary`. 

This PR limits the memory growth of those two dicts by substituting shelve DB instances which are API compatible with dicts. Effectively, the dicts are stored on disk instead of in memory. Writes to disk are minimized by writing only at given intervals. I confirmed memory use is constant. See below.

## Before

```
INFO:idseq_dag.util.log:Scanned 5000 m8 lines from gsnap.m8 for call_hits_m8_initial_scan, and going.
INFO:idseq_dag.util.log:Size of m8 in memory: 4712.
INFO:idseq_dag.util.log:Scanned 10000 m8 lines from gsnap.m8 for call_hits_m8_initial_scan, and going.
INFO:idseq_dag.util.log:Size of m8 in memory: 9328.
INFO:idseq_dag.util.log:Scanned all 13763 m8 lines from gsnap.m8 for call_hits_m8_initial_scan.
INFO:idseq_dag.util.log:Starting to summarize hits for 287 read ids from gsnap.m8.
INFO:idseq_dag.util.log:Summarized hits for 100 read ids from gsnap.m8, and counting. Size in memory: 4712.
INFO:idseq_dag.util.log:Summarized hits for 200 read ids from gsnap.m8, and counting. Size in memory: 9328.
INFO:idseq_dag.util.log:Summarized hits for all 287 read ids from gsnap.m8.
INFO:idseq_dag.util.log:Scanned 5000 m8 lines from gsnap.m8 for call_hits_m8_emit_deduped_and_summarized_hits, and going.
INFO:idseq_dag.util.log:Scanned 10000 m8 lines from gsnap.m8 for call_hits_m8_emit_deduped_and_summarized_hits, and going.
INFO:idseq_dag.util.log:Scanned all 13763 m8 lines from gsnap.m8 for call_hits_m8_emit_deduped_and_summarized_hits.
[Finished in 0.3s]
```

## After

```
INFO:idseq_dag.util.log:Scanned 5000 m8 lines from gsnap.m8 for call_hits_m8_initial_scan, and going.
INFO:idseq_dag.util.log:Temp db: True. Size of m8 in memory: 64.
INFO:idseq_dag.util.log:Wrote 5000 entries to temp db.
INFO:idseq_dag.util.log:Scanned 10000 m8 lines from gsnap.m8 for call_hits_m8_initial_scan, and going.
INFO:idseq_dag.util.log:Temp db: True. Size of m8 in memory: 64.
INFO:idseq_dag.util.log:Wrote 10000 entries to temp db.
INFO:idseq_dag.util.log:Scanned all 13763 m8 lines from gsnap.m8 for call_hits_m8_initial_scan.
INFO:idseq_dag.util.log:Starting to summarize hits for 287 read ids from gsnap.m8.
INFO:idseq_dag.util.log:Summarized hits for 100 read ids from gsnap.m8, and counting. Temp db: True. Size in memory: 64.
INFO:idseq_dag.util.log:Wrote 100 entries to temp db.
INFO:idseq_dag.util.log:Summarized hits for 200 read ids from gsnap.m8, and counting. Temp db: True. Size in memory: 64.
INFO:idseq_dag.util.log:Wrote 200 entries to temp db.
INFO:idseq_dag.util.log:Summarized hits for all 287 read ids from gsnap.m8.
INFO:idseq_dag.util.log:Scanned 5000 m8 lines from gsnap.m8 for call_hits_m8_emit_deduped_and_summarized_hits, and going.
INFO:idseq_dag.util.log:Scanned 10000 m8 lines from gsnap.m8 for call_hits_m8_emit_deduped_and_summarized_hits, and going.
INFO:idseq_dag.util.log:Scanned all 13763 m8 lines from gsnap.m8 for call_hits_m8_emit_deduped_and_summarized_hits.
[Finished in 0.5s]
```

I kept the same interval that was used for log output, which implies 25 writes and 12,500 writes at the observed limit of 625000000 entries over the duration. Please advise on any better way of tuning!

# Version
- [x] I have increased the appropriate version number in https://github.com/chanzuckerberg/idseq-dag/blob/master/idseq_dag/__init__.py. Guidelines here: https://github.com/chanzuckerberg/idseq-dag/blob/pr-template/README.md#release-notes
- [x] I have added release notes for my new version to https://github.com/chanzuckerberg/idseq-dag/blob/master/README.md#release-notes
- [x] I will push a git tag after merging in the form `vX.Y.Z`

# Tests

Testing with these settings
![image](https://user-images.githubusercontent.com/28797/78460530-6c18bb00-7676-11ea-9ab3-b0c642003356.png)

Compared to another branch where `use_temp_db=False`.

- [x] I have verified that the pipeline still completes successfully:
    - [ ] for single-end inputs
    - [x] for paired-end inputs
    - [ ] for FASTQ inputs
    - [ ] for FASTA inputs.
- [x] I have validated that my change does not introduce any correctness bugs to existing output types.
- [ ] I have validated that my change does not introduce significant performance regressions or I have discussed with the team that the benefits of the change are substantial enough that we're comfortable accepting the size of the measured performance penalty.

# Notes

* I got a strange error on a test run. The `sync` call seems to have failed after working in previous calls in one gsnap_out thread. 

![image](https://user-images.githubusercontent.com/28797/78467260-87f47f00-76bf-11ea-87e6-b5873a5c41e0.png)

* I'm seeing another error, out of disk space, so I added `clear()` call to the dbs. Next idea would be to use the local reference dir instead of the default tmp dir. 
![image](https://user-images.githubusercontent.com/28797/78468328-d7d94300-76cb-11ea-99d8-c0ac7e19d307.png)
