### PR TITLE
Error handling updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,8 +226,12 @@ Changes to X or Y force recomputation of all results when a sample is rerun usin
 
 When releasing a new version, please add a Git tag of the form `vX.Y.Z`.
 
-- 4.12.0
-  - Normalize error handling by raising a specific class of exceptions when expected errors occur.
+- 4.11.0
+  - Normalize error handling by raising a specific class of exceptions when expected errors occur
+  - Simplify idseq_dag.util.count.reads() and remove invalid assumptions
+  - Add unit tests for changed components
+  - Fix unit test autodiscovery
+  - Improve portability of existing unit tests and run them in CI
 
 - 4.10.0
   - Add e-value threshold to require all internal alignments (short read and assembly-based) have e-value below threshold.

--- a/README.md
+++ b/README.md
@@ -226,6 +226,9 @@ Changes to X or Y force recomputation of all results when a sample is rerun usin
 
 When releasing a new version, please add a Git tag of the form `vX.Y.Z`.
 
+- 4.12.0
+  - Normalize error handling by raising a specific class of exceptions when expected errors occur.
+
 - 4.10.0
   - Add e-value threshold to require all internal alignments (short read and assembly-based) have e-value below threshold.
 

--- a/idseq_dag/__main__.py
+++ b/idseq_dag/__main__.py
@@ -106,6 +106,7 @@ def run_step():
                               max_fragments=step_instance.additional_attributes["truncate_fragments_to"])
 
         step_instance.update_status_json_file("running")
+        step_instance.validate_input_files()
         step_instance.run()
         step_instance.count_reads()
         step_instance.save_counts()

--- a/idseq_dag/engine/pipeline_step.py
+++ b/idseq_dag/engine/pipeline_step.py
@@ -26,12 +26,6 @@ class StepStatus(IntEnum):
     INVALID_INPUT = 4  # an error occurred when validating the input file
 
 
-class InputFileErrors(Enum):
-    ''' This error will be used by the front-end to display a user-friendly error message '''
-    INSUFFICIENT_READS = "INSUFFICIENT_READS"
-    BROKEN_PAIRS = "BROKEN_PAIRS"
-
-
 class PipelineStep(object):
     ''' Each Pipeline Run Step i.e. run_star, run_bowtie2, etc '''
 

--- a/idseq_dag/exceptions.py
+++ b/idseq_dag/exceptions.py
@@ -8,3 +8,15 @@ class InvalidOutputFileError(Exception):
     def __init__(self, json):
         super().__init__()
         self.json = json
+
+
+class InsufficientReadsError(InvalidInputFileError):
+    pass
+
+
+class BrokenReadPairError(InvalidInputFileError):
+    pass
+
+
+class InvalidFileFormatError(InvalidInputFileError):
+    pass

--- a/idseq_dag/steps/generate_coverage_viz.py
+++ b/idseq_dag/steps/generate_coverage_viz.py
@@ -749,7 +749,7 @@ class PipelineStepGenerateCoverageViz(PipelineStep):  # pylint: disable=abstract
                 total_covered_length += endpoint[0] - last_start_point
 
         if cur_depth != 0:
-            raise ValueError("coverage depth is %s after traversel. 0 is expected" % cur_depth)
+            raise ValueError("coverage depth is %s after traversal. 0 is expected" % cur_depth)
 
         return total_covered_length
 

--- a/idseq_dag/steps/run_alignment_remotely.py
+++ b/idseq_dag/steps/run_alignment_remotely.py
@@ -14,8 +14,8 @@ from botocore.exceptions import ClientError
 import boto3
 import requests
 
-from idseq_dag.engine.pipeline_step import PipelineStep, InvalidInputFileError
-
+from idseq_dag.engine.pipeline_step import PipelineStep
+from idseq_dag.exceptions import InsufficientReadsError
 import idseq_dag.util.command as command
 import idseq_dag.util.command_patterns as command_patterns
 import idseq_dag.util.count as count
@@ -120,7 +120,7 @@ class PipelineStepRunAlignmentRemotely(PipelineStep):
     def validate_input_files(self):
         # first two files are gsnap_filter_1.fa and gsnap_filter_2.fa
         if not count.files_have_min_reads(self.input_files_local[0][:-1], 1):
