### PR TITLE
Set superkingdom_name to None if the dag passes an empty string in Phylo Tree creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,9 @@ Changes to X or Y force recomputation of all results when a sample is rerun usin
 
 When releasing a new version, please add a Git tag of the form `vX.Y.Z`.
 
+- 4.2.2
+  - Fix bug in phylo tree creation for organisms with an unknown superkingdom.
+
 - 4.2.1
   - Switch RunAlignmentRemotely to distribute alignment chunks use AWS Batch instead of custom Autoscaling Group Logic logic
 

--- a/idseq_dag/__init__.py
+++ b/idseq_dag/__init__.py
@@ -1,2 +1,2 @@
 ''' idseq_dag '''
-__version__ = "4.2.1"
+__version__ = "4.2.2"

--- a/idseq_dag/steps/generate_phylo_tree.py
+++ b/idseq_dag/steps/generate_phylo_tree.py
@@ -31,6 +31,7 @@ class PipelineStepGeneratePhyloTree(PipelineStep):
         local_taxon_fasta_files = [f for input_item in self.input_files_local for f in input_item]
         taxid = self.additional_attributes["taxid"]
         reference_taxids = self.additional_attributes.get("reference_taxids", [taxid])  # Note: will only produce a result if species-level or below
+        # During phylo tree creation, if the taxon is in an unknown superkingdom then the k selected from k_config is supposed to be from the key None.
         superkingdom_name = self.additional_attributes.get("superkingdom_name") if self.additional_attributes.get("superkingdom_name") != '' else None
 
         # knsp3 has a command (MakeKSNP3infile) for making a ksnp3-compatible input file from a directory of fasta files.

--- a/idseq_dag/steps/generate_phylo_tree.py
+++ b/idseq_dag/steps/generate_phylo_tree.py
@@ -31,7 +31,7 @@ class PipelineStepGeneratePhyloTree(PipelineStep):
         local_taxon_fasta_files = [f for input_item in self.input_files_local for f in input_item]
         taxid = self.additional_attributes["taxid"]
         reference_taxids = self.additional_attributes.get("reference_taxids", [taxid])  # Note: will only produce a result if species-level or below
-        superkingdom_name = self.additional_attributes.get("superkingdom_name")
+        superkingdom_name = self.additional_attributes.get("superkingdom_name") if self.additional_attributes.get("superkingdom_name") != '' else None
 
         # knsp3 has a command (MakeKSNP3infile) for making a ksnp3-compatible input file from a directory of fasta files.
         # Before we can use the command, we symlink all fasta files to a dedicated directory.


### PR DESCRIPTION
# Description
During phylo tree creation, if the taxon is in an unknown superkingdom then the `k` selected from `k_config` is supposed to be from the key `None`. However the dag passes an empty string, and `'' != None` in Python. This sets `superkingdom_name` to `None` properly.

# Version
- [x] I have increased the appropriate version number in https://github.com/chanzuckerberg/idseq-dag/blob/master/idseq_dag/__init__.py. Guidelines here: https://github.com/chanzuckerberg/idseq-dag/blob/pr-template/README.md#release-notes
- [x] I have added release notes for my new version to https://github.com/chanzuckerberg/idseq-dag/blob/master/README.md#release-notes
- [x] I will push a git tag after merging in the form `vX.Y.Z`

# Tests
- [x] I have verified that the pipeline still completes successfully:
    - [x] for single-end inputs
    - [x] for paired-end inputs
    - [x] for FASTQ inputs
    - [x] for FASTA inputs.
- [x] I have validated that my change does not introduce any correctness bugs to existing output types.
- [x] I have validated that my change does not introduce significant performance regressions or I have discussed with the team that the benefits of the change are substantial enough that we're comfortable accepting the size of the measured performance penalty.

# Notes
*Optional observations, comments or explanations.*
