### PR TITLE
Add step entry point

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,6 @@ SHELL=/bin/bash
 
 lint:
 	python setup.py flake8
-	flake8 scripts/*
 
 test: lint
 	python -m unittest discover -s tests/unit -v

--- a/README.md
+++ b/README.md
@@ -226,6 +226,9 @@ Changes to X or Y force recomputation of all results when a sample is rerun usin
 
 When releasing a new version, please add a Git tag of the form `vX.Y.Z`.
 
+- 4.7.0
+  - Add a step-level entry point CLI.
+
 - 4.6.0
   - Include non-unique reads in unidentified fastas for download.
 

--- a/idseq_dag/__init__.py
+++ b/idseq_dag/__init__.py
@@ -1,2 +1,2 @@
 ''' idseq_dag '''
-__version__ = "4.6.0"
+__version__ = "4.7.0"

--- a/idseq_dag/__main__.py
+++ b/idseq_dag/__main__.py
@@ -97,7 +97,8 @@ def run_step():
 
     try:
         if args.step_class == "PipelineStepRunValidateInput":
-            count_input_reads(input_files=step_instance.input_files_local, max_fragments=None)
+            count_input_reads(input_files=step_instance.input_files_local,
+                              max_fragments=step_instance.additional_attributes["truncate_fragments_to"])
 
         step_instance.update_status_json_file("running")
         step_instance.run()

--- a/idseq_dag/__main__.py
+++ b/idseq_dag/__main__.py
@@ -2,14 +2,26 @@
 
 import argparse
 import os
-import idseq_dag.util.log as log
-from idseq_dag.engine.pipeline_flow import PipelineFlow
-from idseq_dag import __version__
+import sys
+import json
+import contextlib
+import importlib
+import threading
+import logging
+import subprocess
+import traceback
 
-log.configure_logger()
+import idseq_dag
+import idseq_dag.util.s3
+import idseq_dag.util.count
+from idseq_dag import __version__
 
 
 def main():
+    from idseq_dag.engine.pipeline_flow import PipelineFlow
+    import idseq_dag.util.log as log
+    log.configure_logger()
+
     parser = argparse.ArgumentParser()
     parser.add_argument('--version', action='version',
                         version='%(prog)s {version}'.format(version=__version__))
@@ -33,6 +45,75 @@ def main():
         raise
     log.write("start executing the dag")
     flow.start()
+
+def count_input_reads(input_files, max_fragments):
+    input_read_count = idseq_dag.util.count.reads_in_group(input_files[0],
+                                                           max_fragments=max_fragments)
+    counts_dict = dict(fastqs=input_read_count)
+    if input_read_count == len(input_files) * max_fragments:
+        counts_dict["truncated"] = input_read_count
+    with open("fastqs.count", "w") as count_file:
+        json.dump(counts_dict, count_file)
+
+def run_step():
+    root_logger = logging.getLogger()
+    root_logger.setLevel(level=logging.INFO)
+    stream_handler = logging.StreamHandler()
+    stream_handler.setFormatter(idseq_dag.util.log.JsonFormatter())
+    root_logger.addHandler(stream_handler)
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--workflow-name', required=True)
+    parser.add_argument('--step-module', required=True)
+    parser.add_argument('--step-class', required=True)
+    parser.add_argument('--step-name', required=True)
+    parser.add_argument('--input-files', type=json.loads, required=True)
+    parser.add_argument('--output-files', type=json.loads, required=True)
+    parser.add_argument('--output-dir-s3', required=True)
+    parser.add_argument('--additional-files', type=json.loads, default={})
+    parser.add_argument('--additional-attributes', type=json.loads, default={})
+    args = parser.parse_args()
+
+    logging.info("idseq-dag %s running %s.%s", __version__, args.step_module, args.step_class)
+    idseq_dag.util.s3.config["REF_DIR"] = os.getcwd()
+    step = importlib.import_module(args.step_module)
+    step_class = getattr(step, args.step_class)
+    step_instance = step_class(
+        name=args.step_name,
+        input_files=[[None] * len(target) for target in args.input_files],
+        output_files=args.output_files,
+        output_dir_local=os.getcwd(),
+        output_dir_s3=args.output_dir_s3,
+        ref_dir_local=idseq_dag.util.s3.config["REF_DIR"],
+        additional_files=args.additional_files,
+        additional_attributes=args.additional_attributes,
+        step_status_local=args.workflow_name + "_status.json",
+        step_status_lock=contextlib.suppress()
+    )
+    step_instance.input_files_local = args.input_files
+
+    with open(step_instance.step_status_local, "w") as status_file:
+        json.dump(dict(), status_file)
+
+    try:
+        if args.step_class == "PipelineStepRunValidateInput":
+            count_input_reads(input_files=step_instance.input_files_local, max_fragments=None)
+
+        step_instance.update_status_json_file("running")
+        step_instance.run()
+        step_instance.count_reads()
+        step_instance.save_counts()
+        # temporary until we instrument miniwdl - not yet uploaded, but this is the final status
+        step_instance.update_status_json_file("uploaded")
+    except Exception as e:
+        try:
+            # process exception for status reporting
+            s = "user_errored" if isinstance(e, idseq_dag.engine.pipeline_step.InvalidInputFileError) else "pipeline_errored"
+            step_instance.update_status_json_file(s)
+        except Exception:
+            logging.error("Failed to update status to '%s'", s)
+        traceback.print_exc()
+        exit(json.dumps(dict(wdl_error_message=True, error=type(e).__name__, cause=str(e))))
 
 
 if __name__ == "__main__":

--- a/idseq_dag/__main__.py
+++ b/idseq_dag/__main__.py
@@ -74,6 +74,11 @@ def run_step():
     parser.add_argument('--additional-attributes', type=json.loads, default={})
     args = parser.parse_args()
 
+    # If the fasta/fastq input is unpaired, we get an empty string placeholder for it. Remove it.
+    for target in args.input_files:
+        if target[-1] == "":
+            del target[-1]
+
     logging.info("idseq-dag %s running %s.%s", __version__, args.step_module, args.step_class)
     idseq_dag.util.s3.config["REF_DIR"] = os.getcwd()
     step = importlib.import_module(args.step_module)

--- a/idseq_dag/steps/run_priceseq.py
+++ b/idseq_dag/steps/run_priceseq.py
@@ -70,8 +70,7 @@ class PipelineStepRunPriceSeq(PipelineStep):
                     break
 
             if convert_and_rerun:
-                log.write(f"0 reads left after PriceSeqFilter, \
-                            converting input to FASTA and re-running")
+                log.write("0 reads left after PriceSeqFilter, converting input to FASTA and re-running")
                 step = "FASTQ to FASTA conversion"
                 log.write(f"Starting {step}...")
                 convert_out = [

--- a/idseq_dag/steps/run_validate_input.py
+++ b/idseq_dag/steps/run_validate_input.py
@@ -63,7 +63,7 @@ class PipelineStepRunValidateInput(PipelineStep):
                             )
                         )
                     except:
-                        raise RuntimeError(f"Invalid fastq/fasta/gzip file")
+                        raise RuntimeError("Invalid fastq/fasta/gzip file")
                 else:
                     # Validate and truncate the input file to keep behavior consistent with gz input files
                     try:
@@ -82,7 +82,7 @@ class PipelineStepRunValidateInput(PipelineStep):
                         )
                         input_files[i] = tmp_file
                     except:
-                        raise RuntimeError(f"Invalid fastq/fasta file")
+                        raise RuntimeError("Invalid fastq/fasta file")
 
             # keep a dictionary of the distribution of read lengths in the files
             self.summary_dict = {vc.BUCKET_TOO_SHORT: 0,
@@ -104,7 +104,7 @@ class PipelineStepRunValidateInput(PipelineStep):
                 all_fragments.append(num_fragments)
 
             if len(all_fragments) == 2 and abs(all_fragments[1] - all_fragments[0]) > 1000:
-                raise RuntimeError(f"Paired input files need to contain the same number of reads")
+                raise RuntimeError("Paired input files need to contain the same number of reads")
 
             with open(summary_file, 'w') as summary_f:
                 json.dump(self.summary_dict, summary_f)

--- a/idseq_dag/util/command.py
+++ b/idseq_dag/util/command.py
@@ -183,6 +183,7 @@ def retry(operation, MAX_TRIES=3):
     # Note the use of a separate random generator for retries so transient
     # errors won't perturb other random streams used in the application.
     invocation = [0]  # a python trick, without which the nested function would not increment a counter defined in the parent
+
     @wraps(operation)
     def wrapped_operation(*args, **kwargs):
         randgen = None
@@ -239,7 +240,7 @@ def execute(command: Union[command_patterns.CommandPattern, str],
     """
     if not isinstance(command, command_patterns.CommandPattern):
         # log warning if using legacy format
-        log.write(warning=True, message=f"Command parameter is using legacy type str. Use idseq_dag.util.command_patterns.", obj_data={"cmd": command, "type": type(command)})
+        log.write(warning=True, message="Command parameter is using legacy type str. Use idseq_dag.util.command_patterns.", obj_data={"cmd": command, "type": type(command)})
         cmd = command_patterns.ShellScriptCommand(script=command, args=[])
     else:
         cmd = command

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,4 +2,4 @@
 universal=1
 [flake8]
 max-line-length=120
-ignore: E302, F401, E501, W504, E711, E712, E722
+ignore: E302, F401, E501, W504, E711, E712, E722, E741

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,8 @@ setup(name='idseq_dag',
       dependency_links=[],
       entry_points={
           'console_scripts': [
-              'idseq_dag = idseq_dag.__main__:main'
+              'idseq_dag = idseq_dag.__main__:main',
+              'idseq-dag-run-step = idseq_dag.__main__:run_step'
           ]
       },
       zip_safe=False)


### PR DESCRIPTION
# Description
Move the constant contents of idd2wdl.py to idseq-dag and establish a CLI. This allows the enveloping WDL workflows to be much neater and less repetitive.

# Version
- [x] I have increased the appropriate version number in https://github.com/chanzuckerberg/idseq-dag/blob/master/idseq_dag/__init__.py. Guidelines here: https://github.com/chanzuckerberg/idseq-dag/blob/pr-template/README.md#release-notes
- [x] I have added release notes for my new version to https://github.com/chanzuckerberg/idseq-dag/blob/master/README.md#release-notes
- [x] I will push a git tag after merging in the form `vX.Y.Z`

# Tests
- [x] I have verified that the pipeline still completes successfully:
    - [x] for single-end inputs
    - [x] for paired-end inputs
    - [x] for FASTQ inputs
    - [ ] for FASTA inputs.
- [x] I have validated that my change does not introduce any correctness bugs to existing output types.
- [x] I have validated that my change does not introduce significant performance regressions or I have discussed with the team that the benefits of the change are substantial enough that we're comfortable accepting the size of the measured performance penalty.

# Notes
*Optional observations, comments or explanations.*
