### PR TITLE
IDSEQ-2372: Fix contig read count

### DIFF
--- a/examples/blast_contigs_nt.json
+++ b/examples/blast_contigs_nt.json
@@ -12,8 +12,7 @@
         "contigs.fasta",
         "scaffolds.fasta",
         "read-contig.sam",
-        "contig_stats.json",
-        "gsnap.blast.m8"
+        "contig_stats.json"
       ],
       "gsnap_accessions_out": [
         "nt.refseq.fasta"
@@ -22,6 +21,7 @@
         "cdhitdup_cluster_sizes.tsv"
       ],
       "refined_gsnap_out": [
+        "gsnap.blast.m8",
         "gsnap.reassigned.m8",
         "gsnap.hitsummary2.tab",
         "refined_gsnap_counts_with_dcr.json",
@@ -45,16 +45,16 @@
     ],
     "given_targets": {
       "gsnap_out": {
-        "s3_dir": "s3://idseq-samples-prod/samples/150/46136/results/4.2"
+        "s3_dir": "s3://idseq-samples-staging/samples/496/18284/results/idseq-staging-main-1/wdl-1/dag-4.6"
       },
       "assembly_out": {
-        "s3_dir": "s3://idseq-samples-prod/samples/150/46136/postprocess/4.2/assembly"
+        "s3_dir": "s3://idseq-samples-staging/samples/496/18284/results/idseq-staging-main-1/wdl-1/dag-4.6"
       },
       "gsnap_accessions_out": {
-        "s3_dir": "s3://idseq-samples-prod/samples/150/46136/postprocess/4.2/assembly"
+        "s3_dir": "s3://idseq-samples-staging/samples/496/18284/results/idseq-staging-main-1/wdl-1/dag-4.6"
       },
       "cdhitdup_cluster_sizes": {
-        "s3_dir": "s3://idseq-samples-prod/samples/150/46136/results/4.2"
+        "s3_dir": "s3://idseq-samples-staging/samples/496/18284/results/idseq-staging-main-1/wdl-1/dag-4.6"
       }
     }
 }

--- a/idseq_dag/steps/blast_contigs.py
+++ b/idseq_dag/steps/blast_contigs.py
@@ -289,22 +289,7 @@ class PipelineStepBlastContigs(PipelineStep):  # pylint: disable=abstract-method
             increment(species_summary[species_taxid][contig])
             increment(genus_summary[genus_taxid][contig])
 
-        def has_accession(read_info):
-            """
-            For unknown reasons, reads that do not map to an accession but do
-            map to a contig are included in output but not counted. See
-            'int(hit_level) < 0' in generate_taxon_count_json_from_m8.
-            """
-            accession_id = read_info[3]
-            if accession_id == 'None' or accession_id == "":
-                log.write('no accession_id')
-                return False
-            return True
-
         for read_id, read_info in read_dict.items():
-            if not has_accession(read_info):
-                continue
-
             contig = read2contig.get(read_id, '*')
             lineage = contig2lineage.get(contig)
             if contig != '*' and lineage:
@@ -317,9 +302,6 @@ class PipelineStepBlastContigs(PipelineStep):  # pylint: disable=abstract-method
                 record_read(species_taxid, genus_taxid, contig, read_id)
 
         for read_id, read_info in added_reads_dict.items():
-            if not has_accession(read_info):
-                continue
-
             contig = read2contig[read_id]
             species_taxid, genus_taxid, _family_taxid = contig2lineage[contig]
             if should_keep((species_taxid, genus_taxid)):