-            raise InvalidInputFileError("Insufficient reads")
+            raise InsufficientReadsError("Insufficient reads")
 
     def __init__(self, *args, **kwrds):
         PipelineStep.__init__(self, *args, **kwrds)

--- a/idseq_dag/steps/run_alignment_remotely.py
+++ b/idseq_dag/steps/run_alignment_remotely.py
@@ -14,7 +14,7 @@ from botocore.exceptions import ClientError
 import boto3
 import requests
 
-from idseq_dag.engine.pipeline_step import PipelineStep, InputFileErrors
+from idseq_dag.engine.pipeline_step import PipelineStep, InvalidInputFileError
 
 import idseq_dag.util.command as command
 import idseq_dag.util.command_patterns as command_patterns
@@ -120,7 +120,7 @@ class PipelineStepRunAlignmentRemotely(PipelineStep):
     def validate_input_files(self):
         # first two files are gsnap_filter_1.fa and gsnap_filter_2.fa
         if not count.files_have_min_reads(self.input_files_local[0][:-1], 1):
-            self.input_file_error = InputFileErrors.INSUFFICIENT_READS
+            raise InvalidInputFileError("Insufficient reads")
 
     def __init__(self, *args, **kwrds):
         PipelineStep.__init__(self, *args, **kwrds)

--- a/idseq_dag/steps/run_bowtie2.py
+++ b/idseq_dag/steps/run_bowtie2.py
@@ -1,6 +1,6 @@
 import os
 import multiprocessing
-from idseq_dag.engine.pipeline_step import PipelineCountingStep, InputFileErrors
+from idseq_dag.engine.pipeline_step import PipelineCountingStep, InvalidInputFileError
 import idseq_dag.util.command as command
 import idseq_dag.util.command_patterns as command_patterns
 import idseq_dag.util.count as count
@@ -39,7 +39,7 @@ class PipelineStepRunBowtie2(PipelineCountingStep):
 
     def validate_input_files(self):
         if not count.files_have_min_reads(self.input_fas(), 1):
-            self.input_file_error = InputFileErrors.INSUFFICIENT_READS
+            raise InvalidInputFileError("Insufficient reads")
 
     def run(self):
         input_fas = self.input_fas()

--- a/idseq_dag/steps/run_bowtie2.py
+++ b/idseq_dag/steps/run_bowtie2.py
@@ -1,6 +1,7 @@
 import os
 import multiprocessing
-from idseq_dag.engine.pipeline_step import PipelineCountingStep, InvalidInputFileError
+from idseq_dag.engine.pipeline_step import PipelineCountingStep
+from idseq_dag.exceptions import InsufficientReadsError
 import idseq_dag.util.command as command
 import idseq_dag.util.command_patterns as command_patterns
 import idseq_dag.util.count as count
@@ -39,7 +40,7 @@ class PipelineStepRunBowtie2(PipelineCountingStep):
 
     def validate_input_files(self):
         if not count.files_have_min_reads(self.input_fas(), 1):
-            raise InvalidInputFileError("Insufficient reads")
+            raise InsufficientReadsError("Insufficient reads before bowtie2")
 
     def run(self):
         input_fas = self.input_fas()

--- a/idseq_dag/steps/run_cdhitdup.py
+++ b/idseq_dag/steps/run_cdhitdup.py
@@ -3,7 +3,8 @@ import idseq_dag.util.command_patterns as command_patterns
 import idseq_dag.util.count as count
 import idseq_dag.util.fasta as fasta
 
-from idseq_dag.engine.pipeline_step import PipelineStep, InvalidInputFileError
+from idseq_dag.engine.pipeline_step import PipelineStep
+from idseq_dag.exceptions import InsufficientReadsError
 from idseq_dag.util.cdhit_clusters import parse_clusters_file
 from idseq_dag.util.count import save_cdhit_cluster_sizes
 
@@ -40,7 +41,7 @@ class PipelineStepRunCDHitDup(PipelineStep):  # Deliberately not PipelineCountin
 
     def validate_input_files(self):
         if not count.files_have_min_reads(self.input_files_local[0], 2):
