### PR TITLE
Fix error in counting of unidentified.fa

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,9 @@ Changes to X or Y force recomputation of all results when a sample is rerun usin
 
 When releasing a new version, please add a Git tag of the form `vX.Y.Z`.
 
+- 4.7.1
+  - Fix occasional error in unidentified.fa counting.
+
 - 4.7.0
   - Add a step-level entry point CLI.
 

--- a/examples/generate_annotated_fasta.json
+++ b/examples/generate_annotated_fasta.json
@@ -49,19 +49,19 @@
   ],
   "given_targets": {
     "gsnap_filter_out": {
-      "s3_dir": "s3://idseq-samples-prod/samples/150/46136/results/4.2"
+      "s3_dir": "s3://idseq-samples-prod/samples/995/51454/results/idseq-prod-main-1/wdl-1/dag-4.6"
     },
     "gsnap_out": {
-      "s3_dir": "s3://idseq-samples-prod/samples/150/46136/results/4.2"
+      "s3_dir": "s3://idseq-samples-prod/samples/995/51454/results/idseq-prod-main-1/wdl-1/dag-4.6"
     },
     "rapsearch2_out": {
-      "s3_dir": "s3://idseq-samples-prod/samples/150/46136/results/4.2"
+      "s3_dir": "s3://idseq-samples-prod/samples/995/51454/results/idseq-prod-main-1/wdl-1/dag-4.6"
     },
     "cdhitdup_out": {
-      "s3_dir": "s3://idseq-samples-prod/samples/150/46136/results/4.2"
+      "s3_dir": "s3://idseq-samples-prod/samples/995/51454/results/idseq-prod-main-1/wdl-1/dag-4.6"
     },
     "cdhitdup_cluster_sizes": {
-      "s3_dir": "s3://idseq-samples-prod/samples/150/46136/results/4.2"
+      "s3_dir": "s3://idseq-samples-prod/samples/995/51454/results/idseq-prod-main-1/wdl-1/dag-4.6"
     }
   }
 }

--- a/examples/generate_annotated_fasta.json
+++ b/examples/generate_annotated_fasta.json
@@ -49,19 +49,19 @@
   ],
   "given_targets": {
     "gsnap_filter_out": {
-      "s3_dir": "s3://idseq-samples-prod/samples/833/45285/results/4.0"
+      "s3_dir": "s3://idseq-samples-prod/samples/150/46136/results/4.2"
     },
     "gsnap_out": {
-      "s3_dir": "s3://idseq-samples-prod/samples/833/45285/results/4.0"
+      "s3_dir": "s3://idseq-samples-prod/samples/150/46136/results/4.2"
     },
     "rapsearch2_out": {
-      "s3_dir": "s3://idseq-samples-prod/samples/833/45285/results/4.0"
+      "s3_dir": "s3://idseq-samples-prod/samples/150/46136/results/4.2"
     },
     "cdhitdup_out": {
-      "s3_dir": "s3://idseq-samples-prod/samples/833/45285/results/4.0"
+      "s3_dir": "s3://idseq-samples-prod/samples/150/46136/results/4.2"
     },
     "cdhitdup_cluster_sizes": {
-      "s3_dir": "s3://idseq-samples-prod/samples/833/45285/results/4.0"
+      "s3_dir": "s3://idseq-samples-prod/samples/150/46136/results/4.2"
     }
   }
 }

--- a/idseq_dag/__init__.py
+++ b/idseq_dag/__init__.py
@@ -1,2 +1,2 @@
 ''' idseq_dag '''
-__version__ = "4.7.0"
+__version__ = "4.7.1"

--- a/idseq_dag/steps/generate_annotated_fasta.py
+++ b/idseq_dag/steps/generate_annotated_fasta.py
@@ -1,3 +1,5 @@
+from os.path import basename, dirname, join
+
 import idseq_dag.util.fasta as fasta
 import idseq_dag.util.m8 as m8
 
@@ -20,7 +22,10 @@ class PipelineStepGenerateAnnotatedFasta(PipelineCountingStep):
         return self.output_files_local()[1]
 
     def _unique_unidentified_fasta(self):
-        return 'unique_' + self._unidentified_fasta()
+        return join(
+            dirname(self._unidentified_fasta()),
+            'unique_' + basename(self._unidentified_fasta())
+        )
 
     def run(self):
         merged_fasta = self.input_files_local[0][-1]

