### PR TITLE
IDSEQ-2671: Hold cluster size cache lock longer

### DIFF
--- a/idseq_dag/util/count.py
+++ b/idseq_dag/util/count.py
@@ -169,15 +169,15 @@ def load_cdhit_cluster_sizes(filename):
 def save_cdhit_cluster_sizes(filename, cdhit_clusters):
     with _CDHIT_CLUSTER_SIZES_LOCK:
         _CDHIT_CLUSTER_SIZES_CACHE[filename] = {}
-    with open(filename, "w") as tsv:
-        for read_id, clusters in cdhit_clusters.items():
-            cluster_size = clusters[0]
-            assert cluster_size != None, f"""If this happened, probably
-            dedup1.fa output of cdhit contains reads that are not mentioned in
-            dedup1.fa.clstr.  Perhaps set cluster_size=1 for those reads but
-            also follow up with cdhit.  Read id: {read_id}"""
-            tsv.write(f"{cluster_size}\t{read_id}\n")
-            _CDHIT_CLUSTER_SIZES_CACHE[filename][read_id] = cluster_size
+        with open(filename, "w") as tsv:
+            for read_id, clusters in cdhit_clusters.items():
+                cluster_size = clusters[0]
+                assert cluster_size != None, f"""If this happened, probably
+                dedup1.fa output of cdhit contains reads that are not mentioned in
+                dedup1.fa.clstr.  Perhaps set cluster_size=1 for those reads but
+                also follow up with cdhit.  Read id: {read_id}"""
+                tsv.write(f"{cluster_size}\t{read_id}\n")
+                _CDHIT_CLUSTER_SIZES_CACHE[filename][read_id] = cluster_size
 
 
 def reads(local_file_path):


### PR DESCRIPTION
# Description
This is a possible fix to the issue. See explanation in https://jira.czi.team/browse/IDSEQ-2671 . 

I'm still not sure when `load_cdhit_cluster_sizes` and `save_cdhit_cluster_sizes` would ever be called such that `_CDHIT_CLUSTER_SIZES_CACHE` would be shared. Only the prior existence of `_CDHIT_CLUSTER_SIZES_LOCK` makes me believe this happens.

# Version
- [ ] I have increased the appropriate version number in https://github.com/chanzuckerberg/idseq-dag/blob/master/idseq_dag/__init__.py. Guidelines here: https://github.com/chanzuckerberg/idseq-dag/blob/pr-template/README.md#release-notes
- [ ] I have added release notes for my new version to https://github.com/chanzuckerberg/idseq-dag/blob/master/README.md#release-notes
- [ ] I will push a git tag after merging in the form `vX.Y.Z`

# Tests
- [ ] I have verified that the pipeline still completes successfully:
    - [ ] for single-end inputs
    - [ ] for paired-end inputs
    - [ ] for FASTQ inputs
    - [ ] for FASTA inputs.
- [ ] I have validated that my change does not introduce any correctness bugs to existing output types.
- [ ] I have validated that my change does not introduce significant performance regressions or I have discussed with the team that the benefits of the change are substantial enough that we're comfortable accepting the size of the measured performance penalty.

# Notes
*Optional observations, comments or explanations.*