-            raise InvalidInputFileError("Insufficient reads")
+            raise InsufficientReadsError("Insufficient reads before CDHitDup")
 
     def run(self):
         ''' Invoking cd-hit-dup '''

--- a/idseq_dag/steps/run_cdhitdup.py
+++ b/idseq_dag/steps/run_cdhitdup.py
@@ -3,7 +3,7 @@ import idseq_dag.util.command_patterns as command_patterns
 import idseq_dag.util.count as count
 import idseq_dag.util.fasta as fasta
 
-from idseq_dag.engine.pipeline_step import InputFileErrors, PipelineStep
+from idseq_dag.engine.pipeline_step import PipelineStep, InvalidInputFileError
 from idseq_dag.util.cdhit_clusters import parse_clusters_file
 from idseq_dag.util.count import save_cdhit_cluster_sizes
 
@@ -40,7 +40,7 @@ class PipelineStepRunCDHitDup(PipelineStep):  # Deliberately not PipelineCountin
 
     def validate_input_files(self):
         if not count.files_have_min_reads(self.input_files_local[0], 2):
-            self.input_file_error = InputFileErrors.INSUFFICIENT_READS
+            raise InvalidInputFileError("Insufficient reads")
 
     def run(self):
         ''' Invoking cd-hit-dup '''

--- a/idseq_dag/steps/run_gsnap_filter.py
+++ b/idseq_dag/steps/run_gsnap_filter.py
@@ -1,5 +1,6 @@
 import os
-from idseq_dag.engine.pipeline_step import PipelineCountingStep, InvalidInputFileError
+from idseq_dag.engine.pipeline_step import PipelineCountingStep
+from idseq_dag.exceptions import InsufficientReadsError
 import idseq_dag.util.command as command
 import idseq_dag.util.command_patterns as command_patterns
 import idseq_dag.util.convert as convert
@@ -39,7 +40,7 @@ class PipelineStepRunGsnapFilter(PipelineCountingStep):
 
     def validate_input_files(self):
         if not count.files_have_min_reads(self.input_fas(), 1):
-            raise InvalidInputFileError("Insufficient reads")
+            raise InsufficientReadsError("Insufficient reads")
 
     def run(self):
         input_fas = self.input_fas()

--- a/idseq_dag/steps/run_gsnap_filter.py
+++ b/idseq_dag/steps/run_gsnap_filter.py
@@ -1,5 +1,5 @@
 import os
-from idseq_dag.engine.pipeline_step import PipelineCountingStep, InputFileErrors
+from idseq_dag.engine.pipeline_step import PipelineCountingStep, InvalidInputFileError
 import idseq_dag.util.command as command
 import idseq_dag.util.command_patterns as command_patterns
 import idseq_dag.util.convert as convert
@@ -39,7 +39,7 @@ class PipelineStepRunGsnapFilter(PipelineCountingStep):
 
     def validate_input_files(self):
         if not count.files_have_min_reads(self.input_fas(), 1):
-            self.input_file_error = InputFileErrors.INSUFFICIENT_READS
+            raise InvalidInputFileError("Insufficient reads")
 
     def run(self):
         input_fas = self.input_fas()

--- a/idseq_dag/steps/run_lzw.py
+++ b/idseq_dag/steps/run_lzw.py
@@ -8,8 +8,8 @@ import idseq_dag.util.command_patterns as command_patterns
 import idseq_dag.util.count as count
 import idseq_dag.util.fasta as fasta
 import idseq_dag.util.log as log
-
-from idseq_dag.engine.pipeline_step import PipelineCountingStep, InvalidInputFileError
+from idseq_dag.engine.pipeline_step import PipelineCountingStep
+from idseq_dag.exceptions import InsufficientReadsError
 from idseq_dag.util.command import run_in_subprocess
 from idseq_dag.util.thread_with_result import mt_map
 
@@ -44,7 +44,7 @@ class PipelineStepRunLZW(PipelineCountingStep):
 
     def validate_input_files(self):
         if not count.files_have_min_reads(self.input_fas(), 1):
-            raise InvalidInputFileError("Insufficient reads")
+            raise InsufficientReadsError("Insufficient reads")
 
     def run(self):
         input_fas = self.input_fas()
