### PR TITLE
Catch invalid gzip files in run_validate_input step

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,36 @@
 /*.egg-info
 # pycache
 **/__pycache__/*
+
+# Created by https://www.gitignore.io/api/macos
+# Edit at https://www.gitignore.io/?templates=macos
+
+### macOS ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+# End of https://www.gitignore.io/api/macos

--- a/README.md
+++ b/README.md
@@ -226,12 +226,11 @@ Changes to X or Y force recomputation of all results when a sample is rerun usin
 
 When releasing a new version, please add a Git tag of the form `vX.Y.Z`.
 
+- 4.2.3
+  - Validate input step now properly rejects invalid gzip files.
+
 - 4.2.2
-<<<<<<< HEAD
-  - Fix bug that allowed invalid .gz files to pass input file validation.
-=======
   - Fix bug in phylo tree creation for organisms with an unknown superkingdom.
->>>>>>> origin/master
 
 - 4.2.1
   - Switch RunAlignmentRemotely to distribute alignment chunks use AWS Batch instead of custom Autoscaling Group Logic logic

--- a/README.md
+++ b/README.md
@@ -226,6 +226,9 @@ Changes to X or Y force recomputation of all results when a sample is rerun usin
 
 When releasing a new version, please add a Git tag of the form `vX.Y.Z`.
 
+- 4.2.2
+  - Fix bug that allowed invalid .gz files to pass input file validation.
+
 - 4.2.1
   - Switch RunAlignmentRemotely to distribute alignment chunks use AWS Batch instead of custom Autoscaling Group Logic logic
 

--- a/idseq_dag/__init__.py
+++ b/idseq_dag/__init__.py
@@ -1,2 +1,2 @@
 ''' idseq_dag '''
-__version__ = "4.2.2"
+__version__ = "4.2.3"

--- a/idseq_dag/__init__.py
+++ b/idseq_dag/__init__.py
@@ -1,2 +1,2 @@
 ''' idseq_dag '''
-__version__ = "4.2.1"
+__version__ = "4.2.2"

--- a/idseq_dag/steps/run_validate_input.py
+++ b/idseq_dag/steps/run_validate_input.py
@@ -41,17 +41,17 @@ class PipelineStepRunValidateInput(PipelineStep):
                         cmd = command_patterns.SingleCommand(
                             cmd="gzip",
                             args=[
-                            "-d",
-                            input_file
+                                "-d",
+                                input_file
                             ],
-                            )
+                        )
                         command.execute(cmd)
                         input_files[i] = input_file_name
-                    except Exception as e:
+                    except Exception:
                         raise RuntimeError("Invalid gzip file")
 
                 # Validate and truncate the input file
-                tmp_file= f"{input_file_name}.tmp"
+                tmp_file = f"{input_file_name}.tmp"
                 try:
                     command.execute(
                         command_patterns.ShellScriptCommand(

--- a/idseq_dag/steps/run_validate_input.py
+++ b/idseq_dag/steps/run_validate_input.py
@@ -46,7 +46,10 @@ class PipelineStepRunValidateInput(PipelineStep):
                             ],
                         )
                         command.execute(cmd)
+                        # since we're now working with a decompressed file,
+                        # replace the input_file with the name minus .gz
                         input_files[i] = input_file_name
+                        input_file = input_file_name
                     except Exception:
                         raise RuntimeError("Invalid gzip file")
 
@@ -57,7 +60,7 @@ class PipelineStepRunValidateInput(PipelineStep):
                         command_patterns.ShellScriptCommand(
                             script=r'''cat "${input_file}" | cut -c -"$[max_line_length+1]" | head -n "${num_lines}" | awk -f "${awk_script_file}" -v max_line_length="${max_line_length}" > "${output_file}";''',
                             named_args={
-                                "input_file": input_file_name,
+                                "input_file": input_file,
                                 "awk_script_file": command.get_resource_filename("scripts/fastq-fasta-line-validation.awk"),
                                 "max_line_length": vc.MAX_LINE_LENGTH,
                                 "num_lines": num_lines,

--- a/idseq_dag/steps/run_validate_input.py
+++ b/idseq_dag/steps/run_validate_input.py
@@ -31,47 +31,43 @@ class PipelineStepRunValidateInput(PipelineStep):
         try:
             for i in range(num_inputs):
                 input_file = input_files[i]
-                splited_input_file_name, splited_input_file_ext = os.path.splitext(input_file)
+                input_file_name, input_file_ext = os.path.splitext(input_file)
 
                 num_lines = self.calc_max_num_lines(is_fastq, max_fragments)
 
                 # unzip if .gz file
-                if splited_input_file_ext == '.gz':
-                    input_files[i] = splited_input_file_name
+                if input_file_ext == '.gz':
                     try:
-                        command.execute(
-                            command_patterns.ShellScriptCommand(
-                                script=r'''gzip -dc "${input_file}" | cut -c -"$[max_line_length+1]" | head -n "${num_lines}" | awk -f "${awk_script_file}" -v max_line_length="${max_line_length}" > "${output_file}";''',
-                                named_args={
-                                    "input_file": input_file,
-                                    "awk_script_file": command.get_resource_filename("scripts/fastq-fasta-line-validation.awk"),
-                                    "max_line_length": vc.MAX_LINE_LENGTH,
-                                    "num_lines": num_lines,
-                                    "output_file": splited_input_file_name
-                                }
+                        cmd = command_patterns.SingleCommand(
+                            cmd="gzip",
+                            args=[
+                            "-d",
+                            input_file
+                            ],
                             )
+                        command.execute(cmd)
+                        input_files[i] = input_file_name
+                    except Exception as e:
+                        raise RuntimeError("Invalid gzip file")
+
+                # Validate and truncate the input file
+                tmp_file= f"{input_file_name}.tmp"
+                try:
+                    command.execute(
+                        command_patterns.ShellScriptCommand(
+                            script=r'''cat "${input_file}" | cut -c -"$[max_line_length+1]" | head -n "${num_lines}" | awk -f "${awk_script_file}" -v max_line_length="${max_line_length}" > "${output_file}";''',
+                            named_args={
+                                "input_file": input_file_name,
+                                "awk_script_file": command.get_resource_filename("scripts/fastq-fasta-line-validation.awk"),
+                                "max_line_length": vc.MAX_LINE_LENGTH,
+                                "num_lines": num_lines,
+                                "output_file": tmp_file
+                            }
                         )
-                    except:
-                        raise RuntimeError(f"Invalid fastq/fasta/gzip file")
-                else:
-                    # Validate and truncate the input file to keep behavior consistent with gz input files
-                    try:
-                        tmp_file = splited_input_file_name + ".tmp"
-                        command.execute(
-                            command_patterns.ShellScriptCommand(
-                                script=r'''cat "${input_file}" | cut -c -"$[max_line_length+1]" | head -n "${num_lines}" | awk -f "${awk_script_file}" -v max_line_length="${max_line_length}" > "${output_file}";''',
-                                named_args={
-                                    "input_file": input_file,
-                                    "awk_script_file": command.get_resource_filename("scripts/fastq-fasta-line-validation.awk"),
-                                    "max_line_length": vc.MAX_LINE_LENGTH,
-                                    "num_lines": num_lines,
-                                    "output_file": tmp_file
-                                }
-                            )
-                        )
-                        input_files[i] = tmp_file
-                    except:
-                        raise RuntimeError(f"Invalid fastq/fasta file")
+                    )
+                    input_files[i] = tmp_file
+                except:
+                    raise RuntimeError(f"Invalid fastq/fasta file")
 
             # keep a dictionary of the distribution of read lengths in the files
             self.summary_dict = {vc.BUCKET_TOO_SHORT: 0,


### PR DESCRIPTION
# Description
Raises a `RuntimeError` if an input file has a `.gz` extension but is not actually in gzip format. This will notify the user that they need to reupload the sample files.

# Version
- [x] I have increased the appropriate version number in https://github.com/chanzuckerberg/idseq-dag/blob/master/idseq_dag/__init__.py. Guidelines here: https://github.com/chanzuckerberg/idseq-dag/blob/pr-template/README.md#release-notes
- [x] I have added release notes for my new version to https://github.com/chanzuckerberg/idseq-dag/blob/master/README.md#release-notes
- [x] I will push a git tag after merging in the form `vX.Y.Z`

# Tests
- [x] I have verified that the pipeline still completes successfully:
    - [x] for single-end inputs
    - [x] for paired-end inputs
    - [x] for FASTQ inputs
    - [x] for FASTA inputs.
- [x] I have validated that my change does not introduce any correctness bugs to existing output types.
- [x] I have validated that my change does not introduce significant performance regressions or I have discussed with the team that the benefits of the change are substantial enough that we're comfortable accepting the size of the measured performance penalty.

# Notes
Inserts a simple `gzip -t` command before the actual decompression pipeline. If the command returns with a non-zero exit code, an exception is raised.