--- a/idseq_dag/steps/generate_annotated_fasta.py
+++ b/idseq_dag/steps/generate_annotated_fasta.py
@@ -19,6 +19,9 @@ class PipelineStepGenerateAnnotatedFasta(PipelineCountingStep):
     def _unidentified_fasta(self):
         return self.output_files_local()[1]
 
+    def _unique_unidentified_fasta(self):
+        return 'unique_' + self._unidentified_fasta()
+
     def run(self):
         merged_fasta = self.input_files_local[0][-1]
         gsnap_m8 = self.input_files_local[1][1]
@@ -36,15 +39,25 @@ class PipelineStepGenerateAnnotatedFasta(PipelineCountingStep):
 
         annotated_fasta = self._annotated_fasta()
         unidentified_fasta = self._unidentified_fasta()
+        unique_unidentified_fasta = self._unique_unidentified_fasta()
         self.annotate_fasta_with_accessions(merged_fasta, gsnap_m8, rapsearch2_m8, annotated_fasta)
-        self.generate_unidentified_fasta(annotated_fasta, unidentified_fasta, clusters_dict)
+        self.generate_unidentified_fasta(
+            annotated_fasta,
+            unidentified_fasta,
+            clusters_dict,
+            unique_unidentified_fasta
+        )
+        if clusters_dict:
+            self.additional_output_files_visible.append(unique_unidentified_fasta)
 
     def count_reads(self):
         # The webapp expects this count to be called "unidentified_fasta"
+        # To keep backwards compatibility, we use unique reads. See
+        # generate_unidentified_fasta.
         super()._count_reads_work(
             cluster_key=PipelineStepGenerateAnnotatedFasta.old_read_name,
             counter_name="unidentified_fasta",
-            fasta_files=[self._unidentified_fasta()]
+            fasta_files=[self._unique_unidentified_fasta()]
         )
 
     @staticmethod
@@ -82,11 +95,20 @@ class PipelineStepGenerateAnnotatedFasta(PipelineCountingStep):
         # in order to identify all duplicate reads for this read_id.
         return new_read_name.split(":", 4)[-1]
 
-    def generate_unidentified_fasta(self, input_fa, output_fa, clusters_dict=None):
+    def generate_unidentified_fasta(
+        self,
+        input_fa,
+        output_fa,
+        clusters_dict=None,
+        unique_output_fa=None
+    ):
         """
         Generates files with all unmapped reads. If COUNT_ALL, which was added
         in v4, then include non-unique reads extracted upstream by cdhitdup.
+
+        unique_output_fa exists primarily for counting. See count_reads above.
         """
+        unique_output_file = open(unique_output_fa, "w") if clusters_dict else None
         with open(output_fa, "w") as output_file:
             for read in fasta.iterator(input_fa):
                 if not read.header.startswith(UNMAPPED_HEADER_PREFIX):
@@ -94,6 +116,9 @@ class PipelineStepGenerateAnnotatedFasta(PipelineCountingStep):
 
                 output_file.write(read.header + "\n")
                 output_file.write(read.sequence + "\n")
+                if unique_output_file:
+                    unique_output_file.write(read.header + "\n")
+                    unique_output_file.write(read.sequence + "\n")
 
                 if clusters_dict:
                     # get inner part of header like


### PR DESCRIPTION
# Description

Runs in staging have been failing because of reads not found in `dedup1.fa.clstr` during counting of the `generate_annotated_fasta` output. #300 is responsible for the bug. 

The `count_reads` method assumes unique reads. The fix here creates a unique reads file which is the same as the output previous to #300.

# Version
- [x] I have increased the appropriate version number in https://github.com/chanzuckerberg/idseq-dag/blob/master/idseq_dag/__init__.py. Guidelines here: https://github.com/chanzuckerberg/idseq-dag/blob/pr-template/README.md#release-notes
- [x] I have added release notes for my new version to https://github.com/chanzuckerberg/idseq-dag/blob/master/README.md#release-notes
- [x] I will push a git tag after merging in the form `vX.Y.Z`

# Tests
- [x] I have verified that the pipeline still completes successfully:
    - [ ] for single-end inputs
    - [x] for paired-end inputs
    - [x] for FASTQ inputs
    - [ ] for FASTA inputs.
- [x] I have validated that my change does not introduce any correctness bugs to existing output types.
- [x] I have validated that my change does not introduce significant performance regressions or I have discussed with the team that the benefits of the change are substantial enough that we're comfortable accepting the size of the measured performance penalty.

# Notes
*Optional observations, comments or explanations.*
