### PR TITLE
Remove [Datadog] from logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,9 @@ Changes to X or Y force recomputation of all results when a sample is rerun usin
 
 When releasing a new version, please add a Git tag of the form `vX.Y.Z`.
 
+- 4.3.2
+  - Clean up log statement for AMR bug .
+
 - 4.3.1
   - Add compatibility for idseq-web environment name 'production'
 

--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ Changes to X or Y force recomputation of all results when a sample is rerun usin
 
 When releasing a new version, please add a Git tag of the form `vX.Y.Z`.
 
-- 4.3.2
+- 4.3.3
   - Clean up log statement for AMR bug.
 
 - 4.3.1

--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ Changes to X or Y force recomputation of all results when a sample is rerun usin
 When releasing a new version, please add a Git tag of the form `vX.Y.Z`.
 
 - 4.3.2
-  - Clean up log statement for AMR bug .
+  - Clean up log statement for AMR bug.
 
 - 4.3.1
   - Add compatibility for idseq-web environment name 'production'

--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ Changes to X or Y force recomputation of all results when a sample is rerun usin
 
 When releasing a new version, please add a Git tag of the form `vX.Y.Z`.
 
-- 4.3.3
+- 4.3.2
   - Clean up log statement for AMR bug.
 
 - 4.3.1

--- a/idseq_dag/__init__.py
+++ b/idseq_dag/__init__.py
@@ -1,2 +1,2 @@
 ''' idseq_dag '''
-__version__ = "4.3.2"
+__version__ = "4.3.3"

--- a/idseq_dag/__init__.py
+++ b/idseq_dag/__init__.py
@@ -1,2 +1,2 @@
 ''' idseq_dag '''
-__version__ = "4.3.1"
+__version__ = "4.3.2"

--- a/idseq_dag/__init__.py
+++ b/idseq_dag/__init__.py
@@ -1,2 +1,2 @@
 ''' idseq_dag '''
-__version__ = "4.3.3"
+__version__ = "4.3.2"

--- a/idseq_dag/steps/run_srst2.py
+++ b/idseq_dag/steps/run_srst2.py
@@ -236,7 +236,7 @@ class PipelineStepRunSRST2(PipelineStep):
                 # because there were typos in allele names in ARGannot_r2.fasta that caused mismatches with argannot_genome.bed.
                 # Log an error. The following line will crash the pipeline step, which is intended.
                 # We prefer failing the pipeline step to showing incorrect or missing data while failing silently to the user.
-                log.write(f"[Datadog] AmrAlleleMismatchError: {row.allele} (from ARGannot_r2.fasta) could not be found in argannot_genome.bed")
+                log.write(f"AmrAlleleMismatchError: {row.allele} (from ARGannot_r2.fasta) could not be found in argannot_genome.bed")
 
             reads_for_allele = rpm_df[rpm_df["allele"] == row.allele]["reads"].values[0]
             total_reads_list.append(reads_for_allele)


### PR DESCRIPTION
# Description
Remove the `[Datadog]` statement from our logs now that we are no longer forwarding them to Datadog for alerts. (Essentially reverting https://github.com/chanzuckerberg/idseq-dag/pull/253. See also https://github.com/chanzuckerberg/idseq-web/pull/3281)

# Version
- [x] I have increased the appropriate version number in https://github.com/chanzuckerberg/idseq-dag/blob/master/idseq_dag/__init__.py. Guidelines here: https://github.com/chanzuckerberg/idseq-dag/blob/pr-template/README.md#release-notes
- [x] I have added release notes for my new version to https://github.com/chanzuckerberg/idseq-dag/blob/master/README.md#release-notes
- [x] I will push a git tag after merging in the form `vX.Y.Z`