### PR TITLE
Add nonunique reads to unmapped fasta for download

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,9 @@ Changes to X or Y force recomputation of all results when a sample is rerun usin
 
 When releasing a new version, please add a Git tag of the form `vX.Y.Z`.
 
+- 4.6.0
+  - Include non-unique reads in unidentified fastas for download.
+
 - 4.5.0
   - Include non-unique reads in non-host fastqs for download.
 

--- a/examples/generate_annotated_fasta.json
+++ b/examples/generate_annotated_fasta.json
@@ -21,7 +21,9 @@
     ],
     "cdhitdup_out": [
       "dedup1.fa.clstr",
-      "dedup1.fa",
+      "dedup1.fa"
+    ],
+    "cdhitdup_cluster_sizes": [
       "cdhitdup_cluster_sizes.tsv"
     ],
     "annotated_out": [
@@ -35,7 +37,8 @@
         "gsnap_filter_out",
         "gsnap_out",
         "rapsearch2_out",
-        "cdhitdup_out"
+        "cdhitdup_out",
+        "cdhitdup_cluster_sizes"
       ],
       "out": "annotated_out",
       "class": "PipelineStepGenerateAnnotatedFasta",
@@ -55,6 +58,9 @@
       "s3_dir": "s3://idseq-samples-prod/samples/833/45285/results/4.0"
     },
     "cdhitdup_out": {
+      "s3_dir": "s3://idseq-samples-prod/samples/833/45285/results/4.0"
+    },
+    "cdhitdup_cluster_sizes": {
       "s3_dir": "s3://idseq-samples-prod/samples/833/45285/results/4.0"
     }
   }

