### PR TITLE
Determinism

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,10 @@ Changes to X or Y force recomputation of all results when a sample is rerun usin
 
 When releasing a new version, please add a Git tag of the form `vX.Y.Z`.
 
+- 4.4.2
+  - Make the pipeline deterministic with hard coded seeded pseudo random number generation
+  - Re-enable reusing previous chunks when re-running alignment.
+
 - 4.4.1
   - Disable reusing previous chunks when re-running alignment. This was casing an error because the input to this step is non-determinsitic and cdhitdup requires all reads from the input to be present in the `cdhit_cluster_sizes` file.
 

--- a/idseq_dag/__init__.py
+++ b/idseq_dag/__init__.py
@@ -1,2 +1,2 @@
 ''' idseq_dag '''
-__version__ = "4.4.1"
+__version__ = "4.4.2"

--- a/idseq_dag/steps/run_alignment_remotely.py
+++ b/idseq_dag/steps/run_alignment_remotely.py
@@ -204,9 +204,7 @@ class PipelineStepRunAlignmentRemotely(PipelineStep):
                         'kwargs': {
                             'part_suffix': part_suffix,
                             'input_files': chunk_input_files,
-                            # This must be disabled because cdhit dup requires chunks to be computed based on
-                            #  current input, which is non-deterministic between runs.
-                            'lazy_run': False,
+                            'lazy_run': True,
                         },
                     })
                 t.start()

--- a/idseq_dag/steps/run_bowtie2.py
+++ b/idseq_dag/steps/run_bowtie2.py
@@ -64,7 +64,8 @@ class PipelineStepRunBowtie2(PipelineCountingStep):
             '--very-sensitive-local', '-S', output_sam_file
         ]
 
-        # FIXME: we want to move towards a general randomness solution in which
+        # FIXME: https://jira.czi.team/browse/IDSEQ-2738 
+        #  We want to move towards a general randomness solution in which
         #  all randomness is seeded based on the content of the original input.
         #  This is currently introducing non-determinism and hard coding
         #  an arbitrary seed here shouldn't impact correctness.

--- a/idseq_dag/steps/run_bowtie2.py
+++ b/idseq_dag/steps/run_bowtie2.py
@@ -64,7 +64,7 @@ class PipelineStepRunBowtie2(PipelineCountingStep):
             '--very-sensitive-local', '-S', output_sam_file
         ]
 
-        # FIXME: https://jira.czi.team/browse/IDSEQ-2738 
+        # FIXME: https://jira.czi.team/browse/IDSEQ-2738
         #  We want to move towards a general randomness solution in which
         #  all randomness is seeded based on the content of the original input.
         #  This is currently introducing non-determinism and hard coding

--- a/idseq_dag/steps/run_bowtie2.py
+++ b/idseq_dag/steps/run_bowtie2.py
@@ -64,12 +64,11 @@ class PipelineStepRunBowtie2(PipelineCountingStep):
             '--very-sensitive-local', '-S', output_sam_file
         ]
 
-        seed = self.additional_attributes.get("random_seed")
-        if seed:
-            bowtie2_params.extend(['--seed', str(seed)])
-        else:
-            # Seed option won't work with -p threading option.
-            bowtie2_params.extend(['-p', str(multiprocessing.cpu_count())])
+        # FIXME: we want to move towards a general randomness solution in which
+        #  all randomness is seeded based on the content of the original input.
+        #  This is currently introducing non-determinism and hard coding
+        #  an arbitrary seed here shouldn't impact correctness.
+        bowtie2_params.extend(['--seed', '4'])  # chosen by fair dice role, guaranteed to be random
 
         if len(input_fas) == 2:
             bowtie2_params.extend(['-1', input_fas[0], '-2', input_fas[1]])

--- a/idseq_dag/steps/run_subsample.py
+++ b/idseq_dag/steps/run_subsample.py
@@ -67,7 +67,7 @@ class PipelineStepRunSubsample(PipelineCountingStep):
 
         # total_records > max_fragments, sample
         m = hashlib.md5()
-        # FIXME: https://jira.czi.team/browse/IDSEQ-2738 
+        # FIXME: https://jira.czi.team/browse/IDSEQ-2738
         #   Currently input_fas[0] is always the same string so this is equivalent to a hard-coded seed
         #   This is being left here because we want to move towards seeding all RNG based on a hash of the
         #   input file contents and we want to communicate that intent. We may want to use cr32c checksums

--- a/idseq_dag/steps/run_subsample.py
+++ b/idseq_dag/steps/run_subsample.py
@@ -67,7 +67,8 @@ class PipelineStepRunSubsample(PipelineCountingStep):
 
         # total_records > max_fragments, sample
         m = hashlib.md5()
-        # FIXME: currently input_fas[0] is always the same string so this is equivalent to a hard-coded seed
+        # FIXME: https://jira.czi.team/browse/IDSEQ-2738 
+        #   Currently input_fas[0] is always the same string so this is equivalent to a hard-coded seed
         #   This is being left here because we want to move towards seeding all RNG based on a hash of the
         #   input file contents and we want to communicate that intent. We may want to use cr32c checksums
         #   for performance reasons.

