### PR TITLE
fetch_from_s3: amend local file compatibility hack to check if file exists

### DIFF
--- a/idseq_dag/util/s3.py
+++ b/idseq_dag/util/s3.py
@@ -283,7 +283,7 @@ def fetch_from_s3(src,  # pylint: disable=dangerous-default-value
     #   change between idseq-dag and the idseq monorepo.
     if not src.startswith("s3://"):
         log.write(f"fetch_from_s3 is skipping download because source: {src} does not start with s3://")
-        return src
+        return (src if os.path.isfile(src) else None)
 
     # Do not be mislead by the multiprocessing.RLock() above -- that just means it won't deadlock
     # if called from multiple processes but does not mean the behaivior will be correct.  It will


### PR DESCRIPTION
@morsecodist +1 to this workaround, but there's a wrinkle with the subsequent `fetch_reference` function which expects `fetch_from_s3` to return `None` if `src` doesn't exist, as it optimistically tries to look for the `.lz4` version first :cold_sweat: 