@@ -207,7 +207,7 @@ class PipelineStepRunLZW(PipelineCountingStep):
                 break
 
         if kept_count == 0:
-            raise InvalidInputFileError("Insufficient reads")
+            raise InsufficientReadsError("Insufficient reads after LZW filtering")
 
         kept_ratio = float(kept_count) / float(total_reads)
         msg = "LZW filter: cutoff_frac: %f, total reads: %d, filtered reads: %d, " \

--- a/idseq_dag/steps/run_lzw.py
+++ b/idseq_dag/steps/run_lzw.py
@@ -9,7 +9,7 @@ import idseq_dag.util.count as count
 import idseq_dag.util.fasta as fasta
 import idseq_dag.util.log as log
 
-from idseq_dag.engine.pipeline_step import InputFileErrors, PipelineCountingStep, StepStatus
+from idseq_dag.engine.pipeline_step import PipelineCountingStep, InvalidInputFileError
 from idseq_dag.util.command import run_in_subprocess
 from idseq_dag.util.thread_with_result import mt_map
 
@@ -44,7 +44,7 @@ class PipelineStepRunLZW(PipelineCountingStep):
 
     def validate_input_files(self):
         if not count.files_have_min_reads(self.input_fas(), 1):
-            self.input_file_error = InputFileErrors.INSUFFICIENT_READS
+            raise InvalidInputFileError("Insufficient reads")
 
     def run(self):
         input_fas = self.input_fas()
@@ -207,9 +207,7 @@ class PipelineStepRunLZW(PipelineCountingStep):
                 break
 
         if kept_count == 0:
-            self.input_file_error = InputFileErrors.INSUFFICIENT_READS
-            self.status = StepStatus.INVALID_INPUT
-            return
+            raise InvalidInputFileError("Insufficient reads")
 
         kept_ratio = float(kept_count) / float(total_reads)
         msg = "LZW filter: cutoff_frac: %f, total reads: %d, filtered reads: %d, " \

--- a/idseq_dag/steps/run_priceseq.py
+++ b/idseq_dag/steps/run_priceseq.py
@@ -2,7 +2,8 @@
 import os
 from subprocess import run
 
-from idseq_dag.engine.pipeline_step import PipelineStep, InvalidInputFileError
+from idseq_dag.engine.pipeline_step import PipelineStep
+from idseq_dag.exceptions import InsufficientReadsError
 import idseq_dag.util.log as log
 import idseq_dag.util.count as count
 import idseq_dag.util.fasta as fasta
@@ -33,7 +34,7 @@ class PipelineStepRunPriceSeq(PipelineStep):
     """
     def validate_input_files(self):
         if not count.files_have_min_reads(self.input_files_local[0][0:2], 1):
-            raise InvalidInputFileError("Insufficient reads")
+            raise InsufficientReadsError("Insufficient reads")
 
     def run(self):
         """PriceSeqFilter is used to filter input data based on quality. Two FASTQ

--- a/idseq_dag/steps/run_priceseq.py
+++ b/idseq_dag/steps/run_priceseq.py
@@ -2,7 +2,7 @@
 import os
 from subprocess import run
 
-from idseq_dag.engine.pipeline_step import PipelineStep, InputFileErrors
+from idseq_dag.engine.pipeline_step import PipelineStep, InvalidInputFileError
 import idseq_dag.util.log as log
 import idseq_dag.util.count as count
 import idseq_dag.util.fasta as fasta
@@ -33,7 +33,7 @@ class PipelineStepRunPriceSeq(PipelineStep):
     """
     def validate_input_files(self):
         if not count.files_have_min_reads(self.input_files_local[0][0:2], 1):
-            self.input_file_error = InputFileErrors.INSUFFICIENT_READS
+            raise InvalidInputFileError("Insufficient reads")
 
     def run(self):
         """PriceSeqFilter is used to filter input data based on quality. Two FASTQ

--- a/idseq_dag/steps/run_star.py
+++ b/idseq_dag/steps/run_star.py
@@ -3,7 +3,8 @@ import os
 import json
 import re
 
