### PR TITLE
Generate betacoronavirus fastq files for user download

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,9 @@ Changes to X or Y force recomputation of all results when a sample is rerun usin
 
 When releasing a new version, please add a Git tag of the form `vX.Y.Z`.
 
+- 4.3.1
+ - Generate betacoronavirus fastq files for user download.
+
 - 4.3.0
  - Include all reads in the generated non-host fastqs for user download instead of only unique reads.
 

--- a/examples/nonhost_fastq.json
+++ b/examples/nonhost_fastq.json
@@ -15,7 +15,9 @@
       "class": "PipelineStepNonhostFastq",
       "module": "idseq_dag.steps.nonhost_fastq",
       "additional_files": {},
-      "additional_attributes": {}
+      "additional_attributes": {
+        "use_taxon_whitelist": true
+      }
     }
   ],
   "given_targets": {

--- a/idseq_dag/__init__.py
+++ b/idseq_dag/__init__.py
@@ -1,2 +1,2 @@
 ''' idseq_dag '''
-__version__ = "4.3.0"
+__version__ = "4.3.1"

--- a/idseq_dag/steps/nonhost_fastq.py
+++ b/idseq_dag/steps/nonhost_fastq.py
@@ -95,14 +95,17 @@ class PipelineStepNonhostFastq(PipelineStep):
         return new_fastqs
 
     @staticmethod
-    # Extract the original FASTQ header from the fasta file.
-    #
-    # Example fasta line:
-    # >family_nr:4070:family_nt:1903414:genus_nr:4107:genus_nt:586:species_nr:4081:species_nt:587:NR:ABI34274.1:NT:CP029736.1:A00111:123:HCMCTDMXX:1:1111:5575:4382/1
-    #
-    # We just want the part after NT:XX:
-    # We also split based on /1 and /2.
     def extract_header_from_line(line: str) -> Tuple[int, str, Set[int]]:
+        """
+        Extract the original FASTQ header from the fasta file.
+
+        Example fasta line:
+        >family_nr:4070:family_nt:1903414:genus_nr:4107:genus_nt:586:species_nr:4081:species_nt:587:NR:ABI34274.1:NT:CP029736.1:A00111:123:HCMCTDMXX:1:1111:5575:4382/1
+
+        We want to extract the taxids added upstream then we want only the part
+        after NT:XX as the read ID. We also split R1 and R2 reads based on /1
+        and /2.
+        """
         line = line.strip()
         if line[-2:] == "/1":
             read_index = 0

--- a/idseq_dag/steps/nonhost_fastq.py
+++ b/idseq_dag/steps/nonhost_fastq.py
@@ -52,7 +52,7 @@ class PipelineStepNonhostFastq(PipelineStep):
             output_fastqs = [
                 f"{os.path.dirname(fastq)}/{filename}__{os.path.basename(fastq.rstrip('.gz'))}"
                 for fastq in fastqs]
-            self.additional_output_files_visible.extend(output_fastqs)
+            self.additional_output_files_hidden.extend(output_fastqs)
 
         fastqs = self.unzip_files(fastqs)
 

--- a/idseq_dag/steps/nonhost_fastq.py
+++ b/idseq_dag/steps/nonhost_fastq.py
@@ -1,16 +1,30 @@
+import os
+
+from typing import Dict, Optional, Sequence, Set, Tuple
+
 import idseq_dag.util.command as command
 import idseq_dag.util.command_patterns as command_patterns
-import os
 
 from idseq_dag.engine.pipeline_step import PipelineStep
 from idseq_dag.util.cdhit_clusters import parse_clusters_file
-from idseq_dag.util.count import READ_COUNTING_MODE, ReadCountingMode, get_read_cluster_size
+from idseq_dag.util.count import READ_COUNTING_MODE, ReadCountingMode
 
 
 class PipelineStepNonhostFastq(PipelineStep):
     # Either one or two input read files can be supplied.
     # Works for both FASTA and FASTQ, although non-host FASTQ is more useful.
-    def run(self):
+    def run(self) -> None:
+        self.run_with_tax_ids(None, None)
+        self.run_with_tax_ids(set([11128]), "betacoronavirus")
+
+    def run_with_tax_ids(
+        self,
+        tax_ids: Optional[Set[int]],
+        filename: Optional[str]
+    ) -> None:
+        assert (tax_ids and filename) or not (
+            tax_ids or filename), 'Must be supplied with tax_ids and filename or neither'
+
         scratch_dir = os.path.join(self.output_dir_local, "scratch_nonhost_fastq")
         command.make_dirs(scratch_dir)
         self.nonhost_headers = [
@@ -32,10 +46,17 @@ class PipelineStepNonhostFastq(PipelineStep):
                 self.input_files_local[3][0]
             )
 
-        output_fastqs = self.output_files_local()
+        if filename is None:
+            output_fastqs = self.output_files_local()
+        else:
+            output_fastqs = [
+                f"{os.path.dirname(fastq)}/{filename}__{os.path.basename(fastq.rstrip('.gz'))}"
+                for fastq in fastqs]
+            self.additional_output_files_visible.extend(output_fastqs)
+
         fastqs = self.unzip_files(fastqs)
 
-        self.generate_nonhost_headers(nonhost_fasta, clusters_dict)
+        self.generate_nonhost_headers(nonhost_fasta, clusters_dict, tax_ids)
 
         for i in range(len(fastqs)):
             self.generate_nonhost_fastq(self.nonhost_headers[i], fastqs[i], output_fastqs[i])
@@ -46,7 +67,7 @@ class PipelineStepNonhostFastq(PipelineStep):
 
     @staticmethod
     # Unzip files with gunzip if necessary.
-    def unzip_files(fastqs):
+    def unzip_files(fastqs: Sequence[str]) -> Sequence[str]:
         new_fastqs = []
 
         for fastq in fastqs:
@@ -76,7 +97,7 @@ class PipelineStepNonhostFastq(PipelineStep):
     #
     # We just want the part after NT:XX:
     # We also split based on /1 and /2.
-    def extract_header_from_line(line):
+    def extract_header_from_line(line: str) -> Tuple[int, str, Set[int]]:
         line = line.strip()
         if line[-2:] == "/1":
             read_index = 0
@@ -92,9 +113,24 @@ class PipelineStepNonhostFastq(PipelineStep):
         nt_index = fragments.index("NT")
         header = ":".join(fragments[nt_index + 2:])
 
-        return read_index, header
+        annot_tax_ids = set(
+            int(fragments[fragments.index(annot_type) + 1])
+            for annot_type in [
+                "species_nt",
+                "species_nr",
+                "genus_nt",
+                "genus_nr",
+            ]
+        )
 
-    def generate_nonhost_headers(self, nonhost_fasta_file, clusters_dict=None):
+        return read_index, header, annot_tax_ids
+
+    def generate_nonhost_headers(
+        self,
+        nonhost_fasta_file: str,
+        clusters_dict: Dict[str, Tuple] = None,
+        tax_ids: Set[int] = None
+    ):
         with open(nonhost_fasta_file, "r") as input_file, \
                 open(self.nonhost_headers[0], "w") as output_file_0, \
                 open(self.nonhost_headers[1], "w") as output_file_1:
@@ -102,7 +138,9 @@ class PipelineStepNonhostFastq(PipelineStep):
                 # Assumes that the header line in the nonhost_fasta starts with ">"
                 if line[0] != ">":
                     continue
-                read_index, header = PipelineStepNonhostFastq.extract_header_from_line(line)
+                read_index, header, annot_tax_ids = PipelineStepNonhostFastq.extract_header_from_line(line)
+                if tax_ids and not tax_ids.intersection(annot_tax_ids):
+                    continue
                 output_file = output_file_0 if read_index == 0 else output_file_1
                 output_file.write(header + "\n")
                 if not clusters_dict:
@@ -113,7 +151,11 @@ class PipelineStepNonhostFastq(PipelineStep):
 
     @staticmethod
     # Use seqtk, which is orders of magnitude faster than Python for this particular step.
-    def generate_nonhost_fastq(nonhost_headers, fastq, output_file):
+    def generate_nonhost_fastq(
+        nonhost_headers: str,
+        fastq: str,
+        output_file: str
+    ) -> None:
         command.execute(
             command_patterns.ShellScriptCommand(
                 script=r'''seqtk subseq "$1" "$2" > "$3";''',

--- a/idseq_dag/steps/nonhost_fastq.py
+++ b/idseq_dag/steps/nonhost_fastq.py
@@ -15,7 +15,8 @@ class PipelineStepNonhostFastq(PipelineStep):
     # Works for both FASTA and FASTQ, although non-host FASTQ is more useful.
     def run(self) -> None:
         self.run_with_tax_ids(None, None)
-        self.run_with_tax_ids(set([11128]), "betacoronavirus")
+        if self.additional_attributes.get("use_taxon_whitelist"):
+            self.run_with_tax_ids(set([11128]), "betacoronavirus")
 
     def run_with_tax_ids(
         self,

--- a/idseq_dag/steps/nonhost_fastq.py
+++ b/idseq_dag/steps/nonhost_fastq.py
@@ -55,8 +55,8 @@ class PipelineStepNonhostFastq(PipelineStep):
             output_fastqs = self.output_files_local()
         else:
             output_fastqs = [
-                f"{os.path.dirname(fastq)}/{filename}__{os.path.basename(fastq.rstrip('.gz'))}"
-                for fastq in fastqs]
+                f"{os.path.dirname(fastq)}/{filename}__{os.path.basename(self.output_files_local()[i])}"
+                for i, fastq in enumerate(fastqs)]
             self.additional_output_files_hidden.extend(output_fastqs)
 
         fastqs = self.unzip_files(fastqs)

--- a/idseq_dag/steps/nonhost_fastq.py
+++ b/idseq_dag/steps/nonhost_fastq.py
@@ -16,7 +16,11 @@ class PipelineStepNonhostFastq(PipelineStep):
     def run(self) -> None:
         self.run_with_tax_ids(None, None)
         if self.additional_attributes.get("use_taxon_whitelist"):
-            self.run_with_tax_ids(set([11128]), "betacoronavirus")
+            betacoronaviruses = set([
+                2697049,  # SARS-CoV2
+                694002  # betacoronavirus genus
+            ])
+            self.run_with_tax_ids(betacoronaviruses, "betacoronavirus")
 
     def run_with_tax_ids(
         self,

--- a/idseq_dag/steps/run_cdhitdup.py
+++ b/idseq_dag/steps/run_cdhitdup.py
@@ -4,8 +4,8 @@ import idseq_dag.util.count as count
 import idseq_dag.util.fasta as fasta
 
 from idseq_dag.engine.pipeline_step import InputFileErrors, PipelineStep
-from idseq_dag.util.count import save_cdhit_cluster_sizes
 from idseq_dag.util.cdhit_clusters import parse_clusters_file
+from idseq_dag.util.count import save_cdhit_cluster_sizes
 
 
 class PipelineStepRunCDHitDup(PipelineStep):  # Deliberately not PipelineCountingStep


### PR DESCRIPTION
# Description

This builds on #282 for IDSEQ-2600. We want to enable a special download for coronavirus. This change will generate a new pair of fastqs by filtering on the given taxid for coronavirus. It is very similar to https://github.com/chanzuckerberg/idseq-dag/pull/162/files . 

Note the fastqs will be hidden from the list of downloads in the UI. I will be exposing them through a custom bulk download type. We can unhide them later as well if we want. 

# Version
- [x] I have increased the appropriate version number in https://github.com/chanzuckerberg/idseq-dag/blob/master/idseq_dag/__init__.py. Guidelines here: https://github.com/chanzuckerberg/idseq-dag/blob/pr-template/README.md#release-notes
- [x] I have added release notes for my new version to https://github.com/chanzuckerberg/idseq-dag/blob/master/README.md#release-notes
- [x] I will push a git tag after merging in the form `vX.Y.Z`

# Tests

- [x] I have verified that the pipeline still completes successfully:
    - [ ] for single-end inputs
    - [x] for paired-end inputs
    - [ ] for FASTQ inputs
    - [ ] for FASTA inputs.
- [x] I have validated that my change does not introduce any correctness bugs to existing output types.
- [x] I have validated that my change does not introduce significant performance regressions or I have discussed with the team that the benefits of the change are substantial enough that we're comfortable accepting the size of the measured performance penalty.

# Notes

* #162 matched only on species taxid. I feel it's better to match on genus as well for generality. Taxids are tax level specific so there is no risk of mismatch. 

* I added type checks for clarity
* #162 makes the output filename like `betacoronavirus__RR004_water_2_S23A_R1_001.fastq`, unlike the other fastqs for example `nonhost_R1.fastq`. It may be nice to make the others like `nonhost__RR004_water_2_S23A_R1_001.fastq`.
