### PR TITLE
Disable reusing previous chunks when re-running alignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,9 @@ Changes to X or Y force recomputation of all results when a sample is rerun usin
 
 When releasing a new version, please add a Git tag of the form `vX.Y.Z`.
 
+- 4.4.1
+  - Disable reusing previous chunks when re-running alignment. This was casing an error because the input to this step is non-determinsitic and cdhitdup requires all reads from the input to be present in the `cdhit_cluster_sizes` file.
+
 - 4.4
   - When assigning contigs to their best-matching accessions, prioritize the accession that has the most best matches across all contigs when resolving ties.
 

--- a/idseq_dag/__init__.py
+++ b/idseq_dag/__init__.py
@@ -1,2 +1,2 @@
 ''' idseq_dag '''
-__version__ = "4.4"
+__version__ = "4.4.1"

--- a/idseq_dag/steps/run_alignment_remotely.py
+++ b/idseq_dag/steps/run_alignment_remotely.py
@@ -197,12 +197,12 @@ class PipelineStepRunAlignmentRemotely(PipelineStep):
                     target=PipelineStepRunAlignmentRemotely.run_chunk_wrapper,
                     kwargs={
                         'chunks_in_flight_semaphore': self.chunks_in_flight_semaphore,
-                        'chunk_output_files': chunk_output_files, 
+                        'chunk_output_files': chunk_output_files,
                         'n': n,
                         'mutex': mutex,
                         'target': self.run_chunk,
                         'kwargs': {
-                            'part_suffix': part_suffix, 
+                            'part_suffix': part_suffix,
                             'input_files': chunk_input_files,
                             # This must be disabled because cdhit dup requires chunks to be computed based on
                             #  current input, which is non-deterministic between runs.

--- a/idseq_dag/steps/run_alignment_remotely.py
+++ b/idseq_dag/steps/run_alignment_remotely.py
@@ -195,12 +195,20 @@ class PipelineStepRunAlignmentRemotely(PipelineStep):
                 self.check_for_errors(mutex, chunk_output_files, input_chunks, self.alignment_algorithm)
                 t = threading.Thread(
                     target=PipelineStepRunAlignmentRemotely.run_chunk_wrapper,
-                    args=[
-                        self.chunks_in_flight_semaphore, chunk_output_files, n, mutex, self.run_chunk,
-                        [
-                            part_suffix, chunk_input_files, True
-                        ]
-                    ])
+                    kwargs={
+                        'chunks_in_flight_semaphore': self.chunks_in_flight_semaphore,
+                        'chunk_output_files': chunk_output_files, 
+                        'n': n,
+                        'mutex': mutex,
+                        'target': self.run_chunk,
+                        'kwargs': {
+                            'part_suffix': part_suffix, 
+                            'input_files': chunk_input_files,
+                            # This must be disabled because cdhit dup requires chunks to be computed based on
+                            #  current input, which is non-deterministic between runs.
+                            'lazy_run': False,
+                        },
+                    })
                 t.start()
                 chunk_threads.append(t)
 
@@ -324,10 +332,10 @@ class PipelineStepRunAlignmentRemotely(PipelineStep):
                             shutil.copyfileobj(fd, outf)
 
     @staticmethod
-    def run_chunk_wrapper(chunks_in_flight_semaphore, chunk_output_files, n, mutex, target, args):
+    def run_chunk_wrapper(chunks_in_flight_semaphore, chunk_output_files, n, mutex, target, kwargs):
         result = "error"
         try:
-            result = target(*args)
+            result = target(**kwargs)
         except:
             with mutex:
                 log.write(traceback.format_exc())


### PR DESCRIPTION
# Description

Disable reusing previous chunks when re-running alignment. This was casing an error because the input to this step is non-determinsitic and cdhitdup requires all reads from the input to be present in the `cdhit_cluster_sizes` file.

# Version
- [X] I have increased the appropriate version number in https://github.com/chanzuckerberg/idseq-dag/blob/master/idseq_dag/__init__.py. Guidelines here: https://github.com/chanzuckerberg/idseq-dag/blob/pr-template/README.md#release-notes
- [X] I have added release notes for my new version to https://github.com/chanzuckerberg/idseq-dag/blob/master/README.md#release-notes
- [X] I will push a git tag after merging in the form `vX.Y.Z`

# Tests
- [x] I have verified that the pipeline still completes successfully:
    - [ ] for single-end inputs
    - [x] for paired-end inputs
    - [ ] for FASTQ inputs
    - [x] for FASTA inputs.
- [x] I have validated that my change does not introduce any correctness bugs to existing output types.
- [x] I have validated that my change does not introduce significant performance regressions or I have discussed with the team that the benefits of the change are substantial enough that we're comfortable accepting the size of the measured performance penalty.