-from idseq_dag.engine.pipeline_step import PipelineStep, InvalidInputFileError
+from idseq_dag.engine.pipeline_step import PipelineStep
+from idseq_dag.exceptions import BrokenReadPairError
 import idseq_dag.util.command as command
 import idseq_dag.util.command_patterns as command_patterns
 import idseq_dag.util.log as log
@@ -181,7 +182,7 @@ class PipelineStepRunStar(PipelineStep):
                 PipelineStepRunStar.unmapped_files_in(tmp, num_inputs))
 
             if too_discrepant:
-                raise InvalidInputFileError("Broken pairs")
+                raise BrokenReadPairError("Broken pairs")
 
             # Run part 0 in gene-counting mode:
             # (a) ERCCs are doped into part 0 and we want their counts.

--- a/idseq_dag/steps/run_star.py
+++ b/idseq_dag/steps/run_star.py
@@ -3,7 +3,7 @@ import os
 import json
 import re
 
-from idseq_dag.engine.pipeline_step import PipelineStep, StepStatus, InputFileErrors
+from idseq_dag.engine.pipeline_step import PipelineStep, InvalidInputFileError
 import idseq_dag.util.command as command
 import idseq_dag.util.command_patterns as command_patterns
 import idseq_dag.util.log as log
@@ -181,9 +181,7 @@ class PipelineStepRunStar(PipelineStep):
                 PipelineStepRunStar.unmapped_files_in(tmp, num_inputs))
 
             if too_discrepant:
-                self.input_file_error = InputFileErrors.BROKEN_PAIRS
-                self.status = StepStatus.INVALID_INPUT
-                return
+                raise InvalidInputFileError("Broken pairs")
 
             # Run part 0 in gene-counting mode:
             # (a) ERCCs are doped into part 0 and we want their counts.

--- a/idseq_dag/steps/run_subsample.py
+++ b/idseq_dag/steps/run_subsample.py
@@ -1,7 +1,7 @@
 import random
 import hashlib
 
-from idseq_dag.engine.pipeline_step import PipelineCountingStep, InputFileErrors
+from idseq_dag.engine.pipeline_step import PipelineCountingStep, InvalidInputFileError
 import idseq_dag.util.command as command
 import idseq_dag.util.command_patterns as command_patterns
 import idseq_dag.util.log as log
@@ -23,7 +23,7 @@ class PipelineStepRunSubsample(PipelineCountingStep):
 
     def validate_input_files(self):
         if not count.files_have_min_reads(self.input_fas(), 1):
-            self.input_file_error = InputFileErrors.INSUFFICIENT_READS
+            raise InvalidInputFileError("Insufficient reads")
 
     def run(self):
         ''' Invoking subsampling '''

--- a/idseq_dag/steps/run_subsample.py
+++ b/idseq_dag/steps/run_subsample.py
@@ -1,7 +1,8 @@
 import random
 import hashlib
 
-from idseq_dag.engine.pipeline_step import PipelineCountingStep, InvalidInputFileError
+from idseq_dag.engine.pipeline_step import PipelineCountingStep
+from idseq_dag.exceptions import InsufficientReadsError
 import idseq_dag.util.command as command
 import idseq_dag.util.command_patterns as command_patterns
 import idseq_dag.util.log as log
@@ -23,7 +24,7 @@ class PipelineStepRunSubsample(PipelineCountingStep):
 
     def validate_input_files(self):
         if not count.files_have_min_reads(self.input_fas(), 1):
-            raise InvalidInputFileError("Insufficient reads")
+            raise InsufficientReadsError("Insufficient reads")
 
     def run(self):
         ''' Invoking subsampling '''

--- a/idseq_dag/steps/run_trimmomatic.py
+++ b/idseq_dag/steps/run_trimmomatic.py
@@ -1,5 +1,5 @@
 ''' Run Trimmomatic '''
-from idseq_dag.engine.pipeline_step import PipelineStep, InputFileErrors
+from idseq_dag.engine.pipeline_step import PipelineStep, InvalidInputFileError
 import idseq_dag.util.command as command
 import idseq_dag.util.command_patterns as command_patterns
 import idseq_dag.util.count as count
