### PR TITLE
Prod hotfix

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,9 @@ Changes to X or Y force recomputation of all results when a sample is rerun usin
 
 When releasing a new version, please add a Git tag of the form `vX.Y.Z`.
 
+- 4.3.1
+  - Add compatibility for idseq-web environment name 'production'
+
 - 4.3.0
   - Generate betacoronavirus fastq files for user download if use_taxon_whitelist is specified in the DAG.
 

--- a/idseq_dag/__init__.py
+++ b/idseq_dag/__init__.py
@@ -1,2 +1,2 @@
 ''' idseq_dag '''
-__version__ = "4.3.0"
+__version__ = "4.3.1"

--- a/idseq_dag/steps/run_alignment_remotely.py
+++ b/idseq_dag/steps/run_alignment_remotely.py
@@ -374,6 +374,9 @@ class PipelineStepRunAlignmentRemotely(PipelineStep):
 
         # TODO: (tmorse) remove compat hack https://jira.czi.team/browse/IDSEQ-2568
         deployment_environment = os.environ.get("DEPLOYMENT_ENVIRONMENT", self.additional_attributes.get("environment"))
+        # TODO: (tmorse) remove compat hack https://jira.czi.team/browse/IDSEQ-2568
+        if deployment_environment == "production": 
+            deployment_environment = "prod"
         priority_name = os.environ.get("PRIORITY_NAME", "normal")
         provisioning_model = os.environ.get("PROVISIONING_MODEL", "EC2")
 

--- a/idseq_dag/steps/run_alignment_remotely.py
+++ b/idseq_dag/steps/run_alignment_remotely.py
@@ -375,7 +375,7 @@ class PipelineStepRunAlignmentRemotely(PipelineStep):
         # TODO: (tmorse) remove compat hack https://jira.czi.team/browse/IDSEQ-2568
         deployment_environment = os.environ.get("DEPLOYMENT_ENVIRONMENT", self.additional_attributes.get("environment"))
         # TODO: (tmorse) remove compat hack https://jira.czi.team/browse/IDSEQ-2568
-        if deployment_environment == "production": 
+        if deployment_environment == "production":
             deployment_environment = "prod"
         priority_name = os.environ.get("PRIORITY_NAME", "normal")
         provisioning_model = os.environ.get("PROVISIONING_MODEL", "EC2")


### PR DESCRIPTION
# Description

Maps the `production` name to prod to fix a compatibility bug in prod.

# Version
- [X] I have increased the appropriate version number in https://github.com/chanzuckerberg/idseq-dag/blob/master/idseq_dag/__init__.py. Guidelines here: https://github.com/chanzuckerberg/idseq-dag/blob/pr-template/README.md#release-notes
- [X] I have added release notes for my new version to https://github.com/chanzuckerberg/idseq-dag/blob/master/README.md#release-notes
- [X] I will push a git tag after merging in the form `vX.Y.Z`

# Tests
- [ ] I have verified that the pipeline still completes successfully:
    - [ ] for single-end inputs
    - [ ] for paired-end inputs
    - [ ] for FASTQ inputs
    - [ ] for FASTA inputs.
- [ ] I have validated that my change does not introduce any correctness bugs to existing output types.
- [ ] I have validated that my change does not introduce significant performance regressions or I have discussed with the team that the benefits of the change are substantial enough that we're comfortable accepting the size of the measured performance penalty.

# Notes
*Optional observations, comments or explanations.*