--- a/examples/generate_annotated_fasta.json
+++ b/examples/generate_annotated_fasta.json
@@ -21,7 +21,8 @@
     ],
     "cdhitdup_out": [
       "dedup1.fa.clstr",
-      "dedup1.fa"
+      "dedup1.fa",
+      "cdhitdup_cluster_sizes.tsv"
     ],
     "annotated_out": [
       "annotated_merged.fa",

--- a/examples/generate_annotated_fasta.json
+++ b/examples/generate_annotated_fasta.json
@@ -33,7 +33,8 @@
       "in": [
         "gsnap_filter_out",
         "gsnap_out",
-        "rapsearch2_out"
+        "rapsearch2_out",
+        "cdhitdup_out"
       ],
       "out": "annotated_out",
       "class": "PipelineStepGenerateAnnotatedFasta",

--- a/examples/generate_annotated_fasta.json
+++ b/examples/generate_annotated_fasta.json
@@ -1,0 +1,59 @@
+{
+  "name": "generate_annotated_fasta",
+  "output_dir_s3": "s3://idseq-samples-development/gdingle/generate_annotated_fasta",
+  "targets": {
+    "gsnap_filter_out": [
+      "gsnap_filter_1.fa",
+      "gsnap_filter_2.fa",
+      "gsnap_filter_merged.fa"
+    ],
+    "gsnap_out": [
+      "gsnap.m8",
+      "gsnap.deduped.m8",
+      "gsnap.hitsummary.tab",
+      "gsnap_counts_with_dcr.json"
+    ],
+    "rapsearch2_out": [
+      "rapsearch2.m8",
+      "rapsearch2.deduped.m8",
+      "rapsearch2.hitsummary.tab",
+      "rapsearch2_counts_with_dcr.json"
+    ],
+    "cdhitdup_out": [
+      "dedup1.fa.clstr",
+      "dedup1.fa"
+    ],
+    "annotated_out": [
+      "annotated_merged.fa",
+      "unidentified.fa"
+    ]
+  },
+  "steps": [
+    {
+      "in": [
+        "gsnap_filter_out",
+        "gsnap_out",
+        "rapsearch2_out"
+      ],
+      "out": "annotated_out",
+      "class": "PipelineStepGenerateAnnotatedFasta",
+      "module": "idseq_dag.steps.generate_annotated_fasta",
+      "additional_files": {},
+      "additional_attributes": {}
+    }
+  ],
+  "given_targets": {
+    "gsnap_filter_out": {
+      "s3_dir": "s3://idseq-samples-prod/samples/833/45285/results/4.0"
+    },
+    "gsnap_out": {
+      "s3_dir": "s3://idseq-samples-prod/samples/833/45285/results/4.0"
+    },
+    "rapsearch2_out": {
+      "s3_dir": "s3://idseq-samples-prod/samples/833/45285/results/4.0"
+    },
+    "cdhitdup_out": {
+      "s3_dir": "s3://idseq-samples-prod/samples/833/45285/results/4.0"
+    }
+  }
+}

--- a/idseq_dag/__init__.py
+++ b/idseq_dag/__init__.py
@@ -1,2 +1,2 @@
 ''' idseq_dag '''
-__version__ = "4.5.0"
+__version__ = "4.6.0"

--- a/idseq_dag/steps/generate_annotated_fasta.py
+++ b/idseq_dag/steps/generate_annotated_fasta.py
@@ -24,10 +24,10 @@ class PipelineStepGenerateAnnotatedFasta(PipelineCountingStep):
         gsnap_m8 = self.input_files_local[1][1]
         rapsearch2_m8 = self.input_files_local[2][1]
 
-        if len(self.input_files_local) == 4 \
-                and len(self.input_files_local[3]) == 3:
+        # See app/lib/dags/postprocess.json.jbuilder in idseq-web
+        if len(self.input_files_local) == 5:
             assert READ_COUNTING_MODE == ReadCountingMode.COUNT_ALL
-            cdhitdup_clusters, deduped_fasta, _ = self.input_files_local[3]
+            cdhitdup_clusters, deduped_fasta = self.input_files_local[3]
             # NOTE: this will load the set of all original read headers, which
             # could be several GBs in the worst case.
             clusters_dict = parse_clusters_file(cdhitdup_clusters, deduped_fasta)

--- a/idseq_dag/steps/generate_annotated_fasta.py
+++ b/idseq_dag/steps/generate_annotated_fasta.py
@@ -96,8 +96,18 @@ class PipelineStepGenerateAnnotatedFasta(PipelineCountingStep):
                 output_file.write(read.sequence + "\n")
 
                 if clusters_dict:
-                    # get inner part of '>NR::NT::NB501961:14:HM7TLBGX2:4:23511:18703:20079/2'
-                    key = read.header.split(UNMAPPED_HEADER_PREFIX)[1].split('/')[0]
-                    other_headers = clusters_dict[key][1:]  # key should always be present
-                    for other_header in other_headers:
+                    # get inner part of header like
+                    # '>NR::NT::NB501961:14:HM7TLBGX2:4:23511:18703:20079/2'
+                    line = read.header
+                    header_suffix = ""
+                    if line[-2:-1] == "/":  # /1 or /2
+                        line, header_suffix = line[:-2], line[-2:]
+                        assert header_suffix in ('/1', '/2')
+                        assert len(read.header) == len(line) + len(header_suffix)
+
+                    key = line.split(UNMAPPED_HEADER_PREFIX)[1]
+                    other_keys = clusters_dict[key][1:]  # key should always be present
+                    for other_key in other_keys:
+                        other_header = UNMAPPED_HEADER_PREFIX + other_key + header_suffix
                         output_file.write(other_header + "\n")
+                        output_file.write(read.sequence + "\n")  # write duplicate seq


### PR DESCRIPTION
# Description

Like #299 , to be consistent with reads reported after pipeline version 4, we make this fasta include duplicate reads extracted upstream by cdhitdup. It is used in bulk downloads and elsewhere. 

For the change to take effect in prod, it will need a change to dag generation in idseq-web.

# Version
- [x] I have increased the appropriate version number in https://github.com/chanzuckerberg/idseq-dag/blob/master/idseq_dag/__init__.py. Guidelines here: https://github.com/chanzuckerberg/idseq-dag/blob/pr-template/README.md#release-notes
- [x] I have added release notes for my new version to https://github.com/chanzuckerberg/idseq-dag/blob/master/README.md#release-notes
- [x] I will push a git tag after merging in the form `vX.Y.Z`

# Tests

Run before and after, see same file sizes for sample that has no dupes. 

Run with and without clusters_dict, see same file sizes for sample that has no dupes. 

- [x] I have verified that the pipeline still completes successfully:
    - [ ] for single-end inputs
    - [ ] for paired-end inputs
    - [x] for FASTQ inputs
    - [ ] for FASTA inputs.
- [x] I have validated that my change does not introduce any correctness bugs to existing output types.
- [x] I have validated that my change does not introduce significant performance regressions or I have discussed with the team that the benefits of the change are substantial enough that we're comfortable accepting the size of the measured performance penalty.

# Notes

See https://jira.czi.team/browse/IDSEQ-2726