@@ -65,7 +65,7 @@ class PipelineStepRunTrimmomatic(PipelineStep):
     """
     def validate_input_files(self):
         if not count.files_have_min_reads(self.input_files_local[0][0:2], 1):
-            self.input_file_error = InputFileErrors.INSUFFICIENT_READS
+            raise InvalidInputFileError("Insufficient reads")
 
     def run(self):
         """

--- a/idseq_dag/steps/run_trimmomatic.py
+++ b/idseq_dag/steps/run_trimmomatic.py
@@ -1,5 +1,6 @@
 ''' Run Trimmomatic '''
-from idseq_dag.engine.pipeline_step import PipelineStep, InvalidInputFileError
+from idseq_dag.engine.pipeline_step import PipelineStep
+from idseq_dag.exceptions import InsufficientReadsError
 import idseq_dag.util.command as command
 import idseq_dag.util.command_patterns as command_patterns
 import idseq_dag.util.count as count
@@ -65,7 +66,7 @@ class PipelineStepRunTrimmomatic(PipelineStep):
     """
     def validate_input_files(self):
         if not count.files_have_min_reads(self.input_files_local[0][0:2], 1):
-            raise InvalidInputFileError("Insufficient reads")
+            raise InsufficientReadsError("Insufficient reads")
 
     def run(self):
         """

--- a/idseq_dag/steps/run_validate_input.py
+++ b/idseq_dag/steps/run_validate_input.py
@@ -1,7 +1,7 @@
 import json
 import os
 
-from idseq_dag.engine.pipeline_step import PipelineStep
+from idseq_dag.engine.pipeline_step import PipelineStep, InvalidInputFileError
 import idseq_dag.util.command as command
 import idseq_dag.util.command_patterns as command_patterns
 import idseq_dag.util.count as count
@@ -63,7 +63,7 @@ class PipelineStepRunValidateInput(PipelineStep):
                             )
                         )
                     except:
-                        raise RuntimeError("Invalid fastq/fasta/gzip file")
+                        raise InvalidInputFileError("Invalid fastq/fasta/gzip file")
                 else:
                     # Validate and truncate the input file to keep behavior consistent with gz input files
                     try:
@@ -82,7 +82,7 @@ class PipelineStepRunValidateInput(PipelineStep):
                         )
                         input_files[i] = tmp_file
                     except:
