### PR TITLE
STAR determinism

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,8 @@ Version numbers for this repo take the form X.Y.Z.
 Changes to X or Y force recomputation of all results when a sample is rerun using idseq-web. Changes to Z do not force recomputation when the sample is rerun - the pipeline will lazily reuse existing outputs in AWS S3.
 
 When releasing a new version, please add a Git tag of the form `vX.Y.Z`.
+- 4.11.3
+  - Make STAR outputs deterministic by sorting
 
 - 4.11.2
   - Disable lazy loading remote alignment chunks

--- a/idseq_dag/__init__.py
+++ b/idseq_dag/__init__.py
@@ -1,2 +1,2 @@
 ''' idseq_dag '''
-__version__ = "4.11.2"
+__version__ = "4.11.3"

--- a/idseq_dag/steps/run_star.py
+++ b/idseq_dag/steps/run_star.py
@@ -263,6 +263,14 @@ class PipelineStepRunStar(PipelineStep):
                       use_starlong):
         command.make_dirs(output_dir)
 
+        # FIXME: https://jira.czi.team/browse/IDSEQ-2738
+        #  We want to move towards a general randomness solution in which
+        #  all randomness is seeded based on the content of the original input.
+        #  STAR takes in a rng seed and it defaults this seed to 777. It is
+        #  explicitly set here to call out this behavior so it can be updated
+        #  when we update the rest of our rng seeds.
+        rng_seed = '777'
+
         cpus = str(multiprocessing.cpu_count())
         cd = output_dir
         cmd = 'STARlong' if use_starlong else 'STAR'
@@ -274,6 +282,7 @@ class PipelineStepRunStar(PipelineStep):
             '--outFilterMismatchNmax', '999',
             '--clip3pNbases', '0',
             '--runThreadN', cpus,
+            '--runRNGseed', rng_seed,
             '--genomeDir', genome_dir,
             '--readFilesIn', *input_files
         ]

--- a/idseq_dag/steps/run_star.py
+++ b/idseq_dag/steps/run_star.py
@@ -201,7 +201,7 @@ class PipelineStepRunStar(PipelineStep):
                 #  Aligned.toTranscriptome.out.bam with  TranscriptomeSAM, this doesn't
                 #  appear to be configurable
                 is_dna = self.collect_insert_size_metrics_for == "dna"
-                bam_filename = "Aligned.sortedByCoord.out.bam" if is_dna else "Aligned.toTranscriptome.out.bam"
+                bam_filename = "Aligned.out.bam" if is_dna else "Aligned.toTranscriptome.out.bam"
                 if self.collect_insert_size_metrics_for:
                     bam_path = os.path.join(tmp, bam_filename)
 

--- a/idseq_dag/steps/run_star.py
+++ b/idseq_dag/steps/run_star.py
@@ -263,9 +263,9 @@ class PipelineStepRunStar(PipelineStep):
                       use_starlong):
         command.make_dirs(output_dir)
 
-        cpus = str(multiprocessing.cpu_count())
+        cpus = multiprocessing.cpu_count()
         # SortedByCoordinate breaks around > 32 threads
-        threads = min(32, cpus)
+        threads = str(min(32, cpus))
         cd = output_dir
         cmd = 'STARlong' if use_starlong else 'STAR'
         params = [

--- a/idseq_dag/steps/run_star.py
+++ b/idseq_dag/steps/run_star.py
@@ -264,6 +264,8 @@ class PipelineStepRunStar(PipelineStep):
         command.make_dirs(output_dir)
 
         cpus = str(multiprocessing.cpu_count())
+        # SortedByCoordinate breaks around > 32 threads
+        threads = min(32, cpus)
         cd = output_dir
         cmd = 'STARlong' if use_starlong else 'STAR'
         params = [
@@ -273,7 +275,7 @@ class PipelineStepRunStar(PipelineStep):
             '--outReadsUnmapped', 'Fastx',
             '--outFilterMismatchNmax', '999',
             '--clip3pNbases', '0',
-            '--runThreadN', cpus,
+            '--runThreadN', threads,
             '--genomeDir', genome_dir,
             '--readFilesIn', *input_files
         ]

--- a/idseq_dag/steps/run_star.py
+++ b/idseq_dag/steps/run_star.py
@@ -279,6 +279,7 @@ class PipelineStepRunStar(PipelineStep):
         ]
 
         if self.collect_insert_size_metrics_for == "rna":