--- a/idseq_dag/steps/run_subsample.py
+++ b/idseq_dag/steps/run_subsample.py
@@ -1,4 +1,5 @@
 import random
+import hashlib
 
 from idseq_dag.engine.pipeline_step import PipelineCountingStep, InputFileErrors
 import idseq_dag.util.command as command
@@ -65,7 +66,13 @@ class PipelineStepRunSubsample(PipelineCountingStep):
             return
 
         # total_records > max_fragments, sample
-        randgen = random.Random(x=hash(input_fas[0]))
+        m = hashlib.md5()
+        # FIXME: currently input_fas[0] is always the same string so this is equivalent to a hard-coded seed
+        #   This is being left here because we want to move towards seeding all RNG based on a hash of the
+        #   input file contents and we want to communicate that intent. We may want to use cr32c checksums
+        #   for performance reasons.
+        m.update(input_fas[0].encode())
+        randgen = random.Random(x=m.digest())
         records_to_keep = randgen.sample(range(total_records), max_fragments)
         PipelineStepRunSubsample.subset(input_fas[0], output_fas[0], records_to_keep)
         if paired:

--- a/idseq_dag/util/m8.py
+++ b/idseq_dag/util/m8.py
@@ -335,6 +335,13 @@ def _call_hits_m8_work(input_m8, lineage_map, accession2taxid_dict,
                 return level + 1, taxid, accession_id
         return -1, "-1", None
 
+    # FIXME: we want to move towards a general randomness solution in which
+    #  all randomness is seeded based on the content of the original input.
+    #  This is currently introducing non-determinism and hard coding
+    #  an arbitrary seed here shouldn't impact correctness. This is only used
+    #  to break ties.
+    randgen = random.Random(x=4)  # chosen by fair dice role, guaranteed to be random
+
     def call_hit_level_v2(hits):
         ''' Always call hit at the species level with the taxid with most matches '''
         species_level_hits = hits[0]
@@ -350,7 +357,7 @@ def _call_hits_m8_work(input_m8, lineage_map, accession2taxid_dict,
         if max_match > 0:
             selected_taxid = taxid_candidates[0]
             if len(taxid_candidates) > 1:
-                selected_taxid = random.sample(taxid_candidates, 1)[0]
+                selected_taxid = randgen.sample(taxid_candidates, 1)[0]
             accession_id = most_frequent_accession(
                 species_level_hits[selected_taxid])
             return 1, selected_taxid, accession_id

--- a/idseq_dag/util/m8.py
+++ b/idseq_dag/util/m8.py
@@ -335,7 +335,8 @@ def _call_hits_m8_work(input_m8, lineage_map, accession2taxid_dict,
                 return level + 1, taxid, accession_id
         return -1, "-1", None
 
-    # FIXME: we want to move towards a general randomness solution in which
+    # FIXME: https://jira.czi.team/browse/IDSEQ-2738 
+    #  We want to move towards a general randomness solution in which
     #  all randomness is seeded based on the content of the original input.
     #  This is currently introducing non-determinism and hard coding
     #  an arbitrary seed here shouldn't impact correctness. This is only used

--- a/idseq_dag/util/m8.py
+++ b/idseq_dag/util/m8.py
@@ -335,7 +335,7 @@ def _call_hits_m8_work(input_m8, lineage_map, accession2taxid_dict,
                 return level + 1, taxid, accession_id
         return -1, "-1", None
 
-    # FIXME: https://jira.czi.team/browse/IDSEQ-2738 
+    # FIXME: https://jira.czi.team/browse/IDSEQ-2738
     #  We want to move towards a general randomness solution in which
     #  all randomness is seeded based on the content of the original input.
     #  This is currently introducing non-determinism and hard coding


### PR DESCRIPTION
# Description

Makes several elements of the pipeline (and possibly the whole thing) deterministic by adding static seeds to pseudo random number generation:
- Subsampling
- Breaking ties in hit summary
- Bowtie2

See this quip doc for all the details: https://czi.quip.com/Xm0aAeWrjuu9/2020-05-07-Non-Determinism-Bug-Post-Mortem

# Version
- [X] I have increased the appropriate version number in https://github.com/chanzuckerberg/idseq-dag/blob/master/idseq_dag/__init__.py. Guidelines here: https://github.com/chanzuckerberg/idseq-dag/blob/pr-template/README.md#release-notes
- [X] I have added release notes for my new version to https://github.com/chanzuckerberg/idseq-dag/blob/master/README.md#release-notes
- [X] I will push a git tag after merging in the form `vX.Y.Z`

# Tests
- [X] I have verified that the pipeline still completes successfully:
    - [ ] for single-end inputs
    - [X] for paired-end inputs
    - [ ] for FASTQ inputs
    - [X] for FASTA inputs.
- [X] I have validated that my change does not introduce any correctness bugs to existing output types.
- [X] I have validated that my change does not introduce significant performance regressions or I have discussed with the team that the benefits of the change are substantial enough that we're comfortable accepting the size of the measured performance penalty.