-                        raise RuntimeError("Invalid fastq/fasta file")
+                        raise InvalidInputFileError("Invalid fastq/fasta file")
 
             # keep a dictionary of the distribution of read lengths in the files
             self.summary_dict = {vc.BUCKET_TOO_SHORT: 0,
@@ -104,7 +104,7 @@ class PipelineStepRunValidateInput(PipelineStep):
                 all_fragments.append(num_fragments)
 
             if len(all_fragments) == 2 and abs(all_fragments[1] - all_fragments[0]) > 1000:
-                raise RuntimeError("Paired input files need to contain the same number of reads")
+                raise InvalidInputFileError("Paired input files need to contain the same number of reads")
 
             with open(summary_file, 'w') as summary_f:
                 json.dump(self.summary_dict, summary_f)
@@ -142,16 +142,16 @@ class PipelineStepRunValidateInput(PipelineStep):
 
                 read_l = input_f.readline()
                 if len(read_l) == 0:  # unexpected EOF
-                    raise RuntimeError("Invalid input file")
+                    raise InvalidInputFileError("Invalid input file")
 
                 if is_fastq:
                     identifier2_l = input_f.readline()
                     if len(identifier2_l) == 0:
-                        raise RuntimeError("Invalid FASTQ file")
+                        raise InvalidInputFileError("Invalid FASTQ file")
 
                     quality_l = input_f.readline()
                     if len(quality_l) == 0:
-                        raise RuntimeError("Invalid FASTQ file")
+                        raise InvalidInputFileError("Invalid FASTQ file")
 
                 if is_fastq:
                     if identifier_l[0] != '@' or identifier2_l[0] != '+':
@@ -220,7 +220,7 @@ class PipelineStepRunValidateInput(PipelineStep):
 
                 read_l = input_f.readline()
                 if len(read_l) == 0:
-                    raise RuntimeError("Invalid input file")
+                    raise InvalidInputFileError("Invalid input file")
 
                 read_l = read_l.rstrip()
                 next_line = input_f.readline()
@@ -231,11 +231,11 @@ class PipelineStepRunValidateInput(PipelineStep):
                 if is_fastq:
                     identifier2_l = next_line
                     if len(identifier2_l) == 0:
-                        raise RuntimeError("Invalid FASTQ file")
+                        raise InvalidInputFileError("Invalid FASTQ file")
 
                     quality_l = input_f.readline()
                     if len(quality_l) == 0:
-                        raise RuntimeError("Invalid FASTQ file")
+                        raise InvalidInputFileError("Invalid FASTQ file")
 
                     quality_l = quality_l.rstrip()
                     next_line = input_f.readline()
@@ -245,12 +245,12 @@ class PipelineStepRunValidateInput(PipelineStep):
 
                 if is_fastq:
                     if identifier_l[0] != '@':
-                        raise RuntimeError("Invalid FASTQ file")
+                        raise InvalidInputFileError("Invalid FASTQ file")
                     if identifier2_l[0] != '+':
-                        raise RuntimeError("Invalid FASTQ file")
+                        raise InvalidInputFileError("Invalid FASTQ file")
                 else:
                     if identifier_l[0] != '>':
-                        raise RuntimeError("Invalid FASTA file")
+                        raise InvalidInputFileError("Invalid FASTA file")
 
                 # At this point, identifier_l and identifier2_l end in a newline and
                 # read_l and quality_l do not end in a newline

--- a/idseq_dag/steps/run_validate_input.py
+++ b/idseq_dag/steps/run_validate_input.py
@@ -1,7 +1,8 @@
 import json
 import os
 
-from idseq_dag.engine.pipeline_step import PipelineStep, InvalidInputFileError
+from idseq_dag.engine.pipeline_step import PipelineStep
+from idseq_dag.exceptions import InvalidFileFormatError
 import idseq_dag.util.command as command
 import idseq_dag.util.command_patterns as command_patterns
 import idseq_dag.util.count as count
@@ -63,7 +64,7 @@ class PipelineStepRunValidateInput(PipelineStep):
                             )
                         )
                     except:
-                        raise InvalidInputFileError("Invalid fastq/fasta/gzip file")
+                        raise InvalidFileFormatError("Invalid fastq/fasta/gzip file")
                 else:
                     # Validate and truncate the input file to keep behavior consistent with gz input files
                     try:
@@ -82,7 +83,7 @@ class PipelineStepRunValidateInput(PipelineStep):
                         )
                         input_files[i] = tmp_file
                     except:
