### PR TITLE
 IDSEQ-2600: fastqs for coronavirus

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,16 @@ When releasing a new version, please add a Git tag of the form `vX.Y.Z`.
 - 4.3.0
   - Generate betacoronavirus fastq files for user download if use_taxon_whitelist is specified in the DAG.
 
+- 4.2.4
+  - Update RunAlignmentRemotely to name batch jobs with the chunk id, project id, and sample id
+  - Update RunAlignmentRemotely to download results using boto3 rather than fetch_from_s3
+
+- 4.2.3
+  - Validate input step now properly rejects invalid gzip files.
+
+- 4.2.2
+  - Fix bug in phylo tree creation for organisms with an unknown superkingdom.
+
 - 4.2.1
   - Switch RunAlignmentRemotely to distribute alignment chunks use AWS Batch instead of custom Autoscaling Group Logic logic
 

--- a/README.md
+++ b/README.md
@@ -226,21 +226,14 @@ Changes to X or Y force recomputation of all results when a sample is rerun usin
 
 When releasing a new version, please add a Git tag of the form `vX.Y.Z`.
 
-- 4.2.4
-  - Update RunAlignmentRemotely to name batch jobs with the chunk id, project id, and sample id
-  - Update RunAlignmentRemotely to download results using boto3 rather than fetch_from_s3
-
-- 4.2.3
-  - Validate input step now properly rejects invalid gzip files.
-
-- 4.2.2
-  - Fix bug in phylo tree creation for organisms with an unknown superkingdom.
+- 4.3.0
+  - Generate betacoronavirus fastq files for user download if use_taxon_whitelist is specified in the DAG.
 
 - 4.2.1
   - Switch RunAlignmentRemotely to distribute alignment chunks use AWS Batch instead of custom Autoscaling Group Logic logic
 
 - 4.2.0
- - Apply deuterostome, blacklist, whitelist and human filters to contigs.
+  - Apply deuterostome, blacklist, whitelist and human filters to contigs.
 
 - 4.1.1
   - Removed `DAG_SURGERY_HACKS_FOR_READ_COUNTING` and related code.

--- a/examples/nonhost_fastq.json
+++ b/examples/nonhost_fastq.json
@@ -1,10 +1,12 @@
+// TODO: update all these values to a run of mine in staging that has cdhit_cluster_sizes
 {
   "name": "nonhost_fastq",
   "output_dir_s3": "s3://idseq-samples-development/markazhang/samples_12216/expt_test",
   "targets": {
     "fastqs": ["RR004_water_2_S23_R1_001.fastq", "RR004_water_2_S23_R2_001.fastq"],
     "nonhost_fasta": ["refined_taxid_annot.fasta"],
-    "nonhost_fastq_out": ["nonhost_R1.fastq", "nonhost_R2.fastq"]
+    "nonhost_fastq_out": ["nonhost_R1.fastq", "nonhost_R2.fastq"],
+    "cdhit_cluster_sizes": ["cdhit_cluster_sizes.tsv"]
   },
   "steps": [
     {
@@ -22,6 +24,9 @@
     },
     "nonhost_fasta": {
       "s3_dir": "s3://idseq-samples-staging/samples/234/12216/postprocess/3.3/assembly"
+    },
+    "cdhit_cluster_sizes": {
+      "s3://idseq-samples-staging/samples/234/12216/results/3.3"
     }
   }
 }

--- a/examples/nonhost_fastq.json
+++ b/examples/nonhost_fastq.json
@@ -15,7 +15,9 @@
       "class": "PipelineStepNonhostFastq",
       "module": "idseq_dag.steps.nonhost_fastq",
       "additional_files": {},