--- a/idseq_dag/util/m8.py
+++ b/idseq_dag/util/m8.py
@@ -473,12 +473,8 @@ def generate_taxon_count_json_from_m8(
                 hit_level = hit_line_columns[1]
                 hit_taxid = hit_line_columns[2]
                 if int(hit_level) < 0:
-                    # Skip negative levels and continue
                     # See also has_accession in generate_taxon_summary
                     log.write('int(hit_level) < 0')
-                    hit_line = hit_f.readline()
-                    m8_line = m8_f.readline()
-                    continue
 
                 # m8 files correspond to BLAST tabular output format 6:
                 # Columns: read_id | _ref_id | percent_identity | alignment_length...

--- a/idseq_dag/util/m8.py
+++ b/idseq_dag/util/m8.py
@@ -472,7 +472,10 @@ def generate_taxon_count_json_from_m8(
                 read_id = hit_line_columns[0]
                 hit_level = hit_line_columns[1]
                 hit_taxid = hit_line_columns[2]
-                if int(hit_level) < 0:  # Skip negative levels and continue
+                if int(hit_level) < 0:
+                    # Skip negative levels and continue
+                    # See also has_accession in generate_taxon_summary
+                    log.write('int(hit_level) < 0')
                     hit_line = hit_f.readline()
                     m8_line = m8_f.readline()
                     continue

--- a/idseq_dag/util/m8.py
+++ b/idseq_dag/util/m8.py
@@ -473,7 +473,7 @@ def generate_taxon_count_json_from_m8(
                 hit_level = hit_line_columns[1]
                 hit_taxid = hit_line_columns[2]
                 if int(hit_level) < 0:
-                    log.write('int(hit_level) < 0')
+                    log.write('int(hit_level) < 0', debug=True)
 
                 # m8 files correspond to BLAST tabular output format 6:
                 # Columns: read_id | _ref_id | percent_identity | alignment_length...

--- a/idseq_dag/util/m8.py
+++ b/idseq_dag/util/m8.py
@@ -473,7 +473,6 @@ def generate_taxon_count_json_from_m8(
                 hit_level = hit_line_columns[1]
                 hit_taxid = hit_line_columns[2]
                 if int(hit_level) < 0:
-                    # See also has_accession in generate_taxon_summary
                     log.write('int(hit_level) < 0')
 
                 # m8 files correspond to BLAST tabular output format 6:


### PR DESCRIPTION
# Description

I figured out why the contig read count is sometimes greater than the NT or NR read count. 

## Test case

I found a good test case with this betacoronavirus sample: https://staging.idseq.net/samples/18284. 

![image](https://user-images.githubusercontent.com/28797/82391958-896fd180-99f7-11ea-9194-4bdaa0065d68.png)

I traced the conflicting counts all the back through the pipeline to where they diverged, focussing on reads that map to the single contig `NODE_1_length_29904_cov_197.232973`.

* 67577 unique from read-contig.sam
* 67577 unique from gsnap.hitsummary2.tab

to
 
* 123202 nonunique from gsnap_counts_with_dcr.json
* 123202 nonunique from refined_gsnap_counts_with_dcr.json
* 123348 nonunique from contig_summary.json

Unfortunately, its not possible to compare nonunique to nonunique directly which allows for a possible bug in deduplication. However, previous work on IDSEQ-2372 shows that it predates deduplication and pipeline v4.

## Missing accessions

The big clue to the bug is:

* 258 unique reads have no accession but are associated with a contig in gsnap.hitsummary2.tab
* 238 nonunique gap in final contig r and r

While the numbers are not exactly the same, and may be different because of unique/nonunique, there were close enough for me to look for a cause.

## The bug

In `m8.summarize_hits`, there are the lines

```
    with open(hit_summary_file, 'r') as hsf:
        for line in hsf:
            read = line.rstrip().split("\t")
            accession_id, species_taxid, genus_taxid, family_taxid = read[3:7]
            read_dict[read[0]] = read
            if accession_id == 'None' or accession_id == "":
                continue
            ...
```

which means that `read_dict` is assigned reads that have no accession, although the rest of the loop is skipped. `read_dict` is used for contig r *and* r. 

Those reads are later filtered out in `generate_taxon_count_json_from_m8` (r count) but not in `generate_taxon_summary` (contig r count). That's what this PR changes.

## The fix

After the PR, the r count is 123651, greater than the contig r count 123348. Keep in mind that not all aligned reads must be in a contig. To be consistent with the initial hypothesis, the increase in r count must only be greater than 258, which it is. To be more precise, we would need to take into account the cdhitdup cluster sizes for each of those 258 unique reads.

## Discussion

What does it mean for a read to map to a contig but to not map to an accession? 

Should we expect more downstream effects than just a change to NT and NR taxon counts?

Why were those reads included in the refined m8 files but not in the refined counts? 

Maybe @boris-dimitrov  or @yunfangjuan can shed some light? 😄 

In any case, it would be valuable for someone to document the expected behaviors for ourselves and users. 

I went into the whitepaper to see what we say there. 

> Putative accessions are assigned to each read using the NCBI accession2taxid database [36] and a
BLAST+ (v 2.6.0) [37] database is constructed on-the-fly from the set of putative accessions
(one database for each, nt and nr). In parallel, short reads are de novo assembled into contigs
using SPADES [38]. Raw reads are mapped back to the resulting contigs using Bowtie2, in
order to identify the contig to which each raw read belongs. Finally, each contig is aligned to the
set of possible accessions represented by the BLAST database generated in the previous step,
thereby improving the specificity of alignments to all the underlying reads, especially for
homologous regions where short reads may align equally well to multiple different accessions

It's not clear from my reading whether reads in contigs should all be associated with accessions. Likewise, I didn't find anything relevant in the help center. 

# Version
- [x] I have increased the appropriate version number in https://github.com/chanzuckerberg/idseq-dag/blob/master/idseq_dag/__init__.py. Guidelines here: https://github.com/chanzuckerberg/idseq-dag/blob/pr-template/README.md#release-notes
- [x] I have added release notes for my new version to https://github.com/chanzuckerberg/idseq-dag/blob/master/README.md#release-notes
- [x] I will push a git tag after merging in the form `vX.Y.Z`

# Tests
- [x] I have verified that the pipeline still completes successfully:
    - [ ] for single-end inputs
    - [x] for paired-end inputs
    - [ ] for FASTQ inputs
    - [ ] for FASTA inputs.
- [x] I have validated that my change does not introduce any correctness bugs to existing output types.
- [x] I have validated that my change does not introduce significant performance regressions or I have discussed with the team that the benefits of the change are substantial enough that we're comfortable accepting the size of the measured performance penalty.

# Notes
*Optional observations, comments or explanations.*
