### PR TITLE
Increase Alignment Chunk Size and Decrese Chunks in Flight

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,10 @@ Changes to X or Y force recomputation of all results when a sample is rerun usin
 
 When releasing a new version, please add a Git tag of the form `vX.Y.Z`.
 
+- 4.3.8
+  - Increase gsnap and rapsearch2 chunk size by 4x to reduce the number of batch jobs generated
+  - Decreased alignment max chunks in flight from 32 to 16 to better balance chunk execution between large and small jobs
+
 - 4.3.7
   - Remove old alignment code
   - Remove sqlite

--- a/idseq_dag/__init__.py
+++ b/idseq_dag/__init__.py
@@ -1,2 +1,2 @@
 ''' idseq_dag '''
-__version__ = "4.3.7"
+__version__ = "4.3.8"

--- a/idseq_dag/steps/run_alignment_remotely.py
+++ b/idseq_dag/steps/run_alignment_remotely.py
@@ -28,11 +28,11 @@ from idseq_dag.util.trace_lock import TraceLock
 from idseq_dag.util.lineage import DEFAULT_BLACKLIST_S3, DEFAULT_WHITELIST_S3
 from idseq_dag.util.m8 import NT_MIN_ALIGNMENT_LEN
 
-MAX_CHUNKS_IN_FLIGHT = 32
+MAX_CHUNKS_IN_FLIGHT = 16
 CHUNK_MAX_ATTEMPTS = 3
 CHUNK_ATTEMPT_TIMEOUT = 60 * 60 * 3  # 3 hours
-GSNAP_CHUNK_SIZE = 60000
-RAPSEARCH_CHUNK_SIZE = 80000
+GSNAP_CHUNK_SIZE = 240000
+RAPSEARCH_CHUNK_SIZE = 320000
 
 
 def get_batch_job_desc_bucket():


### PR DESCRIPTION
# Description

  - Increase gsnap and rapsearch2 chunk size by 4x to reduce the number of batch jobs generated
  - Decreased alignment max chunks in flight from 32 to 16 to better balance chunk execution between large and small jobs

# Version
- [X] I have increased the appropriate version number in https://github.com/chanzuckerberg/idseq-dag/blob/master/idseq_dag/__init__.py. Guidelines here: https://github.com/chanzuckerberg/idseq-dag/blob/pr-template/README.md#release-notes
- [X] I have added release notes for my new version to https://github.com/chanzuckerberg/idseq-dag/blob/master/README.md#release-notes
- [X] I will push a git tag after merging in the form `vX.Y.Z`

# Tests
- [X] I have verified that the pipeline still completes successfully:
    - [ ] for single-end inputs
    - [X] for paired-end inputs
    - [X] for FASTQ inputs
    - [ ] for FASTA inputs.
- [X] I have validated that my change does not introduce any correctness bugs to existing output types.
- [X] I have validated that my change does not introduce significant performance regressions or I have discussed with the team that the benefits of the change are substantial enough that we're comfortable accepting the size of the measured performance penalty.