### PR TITLE
add e-value threshold to require internal alignments have e-value < 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,9 @@ Changes to X or Y force recomputation of all results when a sample is rerun usin
 
 When releasing a new version, please add a Git tag of the form `vX.Y.Z`.
 
+- 4.10.0
+  - Add e-value threshold to require all internal alignments (short read and assembly-based) have e-value below threshold.
+
 - 4.9.0
   - Update NCBI index databases to those downloaded on 2020-04-20.
 

--- a/idseq_dag/__init__.py
+++ b/idseq_dag/__init__.py
@@ -1,2 +1,2 @@
 ''' idseq_dag '''
-__version__ = "4.9.0"
+__version__ = "4.10.0"

--- a/idseq_dag/util/m8.py
+++ b/idseq_dag/util/m8.py
@@ -198,7 +198,7 @@ def iterate_m8(m8_file, min_alignment_length=0, debug_caller=None, logging_inter
 
             # *** E-value Filter ***
             # Alignments with e-value > 1 are low-quality and associated with false-positives in
-            # all alignments steps (NT and NR). When the e-value is greater than 1, ignore the 
+            # all alignments steps (NT and NR). When the e-value is greater than 1, ignore the
             # alignment
             ###
             if e_value > MAX_EVALUE_THRESHOLD:

--- a/idseq_dag/util/m8.py
+++ b/idseq_dag/util/m8.py
@@ -18,6 +18,10 @@ from idseq_dag.util.dict import open_file_db_by_extension
 # Nevertheless, it may be useful to re-filter blastx results.
 NT_MIN_ALIGNMENT_LEN = 36
 
+# Alignments with e-values greater than 1 are low-quality alignments and associated with
+# a high rate of false-positives. These should be filtered at all alignment steps.
+EVALUE_THRESHOLD = 1
+
 # blastn output format 6 as documented in
 # http://www.metagenomics.wiki/tools/blast/blastn-output-format-6
 # it's also the format of our GSNAP and RAPSEARCH2 output
@@ -190,6 +194,14 @@ def iterate_m8(m8_file, min_alignment_length=0, debug_caller=None, logging_inter
             #      produced by RAPSEARCH2
             ###
             if alignment_length < min_alignment_length:
+                continue
+
+            # *** E-value Filter ***
+            # Alignments with e-value > 1 are low-quality and associated with false-positives in
+            # all alignments steps (NT and NR). When the e-value is greater than 1, ignore the 
+            # alignment
+            ###
+            if e_value > EVALUE_THRESHOLD:
                 continue
 
             if debug_caller and line_count % logging_interval == 0:

--- a/idseq_dag/util/m8.py
+++ b/idseq_dag/util/m8.py
@@ -20,7 +20,7 @@ NT_MIN_ALIGNMENT_LEN = 36
 
 # Alignments with e-values greater than 1 are low-quality alignments and associated with
 # a high rate of false-positives. These should be filtered at all alignment steps.
-EVALUE_THRESHOLD = 1
+MAX_EVALUE_THRESHOLD = 1
 
 # blastn output format 6 as documented in
 # http://www.metagenomics.wiki/tools/blast/blastn-output-format-6
@@ -71,7 +71,7 @@ RERANKED_BLAST_OUTPUT_SCHEMA = {
 MIN_CONTIG_SIZE = 4
 
 
-def parse_tsv(path, schema, expect_headers=False, raw_lines=False):
+def parse_tsv(path, schema, expect_headers=False, raw_lines=False, min_alignment_length=0):
     '''Parse TSV file with given schema, yielding a dict per line.  See BLAST_OUTPUT_SCHEMA, for example.  When expect_headers=True, treat the first line as column headers.'''
     assert expect_headers == False, "Headers not yet implemented."
     schema_items = schema.items()

--- a/idseq_dag/util/m8.py
+++ b/idseq_dag/util/m8.py
@@ -201,7 +201,7 @@ def iterate_m8(m8_file, min_alignment_length=0, debug_caller=None, logging_inter
             # all alignments steps (NT and NR). When the e-value is greater than 1, ignore the 
             # alignment
             ###
-            if e_value > EVALUE_THRESHOLD:
+            if e_value > MAX_EVALUE_THRESHOLD:
                 continue
 
             if debug_caller and line_count % logging_interval == 0:

--- a/idseq_dag/util/m8.py
+++ b/idseq_dag/util/m8.py
@@ -71,7 +71,7 @@ RERANKED_BLAST_OUTPUT_SCHEMA = {
 MIN_CONTIG_SIZE = 4
 
 
-def parse_tsv(path, schema, expect_headers=False, raw_lines=False, min_alignment_length=0):
+def parse_tsv(path, schema, expect_headers=False, raw_lines=False):
     '''Parse TSV file with given schema, yielding a dict per line.  See BLAST_OUTPUT_SCHEMA, for example.  When expect_headers=True, treat the first line as column headers.'''
     assert expect_headers == False, "Headers not yet implemented."
     schema_items = schema.items()


### PR DESCRIPTION
# Description
**issue:** For amplicon sequencing libraries (i.e. sars-cov-2 artic v3 libraries) there were false-positive hits to taxa with e-values in the thousands. 

**solution:** Standard practice is to apply an e-value threshold to ensure that alignments are high-quality. IDseq seeks to maintain high sensitivity, but reduce false-positives with exceptionally high e-values. Thus, a relatively conservative e-value threshold of 1 was implemented to reduce the number of obvious false-positives while still maintaining sensitivity to detect novel organisms.

# Version
- [x] I have increased the appropriate version number in https://github.com/chanzuckerberg/idseq-dag/blob/master/idseq_dag/__init__.py. Guidelines here: https://github.com/chanzuckerberg/idseq-dag/blob/pr-template/README.md#release-notes
- [x] I have added release notes for my new version to https://github.com/chanzuckerberg/idseq-dag/blob/master/README.md#release-notes
- [x] I will push a git tag after merging in the form `vX.Y.Z`

# Tests
- [ ] I have verified that the pipeline still completes successfully:
    - [x] for single-end inputs
    - [x] for paired-end inputs
    - [x] for FASTQ inputs
    - [ ] for FASTA inputs.
- [x] I have validated that my change does not introduce any correctness bugs to existing output types.
- [x] I have validated that my change does not introduce significant performance regressions or I have discussed with the team that the benefits of the change are substantial enough that we're comfortable accepting the size of the measured performance penalty.

# Notes
- I have verified using the benchmark sample, that there is no change in accuracy at species/genus/family levels
- I have verified that intermediate alignment files (gsnap.deduped.m8, gsnap.blast.top.m8, rapsearch2.deduped.m8, rapsearch2.blast.top.m8) do not contain alignment results with e-values greater than the specified threshold.