-      "additional_attributes": {}
+      "additional_attributes": {
+        "use_taxon_whitelist": true
+      }
     }
   ],
   "given_targets": {

--- a/examples/nonhost_fastq.json
+++ b/examples/nonhost_fastq.json
@@ -1,16 +1,16 @@
-// TODO: update all these values to a run of mine in staging that has cdhit_cluster_sizes
 {
   "name": "nonhost_fastq",
-  "output_dir_s3": "s3://idseq-samples-development/markazhang/samples_12216/expt_test",
+  "output_dir_s3": "s3://idseq-samples-development/gdingle/nonhost_fasta",
   "targets": {
-    "fastqs": ["RR004_water_2_S23_R1_001.fastq", "RR004_water_2_S23_R2_001.fastq"],
+    "fastqs": ["RR004_water_2_S23A_R1_001.fastq", "RR004_water_2_S23A_R2_001.fastq"],
     "nonhost_fasta": ["refined_taxid_annot.fasta"],
     "nonhost_fastq_out": ["nonhost_R1.fastq", "nonhost_R2.fastq"],
-    "cdhit_cluster_sizes": ["cdhit_cluster_sizes.tsv"]
+    "cdhitdup_clusters": ["dedup1.fa.clstr"],
+    "deduped_fasta": ["dedup1.fa"]
   },
   "steps": [
     {
-      "in": ["fastqs", "nonhost_fasta"],
+      "in": ["fastqs", "nonhost_fasta", "cdhitdup_clusters", "deduped_fasta"],
       "out": "nonhost_fastq_out",
       "class": "PipelineStepNonhostFastq",
       "module": "idseq_dag.steps.nonhost_fastq",
@@ -20,13 +20,16 @@
   ],
   "given_targets": {
     "fastqs": {
-      "s3_dir": "s3://idseq-samples-staging/samples/234/12216/fastqs"
+      "s3_dir": "s3://idseq-samples-prod/samples/833/45285/fastqs"
     },
     "nonhost_fasta": {
-      "s3_dir": "s3://idseq-samples-staging/samples/234/12216/postprocess/3.3/assembly"
+      "s3_dir": "s3://idseq-samples-prod/samples/833/45285/postprocess/4.0/assembly"
     },
-    "cdhit_cluster_sizes": {
-      "s3://idseq-samples-staging/samples/234/12216/results/3.3"
+    "cdhitdup_clusters": {
+      "s3_dir": "s3://idseq-samples-prod/samples/833/45285/results/4.0"
+    },
+    "deduped_fasta": {
+      "s3_dir": "s3://idseq-samples-prod/samples/833/45285/results/4.0"
     }
   }
 }

--- a/idseq_dag/__init__.py
+++ b/idseq_dag/__init__.py
@@ -1,2 +1,2 @@
 ''' idseq_dag '''
-__version__ = "4.2.4"
+__version__ = "4.3.0"

--- a/idseq_dag/steps/nonhost_fastq.py
+++ b/idseq_dag/steps/nonhost_fastq.py
@@ -43,7 +43,8 @@ class PipelineStepNonhostFastq(PipelineStep):
         nonhost_fasta = self.input_files_local[1][0]
 
         clusters_dict = None
-        if READ_COUNTING_MODE == ReadCountingMode.COUNT_ALL:  # v4 and higher
+        if READ_COUNTING_MODE == ReadCountingMode.COUNT_ALL \
+                and self.additional_attributes.get("use_taxon_whitelist"):
             # NOTE: this will load the set of all original read headers, which
             # could be several GBs in the worst case.
             clusters_dict = parse_clusters_file(

--- a/idseq_dag/steps/nonhost_fastq.py
+++ b/idseq_dag/steps/nonhost_fastq.py
@@ -88,10 +88,7 @@ class PipelineStepNonhostFastq(PipelineStep):
         nt_index = fragments.index("NT")
         header = ":".join(fragments[nt_index + 2:])
 
-        return {
-            "header": header,
-            "read_index": read_index
-        }
+        return read_index, header
 
     def generate_nonhost_headers(self, nonhost_fasta_file, cdhit_cluster_headers=None):
         nonhost_headers = [[], []]
@@ -101,12 +98,11 @@ class PipelineStepNonhostFastq(PipelineStep):
                 num += 1
                 # Assumes that the header line in the nonhost_fasta starts with ">"
                 if line[0] == ">":
-                    header = PipelineStepNonhostFastq.extract_header_from_line(line)
-                    read_index = header["read_index"]
-                    nonhost_headers[read_index].append(header["header"] + "\n")
+                    read_index, header = PipelineStepNonhostFastq.extract_header_from_line(line)
+                    nonhost_headers[read_index].append(header + "\n")
                     if cdhit_cluster_headers:
                         # TODO: (gdingle): get headers of rest of cluster... assumes we have the headers!!!
-                        nonhost_headers[read_index] += cdhit_cluster_headers[read_index]
+                        nonhost_headers[read_index] += cdhit_cluster_headers[header]
                         # TODO: (gdingle): assert that cdhit_cluster_headers[read_index] are not in flattened set of nonhost_headers
                         # TODO: (gdingle): in other words, do not add in reads that were already there
                         # TODO: (gdingle): also assert that all cluster read_index are in nonhost_headers

--- a/idseq_dag/steps/nonhost_fastq.py
+++ b/idseq_dag/steps/nonhost_fastq.py
@@ -154,7 +154,9 @@ class PipelineStepNonhostFastq(PipelineStep):
                     continue
                 output_file = output_file_0 if read_index == 0 else output_file_1
                 output_file.write(header + "\n")
-                if not clusters_dict:
+                # TODO: (gdingle): Show all duplicate reads, not just if
+                # use_taxon_whitelist. See https://jira.czi.team/browse/IDSEQ-2598.
+                if not clusters_dict or not tax_ids:
                     continue
                 other_headers = clusters_dict[header][1:]
                 for header in other_headers:

--- a/idseq_dag/steps/nonhost_fastq.py
+++ b/idseq_dag/steps/nonhost_fastq.py
@@ -16,10 +16,10 @@ class PipelineStepNonhostFastq(PipelineStep):
     def run(self) -> None:
         self.run_with_tax_ids(None, None)
         if self.additional_attributes.get("use_taxon_whitelist"):
-            betacoronaviruses = set([
+            betacoronaviruses = {
                 2697049,  # SARS-CoV2
                 694002,  # betacoronavirus genus
-            ])
+            }
             self.run_with_tax_ids(betacoronaviruses, "betacoronavirus")
 
     def run_with_tax_ids(
@@ -161,9 +161,12 @@ class PipelineStepNonhostFastq(PipelineStep):
                         seen.add(header)
                         assert clusters_dict is not None
                         other_headers = clusters_dict[header][1:]
-                        for header in other_headers:
-                            output_file_0.write(header + "\n")
-                            output_file_1.write(header + "\n")
+                        for other_header in other_headers:
+                            output_file_0.write(other_header + "\n")
+                            output_file_1.write(other_header + "\n")
+                            # Add other headers just in case something has gone
+                            # wrong upstream with cdhitdup.
+                            seen.add(other_header)
                     continue
                 else:
                     # TODO: (gdingle): Show all duplicate reads, not just if

--- a/idseq_dag/steps/nonhost_fastq.py
+++ b/idseq_dag/steps/nonhost_fastq.py
@@ -45,6 +45,8 @@ class PipelineStepNonhostFastq(PipelineStep):
         clusters_dict = None
         if READ_COUNTING_MODE == ReadCountingMode.COUNT_ALL \
                 and self.additional_attributes.get("use_taxon_whitelist"):
+            # TODO: (gdingle): Show all duplicate reads, not just if
+            # use_taxon_whitelist. See https://jira.czi.team/browse/IDSEQ-2598.
             # NOTE: this will load the set of all original read headers, which
             # could be several GBs in the worst case.
             clusters_dict = parse_clusters_file(

--- a/idseq_dag/steps/nonhost_fastq.py
+++ b/idseq_dag/steps/nonhost_fastq.py
@@ -92,6 +92,8 @@ class PipelineStepNonhostFastq(PipelineStep):
         return read_index, header
 
     def generate_nonhost_headers(self, nonhost_fasta_file, clusters_dict=None):
+        # TODO: (gdingle): change to write inline for low mem after testing assertions
+        # TODO: (gdingle): also change back to list for ordering
         nonhost_headers = [set(), set()]
         seen = set()
         with open(nonhost_fasta_file, "r") as input_file:
@@ -106,14 +108,11 @@ class PipelineStepNonhostFastq(PipelineStep):
                         clusters = clusters_dict[header]
                         cluster_size = clusters[0]
                         assert cluster_size == len(clusters[1:]), """cdhit_clusters should
-                        contain the count of reads in a cluster followed by the headers:
-                        {}""".format(clusters)
+                            contain the count of reads in a cluster followed by the headers: {}""".format(clusters)
                         to_add = set(header + "\n" for header in clusters[1:])
                         assert nonhost_headers[read_index].isdisjoint(
                             to_add), 'Cluster reads should not be in nonhost_fastq'
                         nonhost_headers[read_index] |= to_add
-                        # TODO: (gdingle): is suffix /1 /2 actually present? are ids unique to left or right?
-                        # TODO: (gdingle): how to add left and right here?
 
         with open(self.nonhost_headers[0], "w") as output_file:
             output_file.writelines(nonhost_headers[0])

--- a/idseq_dag/steps/run_cdhitdup.py
+++ b/idseq_dag/steps/run_cdhitdup.py
@@ -4,7 +4,8 @@ import idseq_dag.util.count as count
 import idseq_dag.util.fasta as fasta
 
 from idseq_dag.engine.pipeline_step import InputFileErrors, PipelineStep
-from idseq_dag.util.count import save_cdhit_clusters
+from idseq_dag.util.count import save_cdhit_cluster_sizes
+from idseq_dag.util.cdhit_clusters import parse_clusters_file
 
 
 class PipelineStepRunCDHitDup(PipelineStep):  # Deliberately not PipelineCountingStep
@@ -35,9 +36,6 @@ class PipelineStepRunCDHitDup(PipelineStep):  # Deliberately not PipelineCountin
     This step also outputs a TSV file mapping each cluster representative
     to its cluster size, which is useful when converting counts of clusters
     to counts of original fragments.
-
-    # TODO: (gdingle): update docs
-
     """
 
     def validate_input_files(self):
@@ -79,102 +77,13 @@ class PipelineStepRunCDHitDup(PipelineStep):  # Deliberately not PipelineCountin
                 args=cdhitdup_params
             )
         )
-        PipelineStepRunCDHitDup._emit_cluster_sizes(cdhit_cluster_sizes_path, cdhit_clusters_path, output_fas[0])
 
-    @staticmethod
-    def _emit_cluster_sizes(cdhit_cluster_sizes_path, cdhit_clusters_path, deduped_fasta_path):
         # Emit cluster sizes.  One line per cluster.  Format "<cluster_size> <cluster_read_id>".
         # This info is loaded in multiple subsequent steps using m8.load_cdhit_cluster_sizes,
         # and used to convert unique read counts to original read counts, and also to compute
         # per-taxon DCRs emitted alongside taxon_counts.
-
-        # TODO: (gdingle): update docs
-
-        # First identify the cluster representative reads emitted by cd-hit-dup.  Originally we
-        # used the ".clstr" output of cd-hit-dup for this, but turns out that for unpaired reads
-        # the actual deduped output of cdhit contains different representatives.
-        clusters_dict = {}
-        for read in fasta.iterator(deduped_fasta_path):
-            # A read header looks someting like
-            #
-            #    >M05295:357:000000000-CRPNR:1:1101:22051:10534 OPTIONAL RANDOM STUFF"
-            #     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-            #
-            # where the first character on the line is '>' and the read ID (underlined above)
-            # extends from '>' to the first whitespace character, not including '>' itself.
-            #
-            # The fasta iterator already asserts that read.header[0] is '>'.
-            #
-            read_id = read.header.split(None, 1)[0][1:]
-            clusters_dict[read_id] = None  # not yet known
-
-        def record_clusters(cluster_size, emitted_reads_from_cluster, line_number, _read_id):
-            assert emitted_reads_from_cluster, f"If this assertion fails, CD-HIT-DUP has forgotten to emit a read for this cluster.  In that case, just use the current read_id as cluster_representative.  Everything will work fine, aside from reduced sensitivity. {line_number}"
-            assert len(
-                emitted_reads_from_cluster) == 1, f"If this assertion fails, CD-HIT-DUP has emitted multiple reads from the same cluster.  Feel free to comment out this assertion if that happens a lot in practice.  Everything will run fine, but read counts contributed by that cluster will be exaggerated.  If you want to fix that, make the cluster sizes a float --- divide the actual cluster size by the number of reads emitted for the cluster, i.e. by len(emitted_reads_from_cluster). Probably an even better way of fixing it would be to emit your own fasta based on the .clstr file if that's reliable, or use a tool other than cdhit that doesn't have this bug.  {line_number}: {emitted_reads_from_cluster}"
-            cluster_representative = emitted_reads_from_cluster.pop()
-            assert cluster_representative in clusters_dict, "If this fails it's our bug here."
-            clusters_dict[cluster_representative] = [cluster_size] + emitted_reads_from_cluster
-
-        # Example input lines that form a cluster:
-        #
-        #    "0       140nt, >M05295:357:000000000-CRPNR:1:2119:16143:8253... *"
-        #    "1       140nt, >M05295:357:000000000-CRPNR:1:1101:22051:10534... at 1:140:1:140/+/100.00%"
-        #    "2       140nt, >M05295:357:000000000-CRPNR:1:1102:15401:7483... at 1:140:1:140/+/100.00%"
-        #    ...
-        #    "2334    140nt, >M05295:357:000000000-CRPNR:1:1102:13405:3483... at 1:140:1:140/+/100.00%"
-        #
-        # Corresponding output line for that cluster:
-        #
-        #    "2335    M05295:357:000000000-CRPNR:1:2119:16143:8253  M05295:357:000000000-CRPNR:1:2119:16143:8253  M05295:357:000000000-CRPNR:1:1101:22051:10534 M05295:357:000000000-CRPNR:1:1102:15401:748
-
-        # TODO: (gdingle): update docs
-
-        #
-        # Please note that "..." above input lines does not indicate truncation. CD-HIT-DUP appends "..." to the read
-        # IDs even if the read IDs have not been truncated.
-        #
-        # Per CD-HIT-DUP docs, when a "-d" argument is not specified, each read ID is obtained by
-        # splitting the corresponding FASTA line on whitespace and taking the first item.  That is also
-        # how we do it throughout this pipeline.  The code below assumes (and relies upon) the read IDs
-        # being free from whitespace.
-        #
-        # Furthremore, we expect read IDs to be unique in a sequencing run.  Violating that assumption,
-        # if it does not break cdhit itself, might produce slightly bogus numbers, because of how it
-        # affects subsampling and per-read DCR correction.  Preserving this uniqueness is why we do not
-        # specify a "-d" flag to cdhit, and allow it thus to use the entire read id.
-        #
-        # Further note that, although CD-HIT-DUP documentation states the read marked with '*' is the
-        # one chosen as representative, we have found, particularly with unpaired fasta, the emitted
-        # deduplicated read is not the one marked with '*'.  Hence we handle that case correctly below,
-        # and put a lot of assertions to make sure problems with cdhit output are detected.
-        with open(cdhit_clusters_path, "r") as clusters_file:
-            emitted_reads_from_cluster = set()  # set of reads in both dedup1.fa and current cluster; cardinality 1!
-            cluster_size = 0
-            read_id = None
-            line_number = 0
-            for line in clusters_file:
-                line_number += 1
-                if line.startswith(">"):
-                    continue
-                parts = line.strip().split()
-                serial = int(parts[0])
-                assert parts[2][0] == ">", line
-                assert parts[2].endswith("..."), line
-                if serial == 0 and cluster_size > 0:
-                    # We've just encountered the first read of a new cluster.  Emit all data held for the old cluster.
-                    record_clusters(cluster_size, emitted_reads_from_cluster, line_number, read_id)
-                    emitted_reads_from_cluster = set()
-                    cluster_size = 0
-                assert cluster_size == serial, f"{line_number}: {cluster_size}, {serial}, {line}"
-                read_id = parts[2][1:-3]
-                cluster_size += 1
-                if read_id in clusters_dict:
-                    emitted_reads_from_cluster.add(read_id)
-            if cluster_size > 0:
-                record_clusters(cluster_size, emitted_reads_from_cluster, line_number, read_id)
-
-        save_cdhit_clusters(cdhit_cluster_sizes_path, clusters_dict)
+        cluster_sizes_dict = parse_clusters_file(cdhit_clusters_path, deduped_fasta_path)
+        save_cdhit_cluster_sizes(cdhit_cluster_sizes_path, cluster_sizes_dict)
 
     def count_reads(self):
         self.should_count_reads = True

--- a/idseq_dag/steps/run_cdhitdup.py
+++ b/idseq_dag/steps/run_cdhitdup.py
@@ -82,7 +82,7 @@ class PipelineStepRunCDHitDup(PipelineStep):  # Deliberately not PipelineCountin
         # This info is loaded in multiple subsequent steps using m8.load_cdhit_cluster_sizes,
         # and used to convert unique read counts to original read counts, and also to compute
         # per-taxon DCRs emitted alongside taxon_counts.
-        clusters_dict = parse_clusters_file(cdhit_clusters_path, input_fas[0])
+        clusters_dict = parse_clusters_file(cdhit_clusters_path, output_fas[0])
         save_cdhit_cluster_sizes(cdhit_cluster_sizes_path, clusters_dict)
 
     def count_reads(self):

--- a/idseq_dag/steps/run_cdhitdup.py
+++ b/idseq_dag/steps/run_cdhitdup.py
@@ -82,8 +82,8 @@ class PipelineStepRunCDHitDup(PipelineStep):  # Deliberately not PipelineCountin
         # This info is loaded in multiple subsequent steps using m8.load_cdhit_cluster_sizes,
         # and used to convert unique read counts to original read counts, and also to compute
         # per-taxon DCRs emitted alongside taxon_counts.
-        cluster_sizes_dict = parse_clusters_file(cdhit_clusters_path, deduped_fasta_path)
-        save_cdhit_cluster_sizes(cdhit_cluster_sizes_path, cluster_sizes_dict)
+        clusters_dict = parse_clusters_file(cdhit_clusters_path, deduped_fasta_path)
+        save_cdhit_cluster_sizes(cdhit_cluster_sizes_path, clusters_dict)
 
     def count_reads(self):
         self.should_count_reads = True

--- a/idseq_dag/steps/run_cdhitdup.py
+++ b/idseq_dag/steps/run_cdhitdup.py
@@ -4,8 +4,8 @@ import idseq_dag.util.count as count
 import idseq_dag.util.fasta as fasta
 
 from idseq_dag.engine.pipeline_step import InputFileErrors, PipelineStep
-from idseq_dag.util.count import save_cdhit_cluster_sizes
 from idseq_dag.util.cdhit_clusters import parse_clusters_file
+from idseq_dag.util.count import save_cdhit_cluster_sizes
 
 
 class PipelineStepRunCDHitDup(PipelineStep):  # Deliberately not PipelineCountingStep

--- a/idseq_dag/steps/run_cdhitdup.py
+++ b/idseq_dag/steps/run_cdhitdup.py
@@ -82,7 +82,7 @@ class PipelineStepRunCDHitDup(PipelineStep):  # Deliberately not PipelineCountin
         # This info is loaded in multiple subsequent steps using m8.load_cdhit_cluster_sizes,
         # and used to convert unique read counts to original read counts, and also to compute
         # per-taxon DCRs emitted alongside taxon_counts.
-        clusters_dict = parse_clusters_file(cdhit_clusters_path, deduped_fasta_path)
+        clusters_dict = parse_clusters_file(cdhit_clusters_path, input_fas[0])
         save_cdhit_cluster_sizes(cdhit_cluster_sizes_path, clusters_dict)
 
     def count_reads(self):

--- a/idseq_dag/steps/run_cdhitdup.py
+++ b/idseq_dag/steps/run_cdhitdup.py
@@ -126,9 +126,12 @@ class PipelineStepRunCDHitDup(PipelineStep):  # Deliberately not PipelineCountin
         #
         # Corresponding output line for that cluster:
         #
-        #    "2335    140nt, >M05295:357:000000000-CRPNR:1:2119:16143:8253"
+        #    "2335    M05295:357:000000000-CRPNR:1:2119:16143:8253  M05295:357:000000000-CRPNR:1:2119:16143:8253  M05295:357:000000000-CRPNR:1:1101:22051:10534 M05295:357:000000000-CRPNR:1:1102:15401:748
+
+        # TODO: (gdingle): update docs
+
         #
-        # Please note that "..." above does not indicate truncation. CD-HIT-DUP appends "..." to the read
+        # Please note that "..." above input lines does not indicate truncation. CD-HIT-DUP appends "..." to the read
         # IDs even if the read IDs have not been truncated.
         #
         # Per CD-HIT-DUP docs, when a "-d" argument is not specified, each read ID is obtained by

--- a/idseq_dag/util/cdhit_clusters.py
+++ b/idseq_dag/util/cdhit_clusters.py
@@ -83,6 +83,10 @@ def parse_clusters_file(
 
         assert cluster_representative in clusters_dict, "If this fails it's our bug here."
 
+        assert cluster_size - 1 == len(other_reads_from_cluster), """other_reads_from_cluster should
+        contain the number of reads specified by cluster_size minus cluster_representative:
+        {}, {}""".format(cluster_size, other_reads_from_cluster)
+
         clusters_dict[cluster_representative] = (cluster_size,) + tuple(other_reads_from_cluster)
         return
 

--- a/idseq_dag/util/cdhit_clusters.py
+++ b/idseq_dag/util/cdhit_clusters.py
@@ -1,0 +1,115 @@
+from typing import Dict, Optional, Set
+
+# Example input lines that form a cluster:
+#
+#    "0       140nt, >M05295:357:000000000-CRPNR:1:2119:16143:8253... *"
+#    "1       140nt, >M05295:357:000000000-CRPNR:1:1101:22051:10534... at 1:140:1:140/+/100.00%"
+#    "2       140nt, >M05295:357:000000000-CRPNR:1:1102:15401:7483... at 1:140:1:140/+/100.00%"
+#    ...
+#    "2334    140nt, >M05295:357:000000000-CRPNR:1:1102:13405:3483... at 1:140:1:140/+/100.00%"
+#
+# Corresponding output line for that cluster:
+#
+#    "2335    140nt, >M05295:357:000000000-CRPNR:1:2119:16143:8253"
+#
+# Please note that "..." above does not indicate truncation. CD-HIT-DUP appends "..." to the read
+# IDs even if the read IDs have not been truncated.
+#
+# Per CD-HIT-DUP docs, when a "-d" argument is not specified, each read ID is obtained by
+# splitting the corresponding FASTA line on whitespace and taking the first item.  That is also
+# how we do it throughout this pipeline.  The code below assumes (and relies upon) the read IDs
+# being free from whitespace.
+#
+# Furthremore, we expect read IDs to be unique in a sequencing run.  Violating that assumption,
+# if it does not break cdhit itself, might produce slightly bogus numbers, because of how it
+# affects subsampling and per-read DCR correction.  Preserving this uniqueness is why we do not
+# specify a "-d" flag to cdhit, and allow it thus to use the entire read id.
+#
+# Further note that, although CD-HIT-DUP documentation states the read marked with '*' is the
+# one chosen as representative, we have found, particularly with unpaired fasta, the emitted
+# deduplicated read is not the one marked with '*'.  Hence we handle that case correctly below,
+# and put a lot of assertions to make sure problems with cdhit output are detected.
+
+
+def parse_clusters_file(
+    cdhit_clusters_path: str,
+    deduped_fasta_path: str,
+    # TODO: (gdingle): headers
+    headers: bool = False
+) -> dict:
+    # First identify the cluster representative reads emitted by cd-hit-dup.  Originally we
+    # used the ".clstr" output of cd-hit-dup for this, but turns out that for unpaired reads
+    # the actual deduped output of cdhit contains different representatives.
+    cluster_sizes_dict: Dict[str, Optional[int]] = {}
+    for read in fasta.iterator(deduped_fasta_path):
+        # A read header looks someting like
+        #
+        #    >M05295:357:000000000-CRPNR:1:1101:22051:10534 OPTIONAL RANDOM STUFF"
+        #     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+        #
+        # where the first character on the line is '>' and the read ID (underlined above)
+        # extends from '>' to the first whitespace character, not including '>' itself.
+        #
+        # The fasta iterator already asserts that read.header[0] is '>'.
+        #
+        read_id = read.header.split(None, 1)[0][1:]
+        cluster_sizes_dict[read_id] = None  # not yet known
+
+    def record_cluster_size(
+        cluster_size: int,
+        emitted_reads_from_cluster: set,
+        line_number: int,
+        _read_id: str
+    ):
+        assert emitted_reads_from_cluster, f"""If this assertion fails,
+        CD-HIT-DUP has forgotten to emit a read for this cluster.  In that case,
+        just use the current read_id as cluster_representative.  Everything will
+        work fine, aside from reduced sensitivity. {line_number}"""
+        assert len(emitted_reads_from_cluster) == 1, f"""If this assertion
+        fails, CD-HIT-DUP has emitted multiple reads from the same cluster.
+        Feel free to comment out this assertion if that happens a lot in
+        practice.  Everything will run fine, but read counts contributed by that
+        cluster will be exaggerated.  If you want to fix that, make the cluster
+        sizes a float --- divide the actual cluster size by the number of reads
+        emitted for the cluster, i.e. by len(emitted_reads_from_cluster).
+        Probably an even better way of fixing it would be to emit your own fasta
+        based on the .clstr file if that's reliable, or use a tool other than
+        cdhit that doesn't have this bug.  {line_number}:
+        {emitted_reads_from_cluster}"""
+        cluster_representative = emitted_reads_from_cluster.pop()
+        assert cluster_representative in cluster_sizes_dict, "If this fails it's our bug here."
+        cluster_sizes_dict[cluster_representative] = cluster_size
+
+    with open(cdhit_clusters_path, "r") as clusters_file:
+        # set of reads in both dedup1.fa and current cluster; cardinality 1!
+        emitted_reads_from_cluster: Set[str] = set()
+        cluster_size = 0
+        read_id = None
+        line_number = 0
+        for line in clusters_file:
+            line_number += 1
+            if line.startswith(">"):
+                continue
+            parts = line.strip().split()
+            serial = int(parts[0])
+            assert parts[2][0] == ">", line
+            assert parts[2].endswith("..."), line
+            if serial == 0 and cluster_size > 0:
+                # We've just encountered the first read of a new cluster.  Emit all data held for the old cluster.
+                record_cluster_size(cluster_size, emitted_reads_from_cluster, line_number, read_id)
+                emitted_reads_from_cluster = set()
+                cluster_size = 0
+            assert cluster_size == serial, f"{line_number}: {cluster_size}, {serial}, {line}"
+            read_id = parts[2][1:-3]
+            cluster_size += 1
+            if read_id in cluster_sizes_dict:
+                emitted_reads_from_cluster.add(read_id)
+        if cluster_size > 0:
+            record_cluster_size(
+                cluster_size,
+                emitted_reads_from_cluster,
+                line_number,
+                read_id
+            )
+
+    return cluster_sizes_dict

--- a/idseq_dag/util/count.py
+++ b/idseq_dag/util/count.py
@@ -5,9 +5,7 @@ from enum import Enum
 import idseq_dag.util.command as command
 import idseq_dag.util.command_patterns as command_patterns
 import idseq_dag.util.fasta as fasta
-
 from idseq_dag import __version__
-
 
 class ReadCountingMode(Enum):
     COUNT_UNIQUE = "COUNT UNIQUE READS"
@@ -17,7 +15,6 @@ class ReadCountingMode(Enum):
 # Feel free to delete the support for COUNT_UNIQUE after pipeline 4.0 has been released and well accepted.
 PIPELINE_MAJOR_VERSION = int(__version__.split(".", 1)[0])
 READ_COUNTING_MODE = ReadCountingMode.COUNT_ALL if PIPELINE_MAJOR_VERSION >= 4 else ReadCountingMode.COUNT_UNIQUE
-
 
 def _count_reads_via_wc(local_file_path, max_reads):
     '''
@@ -54,7 +51,6 @@ def _count_reads_via_wc(local_file_path, max_reads):
     line_count = int(cmd_output.strip().split(' ')[0])
     return _lines2reads(line_count, file_format)
 
-
 def _lines2reads(line_count, file_format):
     '''
     Convert line count to read count based on file format.
@@ -78,7 +74,6 @@ def _lines2reads(line_count, file_format):
         read_count = line_count
     return read_count
 
-
 def _reads2lines(read_count, file_format):
     '''
     Convert read count to line count based on file format.
@@ -92,7 +87,6 @@ def _reads2lines(read_count, file_format):
         line_count = 2 * read_count
     return line_count
 
-
 def files_have_min_reads(input_files, min_reads):
     """ Checks whether fa/fasta/fq/fastq have the minimum number of reads.
     Pipeline steps can use this method for input validation.
@@ -102,7 +96,6 @@ def files_have_min_reads(input_files, min_reads):
         if num_reads < min_reads:
             return False
     return True
-
 
 def _count_reads_expanding_duplicates(local_file_path, cluster_sizes, cluster_key):
     # See documentation for reads_in_group use case with cluster_sizes, below.
@@ -132,31 +125,21 @@ def _count_reads_expanding_duplicates(local_file_path, cluster_sizes, cluster_ke
         nonunique_count += get_read_cluster_size(cluster_sizes, cluster_key(read_id))
     return unique_count, nonunique_count
 
-
 def get_read_cluster_size(cdhit_cluster_sizes, read_id):
     suffix = None
     cluster_size = cdhit_cluster_sizes.get(read_id)
     if cluster_size == None:
         prefix, suffix = read_id[:-2], read_id[-2:]
         cluster_size = cdhit_cluster_sizes.get(prefix)
-    assert cluster_size != None and suffix in (
-        None, "/1", "/2"), f"Read ID not found in cdhit_cluster_sizes dict: {read_id}"
+    assert cluster_size != None and suffix in (None, "/1", "/2"), f"Read ID not found in cdhit_cluster_sizes dict: {read_id}"
     return cluster_size
 
-
-def _load_cdhit_clusters_work(filename, headers=False):
+def _load_cdhit_cluster_sizes_work(filename):
     cdhit_cluster_sizes = {}
     with open(filename, "r") as f:
         for line in f:
-            # TODO: (gdingle): test me
-            cluster_size_str, *read_ids = line.split(None)
-            assert int(cluster_size_str) == len(
-                read_ids), 'Count in line "{}" must match number of read headers'.format(line)
-            read_id = read_ids.pop()
-            if headers:
-                cdhit_cluster_sizes[read_id.strip()] = read_ids
-            else:
-                cdhit_cluster_sizes[read_id.strip()] = int(cluster_size_str)
+            cluster_size_str, read_id = line.split(None, 1)
+            cdhit_cluster_sizes[read_id.strip()] = int(cluster_size_str)
     return cdhit_cluster_sizes
 
 
@@ -166,26 +149,19 @@ def _load_cdhit_clusters_work(filename, headers=False):
 _CDHIT_CLUSTER_SIZES_CACHE = {}
 _CDHIT_CLUSTER_SIZES_LOCK = multiprocessing.RLock()
 
-
 def load_cdhit_cluster_sizes(filename):
     with _CDHIT_CLUSTER_SIZES_LOCK:
         if filename not in _CDHIT_CLUSTER_SIZES_CACHE:
-            _CDHIT_CLUSTER_SIZES_CACHE[filename] = _load_cdhit_clusters_work(filename)
+            _CDHIT_CLUSTER_SIZES_CACHE[filename] = _load_cdhit_cluster_sizes_work(filename)
         return _CDHIT_CLUSTER_SIZES_CACHE[filename]
 
-
-def load_cdhit_cluster_headers(filename):
+def save_cdhit_cluster_sizes(filename, cdhit_cluster_sizes):
     with _CDHIT_CLUSTER_SIZES_LOCK:
-        return _load_cdhit_clusters_work(filename, headers=True)
-
-
-def save_cdhit_clusters(filename, cdhit_clusters):
+        _CDHIT_CLUSTER_SIZES_CACHE[filename] = cdhit_cluster_sizes
     with open(filename, "w") as tsv:
-        for read_id, cluster in cdhit_clusters.items():
-            assert cluster != None, f"If this happened, probably dedup1.fa output of cdhit contains reads that are not mentioned in dedup1.fa.clstr.  Perhaps set cluster_size=1 for those reads but also follow up with cdhit.  Read id: {read_id}"
-            tsv.write(f"{len(cluster)}\t{read_id}\t{"\t".join(cluster)}\n")
-            # TODO: (gdingle): testme
-
+        for read_id, cluster_size in cdhit_cluster_sizes.items():
+            assert cluster_size != None, f"If this happened, probably dedup1.fa output of cdhit contains reads that are not mentioned in dedup1.fa.clstr.  Perhaps set cluster_size=1 for those reads but also follow up with cdhit.  Read id: {read_id}"
+            tsv.write(f"{cluster_size}\t{read_id}\n")
 
 def reads(local_file_path):
     '''
@@ -193,7 +169,6 @@ def reads(local_file_path):
     Implemented via wc, so very fast.
     '''
     return _count_reads_via_wc(local_file_path, max_reads=None)
-
 
 def reads_in_group(file_group, max_fragments=None, cluster_sizes=None, cluster_key=None):
     '''
@@ -254,8 +229,7 @@ def reads_in_group(file_group, max_fragments=None, cluster_sizes=None, cluster_k
     assert None in (max_fragments, cluster_sizes), "Truncating to max_fragments is not supported at the same time as expanding cluster_sizes.  Consider setting max_fragments=None."
     assert (cluster_sizes == None) == (cluster_key == None), "Please specify cluster_key when using cluster_sizes."
     first_file = file_group[0]
-    # This is so fast, just do it always as a sanity check.
-    unique_fast = _count_reads_via_wc(first_file, max_fragments)
+    unique_fast = _count_reads_via_wc(first_file, max_fragments)  # This is so fast, just do it always as a sanity check.
     if cluster_sizes:
         # Run this even if ReadCountingMode.COUNT_UNIQUE to get it well tested before release.  Dark launch.
         unique, nonunique = _count_reads_expanding_duplicates(first_file, cluster_sizes, cluster_key)

--- a/idseq_dag/util/count.py
+++ b/idseq_dag/util/count.py
@@ -149,11 +149,13 @@ def _load_cdhit_clusters_work(filename, headers=False):
     with open(filename, "r") as f:
         for line in f:
             # TODO: (gdingle): test me
+            cluster_size_str, *read_ids = line.split(None)
+            assert int(cluster_size_str) == len(
+                read_ids), 'Count in line "{}" must match number of read headers'.format(line)
+            read_id = read_ids.pop()
             if headers:
-                cluster_size_str, *read_ids = line.split(None)
                 cdhit_cluster_sizes[read_id.strip()] = read_ids
             else:
-                cluster_size_str, read_id = line.split(None)[0:2]
                 cdhit_cluster_sizes[read_id.strip()] = int(cluster_size_str)
     return cdhit_cluster_sizes
 

--- a/idseq_dag/util/count.py
+++ b/idseq_dag/util/count.py
@@ -5,6 +5,7 @@ from enum import Enum
 import idseq_dag.util.command as command
 import idseq_dag.util.command_patterns as command_patterns
 import idseq_dag.util.fasta as fasta
+
 from idseq_dag import __version__
 
 
@@ -176,13 +177,12 @@ def load_cdhit_cluster_headers(filename):
         return _load_cdhit_clusters_work(filename, headers=True)
 
 
-def save_cdhit_cluster_sizes(filename, cdhit_cluster_sizes):
-    with _CDHIT_CLUSTER_SIZES_LOCK:
-        _CDHIT_CLUSTER_SIZES_CACHE[filename] = cdhit_cluster_sizes
+def save_cdhit_clusters(filename, cdhit_clusters):
     with open(filename, "w") as tsv:
-        for read_id, cluster_size in cdhit_cluster_sizes.items():
-            assert cluster_size != None, f"If this happened, probably dedup1.fa output of cdhit contains reads that are not mentioned in dedup1.fa.clstr.  Perhaps set cluster_size=1 for those reads but also follow up with cdhit.  Read id: {read_id}"
-            tsv.write(f"{cluster_size}\t{read_id}\n")
+        for read_id, cluster in cdhit_clusters.items():
+            assert cluster != None, f"If this happened, probably dedup1.fa output of cdhit contains reads that are not mentioned in dedup1.fa.clstr.  Perhaps set cluster_size=1 for those reads but also follow up with cdhit.  Read id: {read_id}"
+            tsv.write(f"{len(cluster)}\t{read_id}\t{"\t".join(cluster)}\n")
+            # TODO: (gdingle): testme
 
 
 def reads(local_file_path):

--- a/idseq_dag/util/count.py
+++ b/idseq_dag/util/count.py
@@ -7,6 +7,7 @@ import idseq_dag.util.command_patterns as command_patterns
 import idseq_dag.util.fasta as fasta
 from idseq_dag import __version__
 
+
 class ReadCountingMode(Enum):
     COUNT_UNIQUE = "COUNT UNIQUE READS"
     COUNT_ALL = "COUNT ALL READS"
@@ -15,6 +16,7 @@ class ReadCountingMode(Enum):
 # Feel free to delete the support for COUNT_UNIQUE after pipeline 4.0 has been released and well accepted.
 PIPELINE_MAJOR_VERSION = int(__version__.split(".", 1)[0])
 READ_COUNTING_MODE = ReadCountingMode.COUNT_ALL if PIPELINE_MAJOR_VERSION >= 4 else ReadCountingMode.COUNT_UNIQUE
+
 
 def _count_reads_via_wc(local_file_path, max_reads):
     '''
@@ -51,6 +53,7 @@ def _count_reads_via_wc(local_file_path, max_reads):
     line_count = int(cmd_output.strip().split(' ')[0])
     return _lines2reads(line_count, file_format)
 
+
 def _lines2reads(line_count, file_format):
     '''
     Convert line count to read count based on file format.
@@ -74,6 +77,7 @@ def _lines2reads(line_count, file_format):
         read_count = line_count
     return read_count
 
+
 def _reads2lines(read_count, file_format):
     '''
     Convert read count to line count based on file format.
@@ -87,6 +91,7 @@ def _reads2lines(read_count, file_format):
         line_count = 2 * read_count
     return line_count
 
+
 def files_have_min_reads(input_files, min_reads):
     """ Checks whether fa/fasta/fq/fastq have the minimum number of reads.
     Pipeline steps can use this method for input validation.
@@ -96,6 +101,7 @@ def files_have_min_reads(input_files, min_reads):
         if num_reads < min_reads:
             return False
     return True
+
 
 def _count_reads_expanding_duplicates(local_file_path, cluster_sizes, cluster_key):
     # See documentation for reads_in_group use case with cluster_sizes, below.
@@ -125,14 +131,17 @@ def _count_reads_expanding_duplicates(local_file_path, cluster_sizes, cluster_ke
         nonunique_count += get_read_cluster_size(cluster_sizes, cluster_key(read_id))
     return unique_count, nonunique_count
 
+
 def get_read_cluster_size(cdhit_cluster_sizes, read_id):
     suffix = None
     cluster_size = cdhit_cluster_sizes.get(read_id)
     if cluster_size == None:
         prefix, suffix = read_id[:-2], read_id[-2:]
         cluster_size = cdhit_cluster_sizes.get(prefix)
-    assert cluster_size != None and suffix in (None, "/1", "/2"), f"Read ID not found in cdhit_cluster_sizes dict: {read_id}"
+    assert cluster_size != None and suffix in (
+        None, "/1", "/2"), f"Read ID not found in cdhit_cluster_sizes dict: {read_id}"
     return cluster_size
+
 
 def _load_cdhit_cluster_sizes_work(filename):
     cdhit_cluster_sizes = {}
@@ -149,19 +158,30 @@ def _load_cdhit_cluster_sizes_work(filename):
 _CDHIT_CLUSTER_SIZES_CACHE = {}
 _CDHIT_CLUSTER_SIZES_LOCK = multiprocessing.RLock()
 
+
 def load_cdhit_cluster_sizes(filename):
     with _CDHIT_CLUSTER_SIZES_LOCK:
         if filename not in _CDHIT_CLUSTER_SIZES_CACHE:
             _CDHIT_CLUSTER_SIZES_CACHE[filename] = _load_cdhit_cluster_sizes_work(filename)
         return _CDHIT_CLUSTER_SIZES_CACHE[filename]
 
-def save_cdhit_cluster_sizes(filename, cdhit_cluster_sizes):
+
+def save_cdhit_cluster_sizes(filename, cdhit_clusters):
     with _CDHIT_CLUSTER_SIZES_LOCK:
-        _CDHIT_CLUSTER_SIZES_CACHE[filename] = cdhit_cluster_sizes
+        _CDHIT_CLUSTER_SIZES_CACHE[filename] = {}
     with open(filename, "w") as tsv:
-        for read_id, cluster_size in cdhit_cluster_sizes.items():
-            assert cluster_size != None, f"If this happened, probably dedup1.fa output of cdhit contains reads that are not mentioned in dedup1.fa.clstr.  Perhaps set cluster_size=1 for those reads but also follow up with cdhit.  Read id: {read_id}"
+        for read_id, clusters in cdhit_clusters.items():
+            cluster_size = clusters[0]
+            assert cluster_size == len(clusters[1:]), """cdhit_clusters should
+            contain the count of reads in a cluster followed by the headers:
+            {}""".format(clusters)
+            assert cluster_size != None, f"""If this happened, probably
+            dedup1.fa output of cdhit contains reads that are not mentioned in
+            dedup1.fa.clstr.  Perhaps set cluster_size=1 for those reads but
+            also follow up with cdhit.  Read id: {read_id}"""
             tsv.write(f"{cluster_size}\t{read_id}\n")
+            _CDHIT_CLUSTER_SIZES_CACHE[filename][read_id] = cluster_size
+
 
 def reads(local_file_path):
     '''
@@ -169,6 +189,7 @@ def reads(local_file_path):
     Implemented via wc, so very fast.
     '''
     return _count_reads_via_wc(local_file_path, max_reads=None)
+
 
 def reads_in_group(file_group, max_fragments=None, cluster_sizes=None, cluster_key=None):
     '''
@@ -229,7 +250,8 @@ def reads_in_group(file_group, max_fragments=None, cluster_sizes=None, cluster_k
     assert None in (max_fragments, cluster_sizes), "Truncating to max_fragments is not supported at the same time as expanding cluster_sizes.  Consider setting max_fragments=None."
     assert (cluster_sizes == None) == (cluster_key == None), "Please specify cluster_key when using cluster_sizes."
     first_file = file_group[0]
-    unique_fast = _count_reads_via_wc(first_file, max_fragments)  # This is so fast, just do it always as a sanity check.
+    # This is so fast, just do it always as a sanity check.
+    unique_fast = _count_reads_via_wc(first_file, max_fragments)
     if cluster_sizes:
         # Run this even if ReadCountingMode.COUNT_UNIQUE to get it well tested before release.  Dark launch.
         unique, nonunique = _count_reads_expanding_duplicates(first_file, cluster_sizes, cluster_key)

--- a/idseq_dag/util/count.py
+++ b/idseq_dag/util/count.py
@@ -7,6 +7,7 @@ import idseq_dag.util.command_patterns as command_patterns
 import idseq_dag.util.fasta as fasta
 from idseq_dag import __version__
 
+
 class ReadCountingMode(Enum):
     COUNT_UNIQUE = "COUNT UNIQUE READS"
     COUNT_ALL = "COUNT ALL READS"
@@ -15,6 +16,7 @@ class ReadCountingMode(Enum):
 # Feel free to delete the support for COUNT_UNIQUE after pipeline 4.0 has been released and well accepted.
 PIPELINE_MAJOR_VERSION = int(__version__.split(".", 1)[0])
 READ_COUNTING_MODE = ReadCountingMode.COUNT_ALL if PIPELINE_MAJOR_VERSION >= 4 else ReadCountingMode.COUNT_UNIQUE
+
 
 def _count_reads_via_wc(local_file_path, max_reads):
     '''
@@ -51,6 +53,7 @@ def _count_reads_via_wc(local_file_path, max_reads):
     line_count = int(cmd_output.strip().split(' ')[0])
     return _lines2reads(line_count, file_format)
 
+
 def _lines2reads(line_count, file_format):
     '''
     Convert line count to read count based on file format.
@@ -74,6 +77,7 @@ def _lines2reads(line_count, file_format):
         read_count = line_count
     return read_count
 
+
 def _reads2lines(read_count, file_format):
     '''
     Convert read count to line count based on file format.
@@ -87,6 +91,7 @@ def _reads2lines(read_count, file_format):
         line_count = 2 * read_count
     return line_count
 
+
 def files_have_min_reads(input_files, min_reads):
     """ Checks whether fa/fasta/fq/fastq have the minimum number of reads.
     Pipeline steps can use this method for input validation.
@@ -96,6 +101,7 @@ def files_have_min_reads(input_files, min_reads):
         if num_reads < min_reads:
             return False
     return True
+
 
 def _count_reads_expanding_duplicates(local_file_path, cluster_sizes, cluster_key):
     # See documentation for reads_in_group use case with cluster_sizes, below.
@@ -125,21 +131,29 @@ def _count_reads_expanding_duplicates(local_file_path, cluster_sizes, cluster_ke
         nonunique_count += get_read_cluster_size(cluster_sizes, cluster_key(read_id))
     return unique_count, nonunique_count
 
+
 def get_read_cluster_size(cdhit_cluster_sizes, read_id):
     suffix = None
     cluster_size = cdhit_cluster_sizes.get(read_id)
     if cluster_size == None:
         prefix, suffix = read_id[:-2], read_id[-2:]
         cluster_size = cdhit_cluster_sizes.get(prefix)
-    assert cluster_size != None and suffix in (None, "/1", "/2"), f"Read ID not found in cdhit_cluster_sizes dict: {read_id}"
+    assert cluster_size != None and suffix in (
+        None, "/1", "/2"), f"Read ID not found in cdhit_cluster_sizes dict: {read_id}"
     return cluster_size
 
-def _load_cdhit_cluster_sizes_work(filename):
+
+def _load_cdhit_clusters_work(filename, headers=False):
     cdhit_cluster_sizes = {}
     with open(filename, "r") as f:
         for line in f:
-            cluster_size_str, read_id = line.split(None, 1)
-            cdhit_cluster_sizes[read_id.strip()] = int(cluster_size_str)
+            # TODO: (gdingle): test me
+            if headers:
+                cluster_size_str, *read_ids = line.split(None)
+                cdhit_cluster_sizes[read_id.strip()] = read_ids
+            else:
+                cluster_size_str, read_id = line.split(None)[0:2]
+                cdhit_cluster_sizes[read_id.strip()] = int(cluster_size_str)
     return cdhit_cluster_sizes
 
 
@@ -149,11 +163,18 @@ def _load_cdhit_cluster_sizes_work(filename):
 _CDHIT_CLUSTER_SIZES_CACHE = {}
 _CDHIT_CLUSTER_SIZES_LOCK = multiprocessing.RLock()
 
+
 def load_cdhit_cluster_sizes(filename):
     with _CDHIT_CLUSTER_SIZES_LOCK:
         if filename not in _CDHIT_CLUSTER_SIZES_CACHE:
-            _CDHIT_CLUSTER_SIZES_CACHE[filename] = _load_cdhit_cluster_sizes_work(filename)
+            _CDHIT_CLUSTER_SIZES_CACHE[filename] = _load_cdhit_clusters_work(filename)
         return _CDHIT_CLUSTER_SIZES_CACHE[filename]
+
+
+def load_cdhit_cluster_headers(filename):
+    with _CDHIT_CLUSTER_SIZES_LOCK:
+        return _load_cdhit_clusters_work(filename, headers=True)
+
 
 def save_cdhit_cluster_sizes(filename, cdhit_cluster_sizes):
     with _CDHIT_CLUSTER_SIZES_LOCK:
@@ -163,12 +184,14 @@ def save_cdhit_cluster_sizes(filename, cdhit_cluster_sizes):
             assert cluster_size != None, f"If this happened, probably dedup1.fa output of cdhit contains reads that are not mentioned in dedup1.fa.clstr.  Perhaps set cluster_size=1 for those reads but also follow up with cdhit.  Read id: {read_id}"
             tsv.write(f"{cluster_size}\t{read_id}\n")
 
+
 def reads(local_file_path):
     '''
     Count reads in given FASTA or FASTQ file.
     Implemented via wc, so very fast.
     '''
     return _count_reads_via_wc(local_file_path, max_reads=None)
+
 
 def reads_in_group(file_group, max_fragments=None, cluster_sizes=None, cluster_key=None):
     '''
@@ -229,7 +252,8 @@ def reads_in_group(file_group, max_fragments=None, cluster_sizes=None, cluster_k
     assert None in (max_fragments, cluster_sizes), "Truncating to max_fragments is not supported at the same time as expanding cluster_sizes.  Consider setting max_fragments=None."
     assert (cluster_sizes == None) == (cluster_key == None), "Please specify cluster_key when using cluster_sizes."
     first_file = file_group[0]
-    unique_fast = _count_reads_via_wc(first_file, max_fragments)  # This is so fast, just do it always as a sanity check.
+    # This is so fast, just do it always as a sanity check.
+    unique_fast = _count_reads_via_wc(first_file, max_fragments)
     if cluster_sizes:
         # Run this even if ReadCountingMode.COUNT_UNIQUE to get it well tested before release.  Dark launch.
         unique, nonunique = _count_reads_expanding_duplicates(first_file, cluster_sizes, cluster_key)

--- a/idseq_dag/util/count.py
+++ b/idseq_dag/util/count.py
@@ -172,9 +172,6 @@ def save_cdhit_cluster_sizes(filename, cdhit_clusters):
     with open(filename, "w") as tsv:
         for read_id, clusters in cdhit_clusters.items():
             cluster_size = clusters[0]
-            assert cluster_size == len(clusters[1:]), """cdhit_clusters should
-            contain the count of reads in a cluster followed by the headers:
-            {}""".format(clusters)
             assert cluster_size != None, f"""If this happened, probably
             dedup1.fa output of cdhit contains reads that are not mentioned in
             dedup1.fa.clstr.  Perhaps set cluster_size=1 for those reads but

--- a/idseq_dag/util/fasta.py
+++ b/idseq_dag/util/fasta.py
@@ -1,9 +1,8 @@
 #!/usr/bin/env python3
+from typing import Iterator, List, Tuple, NamedTuple
+import sys
 import idseq_dag.util.command as command
 import idseq_dag.util.command_patterns as command_patterns
-import sys
-
-from typing import Iterator, List, NamedTuple, Tuple
 
 class Read(NamedTuple):
     header: str

--- a/idseq_dag/util/fasta.py
+++ b/idseq_dag/util/fasta.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
-from typing import Iterator, List, Tuple, NamedTuple
-import sys
 import idseq_dag.util.command as command
 import idseq_dag.util.command_patterns as command_patterns
+import sys
+
+from typing import Iterator, List, NamedTuple, Tuple
 
 class Read(NamedTuple):
     header: str


### PR DESCRIPTION
# Description

This is motivated by IDSEQ-2599, IDSEQ-2598 and IDSEQ-2600. Following the change to show report stats in terms of original, non-unique reads, we want to include original, non-unique reads in the generated non-host fastqs for user download, most urgently for betacoronavrius. The feature is gated by `use_taxon_whitelist`. 

See also #283 .

# Version
- [x] I have increased the appropriate version number in https://github.com/chanzuckerberg/idseq-dag/blob/master/idseq_dag/__init__.py. Guidelines here: https://github.com/chanzuckerberg/idseq-dag/blob/pr-template/README.md#release-notes
- [x] I have added release notes for my new version to https://github.com/chanzuckerberg/idseq-dag/blob/master/README.md#release-notes
- [x] I will push a git tag after merging in the form `vX.Y.Z`

# Tests

I ran the code with a temp assertion that all dupe reads added were not already in the nonhost fastq.

I checked the file sizes. The new is slightly larger for my test, consistent with the extra reads. 

I spot checked a couple dupe reads that were in the original `clstr` file. They were in the new fastq but not the old. 

See https://idseq.net/samples/46835/pipeline_runs for stress test. The cdhit step took around 8min, of which the command itself took 6min, so any extra parsing time is negligible. The step passed on 80M reads of input so OOM risk should be relatively low. 

- [x] I have verified that the pipeline still completes successfully:
    - [x] for single-end inputs
    - [x] for paired-end inputs
    - [x] for FASTQ inputs
    - [ ] for FASTA inputs.
- [x] I have validated that my change does not introduce any correctness bugs to existing output types.
- [x] I have validated that my change does not introduce significant performance regressions or I have discussed with the team that the benefits of the change are substantial enough that we're comfortable accepting the size of the measured performance penalty.

# Notes
* I improved the memory efficiency of one part of `PipelineStepNonhostFastq`. On the other hand, I made it worse in order to load all clusters for lookup by read ID. 
* The dupe reads are added both to the r1 and r2 fasta, keeping with how we use cdhitdup -- on paired reads when available. However, the pre-existing code does not assume that the input reads from `refined_taxid_annot.fasta` are paired, so I'm not sure what's expected here. Could we have disjoint sets of r1 and r2 reads? Please advise. @cdebourcy ?
* In any case, if we do IDSEQ-2599 then it seems like we will always want to include both ends of a paired read in the fastqs when available, regardless of what's in `refined_taxid_annot.fasta`. It seems like that would be trivial to add in this PR with something that effectively runs 
```
seqtk subseq R1.fastq {all_nonhost_read_headers} > nonhost_R1.fastq
seqtk subseq R2.fastq {all_nonhost_read_headers} > nonhost_R2.fastq
```