+            # SortedByCoordinate is required for deterministic output
             params += [
                 '--outSAMtype', 'BAM', 'SortedByCoordinate',
                 '--outSAMmode', 'NoQS',
@@ -289,6 +290,7 @@ class PipelineStepRunStar(PipelineStep):
             ]
         else:
             if self.collect_insert_size_metrics_for == "dna":
+                # SortedByCoordinate is required for deterministic output
                 params += ['--outSAMtype', 'BAM', 'SortedByCoordinate', '--outSAMmode', 'NoQS', ]
             else:
                 params += ['--outSAMmode', 'None']

--- a/idseq_dag/util/fasta.py
+++ b/idseq_dag/util/fasta.py
@@ -82,11 +82,14 @@ def sort_fastx_by_entry_id(fastq_path):
             else:
                 # WARNING: does not support multiline fasta
                 cmd = "paste -d '|' - - | sort -k1,1 -S 3G | tr '|' '\n'"
-            # By default the sort utility uses a local sort, this is slower than
-            #   a simple byte comparison. It also produces different behavior than
-            #   python's string comparisons. All we care about is a consistent order
-            #   so we can safely set LC_ALL=C to do a simple byte comparison which will
-            #   be both faster and consistent with python.
+            # By default the sort utility uses a locale-based sort, this is significantly
+            #   slower than a simple byte comparison. It also produces a different
+            #   order than python's default string comparisons would which makes testing
+            #   a bit less convenient. All we care about is producing a consistent order
+            #   every time, the order itself is irrelevant, so we set LC_ALL=C to do a
+            #   simple byte comparison instead of a locale-based sort which is faster,
+            #   produces a consistent result regardless of locale, and produces the same
+            #   order python's default string comparison would.
             run(cmd, env={'LC_ALL': 'C'}, stdin=in_file, stdout=out_file, check=True, shell=True)
     os.rename(tmp_sorted_path, fastq_path)
 

--- a/idseq_dag/util/fasta.py
+++ b/idseq_dag/util/fasta.py
@@ -78,10 +78,10 @@ def sort_fastx_by_entry_id(fastq_path):
         with open(tmp_sorted_path, 'wb') as out_file:
             # Command based on this https://www.biostars.org/p/15011/#103041
             if input_file_type(fastq_path) == 'fastq':
-                cmd = "paste - - - - | sort -k1,1 -S 3G | tr '\t' '\n'"
+                cmd = "paste -d '|' - - - - | sort -k1,1 -S 3G | tr '|' '\n'"
             else:
                 # WARNING: does not support multiline fasta
-                cmd = "paste - - | sort -k1,1 -S 3G | tr '\t' '\n'"
+                cmd = "paste -d '|' - - | sort -k1,1 -S 3G | tr '|' '\n'"
             # By default the sort utility uses a local sort, this is slower than
             #   a simple byte comparison. It also produces different behavior than
             #   python's string comparisons. All we care about is a consistent order

