### PR TITLE
Raise InsufficientReadsError on empty input file; add test

### DIFF
--- a/idseq_dag/__init__.py
+++ b/idseq_dag/__init__.py
@@ -1,2 +1,2 @@
 ''' idseq_dag '''
-__version__ = "4.11.5"
+__version__ = "4.11.6"

--- a/idseq_dag/steps/run_validate_input.py
+++ b/idseq_dag/steps/run_validate_input.py
@@ -2,7 +2,7 @@ import json
 import os
 
 from idseq_dag.engine.pipeline_step import PipelineStep
-from idseq_dag.exceptions import InvalidFileFormatError
+from idseq_dag.exceptions import InvalidFileFormatError, InsufficientReadsError
 import idseq_dag.util.command as command
 import idseq_dag.util.command_patterns as command_patterns
 import idseq_dag.util.count as count
@@ -139,6 +139,8 @@ class PipelineStepRunValidateInput(PipelineStep):
 
                 identifier_l = input_f.readline()
                 if len(identifier_l) == 0:  # EOF
+                    if num_fragments == 1:
+                        raise InsufficientReadsError("The input file contains 0 reads")
                     break
 
                 read_l = input_f.readline()

--- a/tests/unit/test_priceseq.py
+++ b/tests/unit/test_priceseq.py
@@ -10,7 +10,7 @@ fasta_filename = os.path.join(os.path.dirname(__file__), "fixtures", "reads.fast
 fastq_filename = os.path.join(os.path.dirname(__file__), "fixtures", "reads.fastq")
 
 @unittest.skipIf(os.uname().sysname != "Linux", "Skipping test on incompatible platform")
-class TestCountReads(unittest.TestCase):
+class TestPriceSeq(unittest.TestCase):
     def run_priceseqfilter(self, **args):
         with tempfile.TemporaryDirectory() as td, tempfile.NamedTemporaryFile(suffix="." + args["file_type"]) as tf:
             args["out_files"] = [tf.name] * len(args["in_files"])

--- a/tests/unit/test_validate_input.py
+++ b/tests/unit/test_validate_input.py
@@ -1,5 +1,4 @@
 import os
-import sys
 import tempfile
 import unittest
 
@@ -9,21 +8,24 @@ from idseq_dag.exceptions import InsufficientReadsError, InvalidFileFormatError
 fasta_filename = os.path.join(os.path.dirname(__file__), "fixtures", "reads.fasta")
 fastq_filename = os.path.join(os.path.dirname(__file__), "fixtures", "reads.fastq")
 
+
 class TestValidateInput(unittest.TestCase):
-    def test_validate_input(self):
-        PipelineStepRunValidateInput.quick_check_file(None, fasta_filename, is_fastq=False, max_fragments_to_check=100)
-        PipelineStepRunValidateInput.quick_check_file(None, fastq_filename, is_fastq=True, max_fragments_to_check=100)
+    def test_quick_check_file(self):
+        quick_check_file = PipelineStepRunValidateInput.quick_check_file
+        # quick_check_file returns false for multi-line fasta
+        self.assertFalse(quick_check_file(None, fasta_filename, is_fastq=False, max_fragments_to_check=100))
+        self.assertTrue(quick_check_file(None, fastq_filename, is_fastq=True, max_fragments_to_check=100))
         with self.assertRaises(FileNotFoundError):
-            PipelineStepRunValidateInput.quick_check_file(None, "nonexistent", is_fastq=True, max_fragments_to_check=100)
+            quick_check_file(None, "nonexistent", is_fastq=True, max_fragments_to_check=100)
         with tempfile.NamedTemporaryFile() as tf:
             with self.assertRaises(InsufficientReadsError):
-                PipelineStepRunValidateInput.quick_check_file(None, tf.name, is_fastq=True, max_fragments_to_check=100)
+                quick_check_file(None, tf.name, is_fastq=True, max_fragments_to_check=100)
             tf.write(b">@" * 9000)
             tf.flush()
             with self.assertRaises(InvalidFileFormatError):
-                PipelineStepRunValidateInput.quick_check_file(None, tf.name, is_fastq=True, max_fragments_to_check=100)
+                quick_check_file(None, tf.name, is_fastq=True, max_fragments_to_check=100)
             tf.seek(0)
             tf.write(">read\n\n".encode())
             tf.flush()
             with self.assertRaises(InvalidFileFormatError):
-                PipelineStepRunValidateInput.quick_check_file(None, tf.name, is_fastq=True, max_fragments_to_check=100)
+                quick_check_file(None, tf.name, is_fastq=True, max_fragments_to_check=100)

--- a/tests/unit/test_validate_input.py
+++ b/tests/unit/test_validate_input.py
@@ -1,0 +1,29 @@
+import os
+import sys
+import tempfile
+import unittest
+
+from idseq_dag.steps.run_validate_input import PipelineStepRunValidateInput
+from idseq_dag.exceptions import InsufficientReadsError, InvalidFileFormatError
+
+fasta_filename = os.path.join(os.path.dirname(__file__), "fixtures", "reads.fasta")
+fastq_filename = os.path.join(os.path.dirname(__file__), "fixtures", "reads.fastq")
+
+class TestValidateInput(unittest.TestCase):
+    def test_validate_input(self):
+        PipelineStepRunValidateInput.quick_check_file(None, fasta_filename, is_fastq=False, max_fragments_to_check=100)
+        PipelineStepRunValidateInput.quick_check_file(None, fastq_filename, is_fastq=True, max_fragments_to_check=100)
+        with self.assertRaises(FileNotFoundError):
+            PipelineStepRunValidateInput.quick_check_file(None, "nonexistent", is_fastq=True, max_fragments_to_check=100)
+        with tempfile.NamedTemporaryFile() as tf:
+            with self.assertRaises(InsufficientReadsError):
+                PipelineStepRunValidateInput.quick_check_file(None, tf.name, is_fastq=True, max_fragments_to_check=100)
+            tf.write(b">@" * 9000)
+            tf.flush()
+            with self.assertRaises(InvalidFileFormatError):
+                PipelineStepRunValidateInput.quick_check_file(None, tf.name, is_fastq=True, max_fragments_to_check=100)
+            tf.seek(0)
+            tf.write(">read\n\n".encode())
+            tf.flush()
+            with self.assertRaises(InvalidFileFormatError):
+                PipelineStepRunValidateInput.quick_check_file(None, tf.name, is_fastq=True, max_fragments_to_check=100)

--- a/tests/unit/test_validate_input.py
+++ b/tests/unit/test_validate_input.py
@@ -18,14 +18,14 @@ class TestValidateInput(unittest.TestCase):
         with self.assertRaises(FileNotFoundError):
             quick_check_file(None, "nonexistent", is_fastq=True, max_fragments_to_check=100)
         with tempfile.NamedTemporaryFile() as tf:
-            with self.assertRaises(InsufficientReadsError):
+            with self.assertRaises(InsufficientReadsError):  # Test that empty input file causes an error
                 quick_check_file(None, tf.name, is_fastq=True, max_fragments_to_check=100)
             tf.write(b">@" * 9000)
             tf.flush()
-            with self.assertRaises(InvalidFileFormatError):
+            with self.assertRaises(InvalidFileFormatError):  # Test that malformed FASTQ file causes an error
                 quick_check_file(None, tf.name, is_fastq=True, max_fragments_to_check=100)
             tf.seek(0)
             tf.write(">read\n\n".encode())
             tf.flush()
-            with self.assertRaises(InvalidFileFormatError):
+            with self.assertRaises(InvalidFileFormatError):  # Test that FASTQ file with empty read causes an error
                 quick_check_file(None, tf.name, is_fastq=True, max_fragments_to_check=100)


### PR DESCRIPTION
As seen in ops (STAR fails downstream with an internal error).