### PR TITLE
Remove use_taxon_whitelist requirement for betacoronavirus fastqs

### DIFF
--- a/idseq_dag/steps/nonhost_fastq.py
+++ b/idseq_dag/steps/nonhost_fastq.py
@@ -15,12 +15,13 @@ class PipelineStepNonhostFastq(PipelineStep):
     # Works for both FASTA and FASTQ, although non-host FASTQ is more useful.
     def run(self) -> None:
         self.run_with_tax_ids(None, None)
-        if self.additional_attributes.get("use_taxon_whitelist"):
-            betacoronaviruses = {
-                2697049,  # SARS-CoV2
-                694002,  # betacoronavirus genus
-            }
-            self.run_with_tax_ids(betacoronaviruses, "betacoronavirus")
+        # TODO: (gdingle): Generate taxon-specific downloads in idseq-web at
+        # time of download. See https://jira.czi.team/browse/IDSEQ-2599.
+        betacoronaviruses = {
+            2697049,  # SARS-CoV2
+            694002,  # betacoronavirus genus
+        }
+        self.run_with_tax_ids(betacoronaviruses, "betacoronavirus")
 
     def run_with_tax_ids(
         self,
@@ -43,10 +44,9 @@ class PipelineStepNonhostFastq(PipelineStep):
         nonhost_fasta = self.input_files_local[1][0]
 
         clusters_dict = None
-        if READ_COUNTING_MODE == ReadCountingMode.COUNT_ALL \
-                and self.additional_attributes.get("use_taxon_whitelist"):
+        if READ_COUNTING_MODE == ReadCountingMode.COUNT_ALL and tax_ids:
             # TODO: (gdingle): Show all duplicate reads, not just if
-            # use_taxon_whitelist. See https://jira.czi.team/browse/IDSEQ-2598.
+            # taxids. See https://jira.czi.team/browse/IDSEQ-2598.
             # NOTE: this will load the set of all original read headers, which
             # could be several GBs in the worst case.
             clusters_dict = parse_clusters_file(


### PR DESCRIPTION
# Description

Per Biohub request, this removes the requirement that use_taxon_whitelist is true for a run to generate betacoronavirus fastqs. This will have the effect of generating those files for all runs, although only Biohub users will have access to them in bulk downloads.

Based on two previous runs, with and without betacoronavirus fastqs, this change will add 1 min of runtime to the experimental stage. Most of the additional time will be needed anyway if we do https://jira.czi.team/browse/IDSEQ-2598. 

# Version
- [x] I have increased the appropriate version number in https://github.com/chanzuckerberg/idseq-dag/blob/master/idseq_dag/__init__.py. Guidelines here: https://github.com/chanzuckerberg/idseq-dag/blob/pr-template/README.md#release-notes
- [x] I have added release notes for my new version to https://github.com/chanzuckerberg/idseq-dag/blob/master/README.md#release-notes
- [x] I will push a git tag after merging in the form `vX.Y.Z`

# Tests
- [x] I have verified that the pipeline still completes successfully:
    - [ ] for single-end inputs
    - [x] for paired-end inputs
    - [x] for FASTQ inputs
    - [ ] for FASTA inputs.
- [x] I have validated that my change does not introduce any correctness bugs to existing output types.
- [x] I have validated that my change does not introduce significant performance regressions or I have discussed with the team that the benefits of the change are substantial enough that we're comfortable accepting the size of the measured performance penalty.