--- a/tests/unit/util/test_fasta.py
+++ b/tests/unit/util/test_fasta.py
@@ -1,0 +1,41 @@
+import os
+import unittest
+import shutil
+from os.path import dirname, join
+
+from idseq_dag.util.fasta import sort_fastx_by_entry_id, multilinefa2singlelinefa
+
+class TestFasta(unittest.TestCase):
+    def test_sort_fastx_by_entry_id_fastq(self):
+        try:
+            fastq = join(dirname(__file__), "..", "fixtures", "reads.fastq")
+            tmp_fastq_path = fastq + ".tmp-sort-fastx-by-entry-id-fastq"
+            shutil.copyfile(fastq, tmp_fastq_path)
+            sort_fastx_by_entry_id(tmp_fastq_path)
+            prev = None
+            with open(tmp_fastq_path) as result:
+                for i, line in enumerate(result):
+                    if i % 4 == 0:
+                        if prev:
+                            assert line > prev, f"Expected '{line}' to come before '{prev}'"
+                        prev = line
+        finally:
+            os.remove(tmp_fastq_path)
+
+    def test_sort_fastx_by_entry_id_fasta(self):
+        try:
+            fasta = join(dirname(__file__), "..", "fixtures", "reads.fasta")
+            tmp_fasta_path = fasta + ".tmp-sort-fastx-by-entry-id-fasta"
+            # The sort function only supports single line fasta so we must
+            #   convert the fixture
+            multilinefa2singlelinefa(fasta, tmp_fasta_path)
+            sort_fastx_by_entry_id(tmp_fasta_path)
+            prev = None
+            with open(tmp_fasta_path) as result:
+                for i, line in enumerate(result):
+                    if i % 4 == 0:
+                        if prev:
+                            assert line > prev, f"Expected '{line}' to come before '{prev}'"
+                        prev = line
+        finally:
+            os.remove(tmp_fasta_path)

--- a/tests/unit/util/test_fasta.py
+++ b/tests/unit/util/test_fasta.py
@@ -13,12 +13,15 @@ class TestFasta(unittest.TestCase):
             shutil.copyfile(fastq, tmp_fastq_path)
             sort_fastx_by_entry_id(tmp_fastq_path)
             prev = None
+            line_count = 0
             with open(tmp_fastq_path) as result:
                 for i, line in enumerate(result):
                     if i % 4 == 0:
                         if prev:
                             assert line > prev, f"Expected '{line}' to come before '{prev}'"
                         prev = line
+                    line_count = i + 1
+            assert line_count % 4 == 0, f"Expected number of lines in fastq to be a factor of 4 but it was {line_count}"
         finally:
             os.remove(tmp_fastq_path)
 
@@ -37,5 +40,7 @@ class TestFasta(unittest.TestCase):
                         if prev:
                             assert line > prev, f"Expected '{line}' to come before '{prev}'"
                         prev = line
+                    line_count = i + 1
+            assert line_count % 2 == 0, f"Expected number of lines in fasta to be a factor of 2 but it was {line_count}"
         finally:
             os.remove(tmp_fasta_path)


### PR DESCRIPTION
# Description
After a lot of testing I have determined that STAR produces outputs in a non-deterministic order, but the reads themselves remain consistent over time. This non-determinism can have downstream effects on other steps of the pipeline, which is why the results can be different despite the files containing the same information. I have made this deterministic by sorting the resulting fastq files with a subsequent sort command after STAR.

# Version
- [X] I have increased the appropriate version number in https://github.com/chanzuckerberg/idseq-dag/blob/master/idseq_dag/__init__.py. Guidelines here: https://github.com/chanzuckerberg/idseq-dag/blob/pr-template/README.md#release-notes
- [X] I have added release notes for my new version to https://github.com/chanzuckerberg/idseq-dag/blob/master/README.md#release-notes
- [X] I will push a git tag after merging in the form `vX.Y.Z`

# Tests
- [x] I have verified that the pipeline still completes successfully:
    - [x] for single-end inputs
    - [x] for paired-end inputs
    - [x] for FASTQ inputs
    - [x] for FASTA inputs.
- [x] I have validated that my change does not introduce any correctness bugs to existing output types.
- [x] I have validated that my change does not introduce significant performance regressions or I have discussed with the team that the benefits of the change are substantial enough that we're comfortable accepting the size of the measured performance penalty.

In the process of running tests but I wrote unit tests for the function itself.