-                        raise InvalidInputFileError("Invalid fastq/fasta file")
+                        raise InvalidFileFormatError("Invalid fastq/fasta file")
 
             # keep a dictionary of the distribution of read lengths in the files
             self.summary_dict = {vc.BUCKET_TOO_SHORT: 0,
@@ -104,7 +105,7 @@ class PipelineStepRunValidateInput(PipelineStep):
                 all_fragments.append(num_fragments)
 
             if len(all_fragments) == 2 and abs(all_fragments[1] - all_fragments[0]) > 1000:
-                raise InvalidInputFileError("Paired input files need to contain the same number of reads")
+                raise InvalidFileFormatError("Paired input files need to contain the same number of reads")
 
             with open(summary_file, 'w') as summary_f:
                 json.dump(self.summary_dict, summary_f)
@@ -142,16 +143,16 @@ class PipelineStepRunValidateInput(PipelineStep):
 
                 read_l = input_f.readline()
                 if len(read_l) == 0:  # unexpected EOF
-                    raise InvalidInputFileError("Invalid input file")
+                    raise InvalidFileFormatError("Invalid input file")
 
                 if is_fastq:
                     identifier2_l = input_f.readline()
                     if len(identifier2_l) == 0:
-                        raise InvalidInputFileError("Invalid FASTQ file")
+                        raise InvalidFileFormatError("Invalid FASTQ file")
 
                     quality_l = input_f.readline()
                     if len(quality_l) == 0:
-                        raise InvalidInputFileError("Invalid FASTQ file")
+                        raise InvalidFileFormatError("Invalid FASTQ file")
 
                 if is_fastq:
                     if identifier_l[0] != '@' or identifier2_l[0] != '+':
@@ -220,7 +221,7 @@ class PipelineStepRunValidateInput(PipelineStep):
 
                 read_l = input_f.readline()
                 if len(read_l) == 0:
-                    raise InvalidInputFileError("Invalid input file")
+                    raise InvalidFileFormatError("Invalid input file")
 
                 read_l = read_l.rstrip()
                 next_line = input_f.readline()
@@ -231,11 +232,11 @@ class PipelineStepRunValidateInput(PipelineStep):
                 if is_fastq:
                     identifier2_l = next_line
                     if len(identifier2_l) == 0:
-                        raise InvalidInputFileError("Invalid FASTQ file")
+                        raise InvalidFileFormatError("Invalid FASTQ file")
 
                     quality_l = input_f.readline()
                     if len(quality_l) == 0:
-                        raise InvalidInputFileError("Invalid FASTQ file")
+                        raise InvalidFileFormatError("Invalid FASTQ file")
 
                     quality_l = quality_l.rstrip()
                     next_line = input_f.readline()
@@ -245,12 +246,12 @@ class PipelineStepRunValidateInput(PipelineStep):
 
                 if is_fastq:
                     if identifier_l[0] != '@':
-                        raise InvalidInputFileError("Invalid FASTQ file")
+                        raise InvalidFileFormatError("Invalid FASTQ file")
                     if identifier2_l[0] != '+':
-                        raise InvalidInputFileError("Invalid FASTQ file")
+                        raise InvalidFileFormatError("Invalid FASTQ file")
                 else:
                     if identifier_l[0] != '>':
-                        raise InvalidInputFileError("Invalid FASTA file")
+                        raise InvalidFileFormatError("Invalid FASTA file")
 
                 # At this point, identifier_l and identifier2_l end in a newline and
                 # read_l and quality_l do not end in a newline

--- a/idseq_dag/util/count.py
+++ b/idseq_dag/util/count.py
@@ -5,7 +5,7 @@ from subprocess import run, PIPE
 
 import idseq_dag.util.fasta as fasta
 from idseq_dag import __version__
-from idseq_dag.exceptions import InvalidInputFileError
+from idseq_dag.exceptions import InvalidFileFormatError
 
 class ReadCountingMode(Enum):
     COUNT_UNIQUE = "COUNT UNIQUE READS"
@@ -38,9 +38,9 @@ def count_reads(filename):
                 cmd = "gunzip | " + cmd
             num_lines = int(run(cmd, stdin=fh, stdout=PIPE, check=True, shell=True).stdout)
             if num_lines % 4 != 0:
-                raise InvalidInputFileError("File does not follow fastq format")
+                raise InvalidFileFormatError("File does not follow fastq format")
             return num_lines // 4
-        raise InvalidInputFileError("Unable to recognize file format")
+        raise InvalidFileFormatError("Unable to recognize file format")
 
 
 reads = count_reads


### PR DESCRIPTION
# Description
Fix some of the error handling issues in idseq-dag. Raise exceptions instead of passing around non-uniform internal state. Raise an appropriate error class instead of generic RuntimeError.

# Version
- [x] I have increased the appropriate version number in https://github.com/chanzuckerberg/idseq-dag/blob/master/idseq_dag/__init__.py. Guidelines here: https://github.com/chanzuckerberg/idseq-dag/blob/pr-template/README.md#release-notes
- [x] I have added release notes for my new version to https://github.com/chanzuckerberg/idseq-dag/blob/master/README.md#release-notes
- [x] I will push a git tag after merging in the form `vX.Y.Z`

# Tests
- [x] I have verified that the pipeline still completes successfully:
    - [ ] for single-end inputs
    - [x] for paired-end inputs
    - [x] for FASTQ inputs
    - [ ] for FASTA inputs.
- [x] I have validated that my change does not introduce any correctness bugs to existing output types.
- [x] I have validated that my change does not introduce significant performance regressions or I have discussed with the team that the benefits of the change are substantial enough that we're comfortable accepting the size of the measured performance penalty.

# Notes
*Optional observations, comments or explanations.*
