### PR TITLE
count_reads: correctly count reads in empty file

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,10 @@ Version numbers for this repo take the form X.Y.Z.
 Changes to X or Y force recomputation of all results when a sample is rerun using idseq-web. Changes to Z do not force recomputation when the sample is rerun - the pipeline will lazily reuse existing outputs in AWS S3.
 
 When releasing a new version, please add a Git tag of the form `vX.Y.Z`.
+
+- 4.11.4
+  - Correctly count reads in empty file
+
 - 4.11.3
   - Make STAR outputs deterministic by sorting
 

--- a/idseq_dag/__init__.py
+++ b/idseq_dag/__init__.py
@@ -1,2 +1,2 @@
 ''' idseq_dag '''
-__version__ = "4.11.3"
+__version__ = "4.11.4"

--- a/idseq_dag/util/count.py
+++ b/idseq_dag/util/count.py
@@ -25,7 +25,10 @@ def count_reads(filename):
     with open(filename, "rb") as gz_fh:
         is_gzipped = True if gz_fh.read(2).startswith(GZIP_MAGIC_HEADER) else False
     with gzip.open(filename) if is_gzipped else open(filename, mode="rb") as fmt_fh:
-        first_char = fmt_fh.read(1).decode()[0]
+        chunk = fmt_fh.read(1)
+        if len(chunk) == 0:
+            return 0
+        first_char = chunk.decode()[0]
     with open(filename, "rb") as fh:
         if first_char == ">":
             cmd = "grep -c '^>'"

--- a/tests/unit/test_count_reads.py
+++ b/tests/unit/test_count_reads.py
@@ -18,6 +18,8 @@ class TestCountReads(unittest.TestCase):
             self.assertEqual(count_reads(filename), expect_reads[filename])
 
         with tempfile.NamedTemporaryFile() as tf:
+            self.assertEqual(count_reads(tf.name), 0)
+
             tf.write(b"test")
             tf.flush()
             with self.assertRaises(InvalidInputFileError):


### PR DESCRIPTION
# Description
 correctly count reads in empty file

# Version
- [x] I have increased the appropriate version number in https://github.com/chanzuckerberg/idseq-dag/blob/master/idseq_dag/__init__.py. Guidelines here: https://github.com/chanzuckerberg/idseq-dag/blob/pr-template/README.md#release-notes
- [x] I have added release notes for my new version to https://github.com/chanzuckerberg/idseq-dag/blob/master/README.md#release-notes
- [x] I will push a git tag after merging in the form `vX.Y.Z`

# Tests
- [x] I have verified that the pipeline still completes successfully:
    - [ ] for single-end inputs
    - [ ] for paired-end inputs
    - [ ] for FASTQ inputs
    - [ ] for FASTA inputs.
- [x] I have validated that my change does not introduce any correctness bugs to existing output types.
- [x] I have validated that my change does not introduce significant performance regressions or I have discussed with the team that the benefits of the change are substantial enough that we're comfortable accepting the size of the measured performance penalty.

# Notes
*Optional observations, comments or explanations.*
